### PR TITLE
feat: implement market data abstraction, scoring engine, and JSON artifacts (#28 #29 #30)

### DIFF
--- a/.agents/skills/market-analysis/SKILL.md
+++ b/.agents/skills/market-analysis/SKILL.md
@@ -12,12 +12,12 @@ All scripts are in `.agents/skills/market-analysis/scripts/`.
 
 Four sub-commands:
 
-| Command | Purpose |
-|---------|---------|
-| `fetch` | Download OHLCV data from Stooq and save to `data/prices/` |
-| `check` | Run data-quality checks on saved data |
-| `score` | Score and rank instruments cross-sectionally |
-| `generate` | Generate a versioned JSON analysis artifact |
+| Command    | Purpose                                                   |
+| ---------- | --------------------------------------------------------- |
+| `fetch`    | Download OHLCV data from Stooq and save to `data/prices/` |
+| `check`    | Run data-quality checks on saved data                     |
+| `score`    | Score and rank instruments cross-sectionally              |
+| `generate` | Generate a versioned JSON analysis artifact               |
 
 ### `validate_analysis.py`
 
@@ -109,10 +109,10 @@ schema reference. Key structure:
 Instruments failing quality checks are included in output but marked
 `is_reliable: false` and excluded from top rankings:
 
-| Gate | Trigger |
-|------|---------|
-| `stale_data` | Latest bar older than `stale_days` calendar days |
-| `insufficient_history` | Fewer than `min_history` bars |
-| `missing_bars` | Gap > 7 calendar days between consecutive bars |
-| `malformed_input` | Non-positive prices, high < low, or price outside [low, high] |
-| `high_volatility` | 20-day annualized volatility > 100% |
+| Gate                   | Trigger                                                       |
+| ---------------------- | ------------------------------------------------------------- |
+| `stale_data`           | Latest bar older than `stale_days` calendar days              |
+| `insufficient_history` | Fewer than `min_history` bars                                 |
+| `missing_bars`         | Gap > 7 calendar days between consecutive bars                |
+| `malformed_input`      | Non-positive prices, high < low, or price outside [low, high] |
+| `high_volatility`      | 20-day annualized volatility > 100%                           |

--- a/.agents/skills/market-analysis/SKILL.md
+++ b/.agents/skills/market-analysis/SKILL.md
@@ -1,0 +1,118 @@
+# market-analysis
+
+Fetch OHLCV market data, score instruments, and generate structured analysis artifacts.
+
+> **Disclaimer:** All output is informational only and does not constitute investment advice.
+
+## Scripts
+
+All scripts are in `.agents/skills/market-analysis/scripts/`.
+
+### `market_analysis.py`
+
+Four sub-commands:
+
+| Command | Purpose |
+|---------|---------|
+| `fetch` | Download OHLCV data from Stooq and save to `data/prices/` |
+| `check` | Run data-quality checks on saved data |
+| `score` | Score and rank instruments cross-sectionally |
+| `generate` | Generate a versioned JSON analysis artifact |
+
+### `validate_analysis.py`
+
+Validate a generated JSON artifact against the expected schema.
+
+## Usage
+
+```sh
+# Fetch daily OHLCV data for two symbols
+uv run .agents/skills/market-analysis/scripts/market_analysis.py \
+    fetch --symbol AAPL.US --start 2023-01-01 --end 2024-12-31
+
+uv run .agents/skills/market-analysis/scripts/market_analysis.py \
+    fetch --symbol MSFT.US --start 2023-01-01 --end 2024-12-31
+
+# Check data quality
+uv run .agents/skills/market-analysis/scripts/market_analysis.py \
+    check --symbol AAPL.US
+
+# Score instruments and print ranking
+uv run .agents/skills/market-analysis/scripts/market_analysis.py \
+    score --symbols AAPL.US,MSFT.US
+
+# Generate a dated JSON artifact in data/analysis/
+uv run .agents/skills/market-analysis/scripts/market_analysis.py \
+    generate --symbols AAPL.US,MSFT.US --output data/analysis/
+
+# Validate the generated artifact
+uv run .agents/skills/market-analysis/scripts/validate_analysis.py \
+    --input data/analysis/$(date +%Y-%m-%d).json
+```
+
+## Data layout
+
+```
+data/
+├── prices/
+│   ├── AAPL.US_d.csv        # Daily OHLCV for AAPL.US
+│   └── MSFT.US_d.csv
+└── analysis/
+    └── YYYY-MM-DD.json      # Analysis artifact
+```
+
+Each `data/prices/<SYMBOL>_<INTERVAL>.csv` has columns:
+`symbol, timestamp, open, high, low, close, volume, source, interval`
+
+Timestamps are UTC ISO 8601.
+
+## Artifact format
+
+`data/analysis/YYYY-MM-DD.json` — see `data/schema/analysis.schema.json` for the
+schema reference. Key structure:
+
+```json
+{
+  "version": "1.0.0",
+  "metadata": {
+    "generated_at": "...",
+    "git_commit": "...",
+    "data_source": "stooq",
+    "data_freshness": {"AAPL.US": "2024-12-31"},
+    "scoring_version": "1.0.0",
+    "config": {"stale_days": 5, "min_history": 60, "interval": "d"}
+  },
+  "instruments": [
+    {
+      "symbol": "AAPL.US",
+      "rank": 1,
+      "score": 72.5,
+      "is_reliable": true,
+      "risk_gates": [],
+      "explanation": "20d up +5.3%; above MA20 by 2.1%; RSI14=62",
+      "features": { "ret_1d": 0.012, "ret_5d": 0.031, ... }
+    }
+  ]
+}
+```
+
+## Provider limitations (StooqProvider)
+
+- Daily, weekly, and monthly bars only — no intraday data.
+- Symbol format is Stooq-specific: `AAPL.US`, `^SPX`, `7203.JP`.
+- Data availability varies by symbol; some return empty results.
+- No authentication required, but subject to Stooq rate limits.
+- Requires outbound network access. Use `CsvFileProvider` for tests.
+
+## Risk gates
+
+Instruments failing quality checks are included in output but marked
+`is_reliable: false` and excluded from top rankings:
+
+| Gate | Trigger |
+|------|---------|
+| `stale_data` | Latest bar older than `stale_days` calendar days |
+| `insufficient_history` | Fewer than `min_history` bars |
+| `missing_bars` | Gap > 7 calendar days between consecutive bars |
+| `malformed_input` | Non-positive prices, high < low, or price outside [low, high] |
+| `high_volatility` | 20-day annualized volatility > 100% |

--- a/.agents/skills/market-analysis/scripts/market_analysis.py
+++ b/.agents/skills/market-analysis/scripts/market_analysis.py
@@ -531,7 +531,7 @@ def score_instruments(
             )
         )
 
-    scores.sort(key=lambda s: s.score, reverse=True)
+    scores.sort(key=lambda s: (not s.is_reliable, -s.score))
     for rank, s in enumerate(scores, start=1):
         s.rank = rank
 
@@ -609,8 +609,8 @@ def generate_artifact(
     config: dict[str, Any],
 ) -> dict[str, Any]:
     now = datetime.now(tz=UTC)
-    sources = {b.source for bars in data.values() for b in bars}
-    data_source = next(iter(sources)) if sources else "unknown"
+    sources = sorted({b.source for bars in data.values() for b in bars})
+    data_source = ",".join(sources) if sources else "unknown"
     freshness = {
         symbol: bars[-1].timestamp.date().isoformat() if bars else "n/a"
         for symbol, bars in data.items()

--- a/.agents/skills/market-analysis/scripts/market_analysis.py
+++ b/.agents/skills/market-analysis/scripts/market_analysis.py
@@ -1,0 +1,785 @@
+#!/usr/bin/env python3
+r"""Market data fetch, scoring, and analysis artifact generation for AIMS.
+
+This tool is informational only and does not constitute investment advice.
+
+Usage:
+    uv run .agents/skills/market-analysis/scripts/market_analysis.py \
+        fetch --symbol AAPL.US --start 2024-01-01 --end 2024-12-31
+    uv run .agents/skills/market-analysis/scripts/market_analysis.py \
+        check --symbol AAPL.US
+    uv run .agents/skills/market-analysis/scripts/market_analysis.py \
+        score --symbols AAPL.US,MSFT.US
+    uv run .agents/skills/market-analysis/scripts/market_analysis.py \
+        generate --symbols AAPL.US,MSFT.US --output data/analysis/
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import subprocess
+import sys
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Final
+from urllib.error import URLError
+from urllib.request import urlopen
+
+# ── Constants ────────────────────────────────────────────────────────────────
+
+_DEFAULT_PRICES_DIR: Final[Path] = Path("data/prices")
+_DEFAULT_ANALYSIS_DIR: Final[Path] = Path("data/analysis")
+_DEFAULT_INTERVAL: Final[str] = "d"
+_STALE_DAYS: Final[int] = 5
+_MIN_HISTORY: Final[int] = 60
+_HIGH_VOL_THRESHOLD: Final[float] = 1.0
+_MAX_GAP_DAYS: Final[int] = 7
+
+SCORING_VERSION: Final[str] = "1.0.0"
+ARTIFACT_VERSION: Final[str] = "1.0.0"
+
+RISK_GATE_STALE: Final[str] = "stale_data"
+RISK_GATE_HIGH_VOL: Final[str] = "high_volatility"
+RISK_GATE_INSUFFICIENT: Final[str] = "insufficient_history"
+RISK_GATE_MISSING_BARS: Final[str] = "missing_bars"
+RISK_GATE_MALFORMED: Final[str] = "malformed_input"
+
+_OHLCV_FIELDS: Final[tuple[str, ...]] = (
+    "symbol",
+    "timestamp",
+    "open",
+    "high",
+    "low",
+    "close",
+    "volume",
+    "source",
+    "interval",
+)
+
+# ── Data model ───────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class OhlcvBar:
+    """Single OHLCV candlestick bar with a UTC-aware timestamp."""
+
+    symbol: str
+    timestamp: datetime
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+    source: str
+    interval: str
+
+
+@dataclass
+class DataQualityReport:
+    """Result of a data-quality assessment for one symbol."""
+
+    symbol: str
+    interval: str
+    bar_count: int
+    issues: list[str] = field(default_factory=list)
+
+    @property
+    def is_valid(self) -> bool:
+        return not self.issues
+
+
+# ── Providers ─────────────────────────────────────────────────────────────────
+
+
+class MarketDataProvider(ABC):
+    """Abstract base class for OHLCV market data providers."""
+
+    @abstractmethod
+    def fetch_ohlcv(
+        self,
+        symbol: str,
+        start: datetime,
+        end: datetime,
+        interval: str = _DEFAULT_INTERVAL,
+    ) -> list[OhlcvBar]:
+        """Fetch OHLCV bars for *symbol* in [*start*, *end*]."""
+
+
+class StooqProvider(MarketDataProvider):
+    """Provider backed by the Stooq free CSV download API.
+
+    Limitations:
+        - Daily / weekly / monthly bars only (no intraday).
+        - Symbol format is Stooq-specific: e.g. 'AAPL.US', '^SPX', '7203.JP'.
+        - Data coverage varies; some symbols return empty results.
+        - No authentication required; subject to Stooq rate limits.
+        - Requires outbound network access — not suitable for unit tests.
+          Use CsvFileProvider for deterministic testing.
+    """
+
+    _BASE_URL: Final[str] = "https://stooq.com/q/d/l/"
+    _SOURCE: Final[str] = "stooq"
+
+    def fetch_ohlcv(
+        self,
+        symbol: str,
+        start: datetime,
+        end: datetime,
+        interval: str = _DEFAULT_INTERVAL,
+    ) -> list[OhlcvBar]:
+        url = (
+            f"{self._BASE_URL}?s={symbol}"
+            f"&d1={start.strftime('%Y%m%d')}"
+            f"&d2={end.strftime('%Y%m%d')}"
+            f"&i={interval}"
+        )
+        with urlopen(url, timeout=30) as resp:
+            content = resp.read().decode("utf-8")
+        return self._parse_csv(content, symbol, interval)
+
+    def _parse_csv(self, content: str, symbol: str, interval: str) -> list[OhlcvBar]:
+        bars: list[OhlcvBar] = []
+        for row in csv.DictReader(io.StringIO(content)):
+            date_str = row.get("Date", "")
+            if not date_str:
+                continue
+            try:
+                ts = datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=UTC)
+                bars.append(
+                    OhlcvBar(
+                        symbol=symbol,
+                        timestamp=ts,
+                        open=float(row.get("Open") or 0),
+                        high=float(row.get("High") or 0),
+                        low=float(row.get("Low") or 0),
+                        close=float(row.get("Close") or 0),
+                        volume=float(row.get("Volume") or 0),
+                        source=self._SOURCE,
+                        interval=interval,
+                    )
+                )
+            except ValueError:
+                pass
+        return sorted(bars, key=lambda b: b.timestamp)
+
+
+class CsvFileProvider(MarketDataProvider):
+    """Provider that loads bars from CSV files written by save_ohlcv.
+
+    Suitable for offline workflows and deterministic unit tests.
+    """
+
+    def __init__(self, data_dir: Path = _DEFAULT_PRICES_DIR) -> None:
+        self._data_dir = data_dir
+
+    def fetch_ohlcv(
+        self,
+        symbol: str,
+        start: datetime,
+        end: datetime,
+        interval: str = _DEFAULT_INTERVAL,
+    ) -> list[OhlcvBar]:
+        all_bars = load_ohlcv(symbol, interval, self._data_dir)
+        return [b for b in all_bars if start <= b.timestamp <= end]
+
+
+# ── Save / Load ───────────────────────────────────────────────────────────────
+
+
+def ohlcv_csv_path(
+    symbol: str,
+    interval: str,
+    data_dir: Path = _DEFAULT_PRICES_DIR,
+) -> Path:
+    safe = symbol.replace("/", "-").replace("^", "_")
+    return data_dir / f"{safe}_{interval}.csv"
+
+
+def save_ohlcv(
+    bars: list[OhlcvBar],
+    data_dir: Path = _DEFAULT_PRICES_DIR,
+) -> Path:
+    if not bars:
+        msg = "cannot save an empty bars list"
+        raise ValueError(msg)
+    path = ohlcv_csv_path(bars[0].symbol, bars[0].interval, data_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=list(_OHLCV_FIELDS))
+        writer.writeheader()
+        for b in bars:
+            writer.writerow({
+                "symbol": b.symbol,
+                "timestamp": b.timestamp.isoformat(),
+                "open": b.open,
+                "high": b.high,
+                "low": b.low,
+                "close": b.close,
+                "volume": b.volume,
+                "source": b.source,
+                "interval": b.interval,
+            })
+    return path
+
+
+def load_ohlcv(
+    symbol: str,
+    interval: str,
+    data_dir: Path = _DEFAULT_PRICES_DIR,
+) -> list[OhlcvBar]:
+    path = ohlcv_csv_path(symbol, interval, data_dir)
+    if not path.exists():
+        msg = f"no OHLCV data at {path}"
+        raise FileNotFoundError(msg)
+    bars: list[OhlcvBar] = []
+    with path.open(newline="") as fh:
+        for row in csv.DictReader(fh):
+            ts = datetime.fromisoformat(row["timestamp"])
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=UTC)
+            bars.append(
+                OhlcvBar(
+                    symbol=row["symbol"],
+                    timestamp=ts,
+                    open=float(row["open"]),
+                    high=float(row["high"]),
+                    low=float(row["low"]),
+                    close=float(row["close"]),
+                    volume=float(row["volume"]),
+                    source=row["source"],
+                    interval=row["interval"],
+                )
+            )
+    return sorted(bars, key=lambda b: b.timestamp)
+
+
+# ── Data quality ──────────────────────────────────────────────────────────────
+
+
+def check_data_quality(
+    bars: list[OhlcvBar],
+    *,
+    stale_days: int = _STALE_DAYS,
+    min_history: int = _MIN_HISTORY,
+    reference_time: datetime | None = None,
+) -> DataQualityReport:
+    if not bars:
+        return DataQualityReport(
+            symbol="", interval="", bar_count=0, issues=["empty data"]
+        )
+
+    symbol = bars[0].symbol
+    interval = bars[0].interval
+    report = DataQualityReport(symbol=symbol, interval=interval, bar_count=len(bars))
+
+    now = reference_time if reference_time is not None else datetime.now(tz=UTC)
+    age = (now - bars[-1].timestamp).days
+    if age > stale_days:
+        report.issues.append(
+            f"stale data: latest bar is {age} days old (threshold: {stale_days})"
+        )
+
+    if len(bars) < min_history:
+        report.issues.append(
+            f"insufficient history: {len(bars)} bars (minimum: {min_history})"
+        )
+
+    for i, bar in enumerate(bars):
+        if bar.open <= 0 or bar.high <= 0 or bar.low <= 0 or bar.close <= 0:
+            report.issues.append(f"malformed OHLC at index {i}: non-positive price")
+            break
+        if bar.high < bar.low:
+            report.issues.append(f"malformed OHLC at index {i}: high < low")
+            break
+        if not (bar.low <= bar.open <= bar.high):
+            report.issues.append(
+                f"malformed OHLC at index {i}: open outside [low, high]"
+            )
+            break
+        if not (bar.low <= bar.close <= bar.high):
+            report.issues.append(
+                f"malformed OHLC at index {i}: close outside [low, high]"
+            )
+            break
+
+    timestamps = [b.timestamp for b in bars]
+    if len(timestamps) != len(set(timestamps)):
+        report.issues.append("duplicate timestamps detected")
+
+    if len(bars) >= 2:
+        for i in range(1, len(bars)):
+            gap = (bars[i].timestamp - bars[i - 1].timestamp).days
+            if gap > _MAX_GAP_DAYS:
+                report.issues.append(
+                    f"possible missing bars: {gap}-day gap between"
+                    f" {bars[i - 1].timestamp.date()} and"
+                    f" {bars[i].timestamp.date()}"
+                )
+                break
+
+    return report
+
+
+# ── Feature computation ────────────────────────────────────────────────────────
+
+
+@dataclass
+class InstrumentFeatures:
+    """Raw features computed from OHLCV bars."""
+
+    ret_1d: float | None
+    ret_5d: float | None
+    ret_20d: float | None
+    ret_60d: float | None
+    ma20_dist: float | None
+    ma50_dist: float | None
+    vol_20d: float | None
+    mdd_60d: float | None
+    rsi_14: float | None
+    zscore_20d: float | None
+
+
+def _compute_return(closes: list[float], n: int) -> float | None:
+    if len(closes) < n + 1:
+        return None
+    return closes[-1] / closes[-(n + 1)] - 1.0
+
+
+def _compute_ma_distance(closes: list[float], n: int) -> float | None:
+    if len(closes) < n:
+        return None
+    ma = sum(closes[-n:]) / n
+    return (closes[-1] - ma) / ma
+
+
+def _compute_realized_vol(closes: list[float], n: int) -> float | None:
+    if len(closes) < n + 1:
+        return None
+    rets = [
+        closes[i] / closes[i - 1] - 1.0 for i in range(len(closes) - n, len(closes))
+    ]
+    mean_r = sum(rets) / len(rets)
+    var = sum((r - mean_r) ** 2 for r in rets) / len(rets)
+    return var**0.5 * 252**0.5
+
+
+def _compute_max_drawdown(closes: list[float], n: int) -> float | None:
+    if not closes:
+        return None
+    window = closes[-min(n, len(closes)) :]
+    peak = window[0]
+    mdd = 0.0
+    for c in window:
+        peak = max(peak, c)
+        dd = (peak - c) / peak
+        mdd = max(mdd, dd)
+    return mdd
+
+
+def _compute_rsi(closes: list[float], n: int) -> float | None:
+    if len(closes) < n + 1:
+        return None
+    gains = losses = 0.0
+    for i in range(len(closes) - n, len(closes)):
+        diff = closes[i] - closes[i - 1]
+        if diff > 0:
+            gains += diff
+        else:
+            losses -= diff
+    avg_loss = losses / n
+    if not avg_loss:
+        return 100.0
+    return 100.0 - 100.0 / (1.0 + gains / n / avg_loss)
+
+
+def _compute_zscore(closes: list[float], n: int) -> float | None:
+    if len(closes) < n:
+        return None
+    window = closes[-n:]
+    mean = sum(window) / n
+    std = (sum((c - mean) ** 2 for c in window) / n) ** 0.5
+    if not std:
+        return 0.0
+    return (closes[-1] - mean) / std
+
+
+def compute_features(bars: list[OhlcvBar]) -> InstrumentFeatures:
+    closes = [b.close for b in bars]
+    return InstrumentFeatures(
+        ret_1d=_compute_return(closes, 1),
+        ret_5d=_compute_return(closes, 5),
+        ret_20d=_compute_return(closes, 20),
+        ret_60d=_compute_return(closes, 60),
+        ma20_dist=_compute_ma_distance(closes, 20),
+        ma50_dist=_compute_ma_distance(closes, 50),
+        vol_20d=_compute_realized_vol(closes, 20),
+        mdd_60d=_compute_max_drawdown(closes, 60),
+        rsi_14=_compute_rsi(closes, 14),
+        zscore_20d=_compute_zscore(closes, 20),
+    )
+
+
+# ── Scoring ────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class InstrumentScore:
+    """Scoring result for one instrument."""
+
+    symbol: str
+    rank: int
+    score: float
+    features: InstrumentFeatures
+    risk_gates: list[str]
+    is_reliable: bool
+    explanation: str
+
+
+def _percentile_rank(values: list[float | None], idx: int) -> float:
+    valid = [v for v in values if v is not None]
+    if not valid:
+        return 50.0
+    v = values[idx]
+    if v is None:
+        return 50.0
+    below = sum(1 for x in valid if x < v)
+    return 100.0 * below / len(valid)
+
+
+def _collect_risk_gates(
+    report: DataQualityReport, features: InstrumentFeatures
+) -> list[str]:
+    gates: list[str] = []
+    for issue in report.issues:
+        if "stale" in issue:
+            gates.append(RISK_GATE_STALE)
+        elif "insufficient" in issue:
+            gates.append(RISK_GATE_INSUFFICIENT)
+        elif "missing" in issue or "gap" in issue:
+            gates.append(RISK_GATE_MISSING_BARS)
+        else:
+            gates.append(RISK_GATE_MALFORMED)
+    if features.vol_20d is not None and features.vol_20d > _HIGH_VOL_THRESHOLD:
+        gates.append(RISK_GATE_HIGH_VOL)
+    return gates
+
+
+def _build_explanation(
+    symbol: str,
+    features: InstrumentFeatures,
+    risk_gates: list[str],
+) -> str:
+    if risk_gates:
+        return f"Suppressed: {', '.join(risk_gates)}"
+    parts: list[str] = []
+    if features.ret_20d is not None:
+        direction = "up" if features.ret_20d >= 0 else "down"
+        parts.append(f"20d {direction} {features.ret_20d:+.1%}")
+    if features.ma20_dist is not None:
+        side = "above" if features.ma20_dist >= 0 else "below"
+        parts.append(f"{side} MA20 by {abs(features.ma20_dist):.1%}")
+    if features.rsi_14 is not None:
+        parts.append(f"RSI14={features.rsi_14:.0f}")
+    if not parts:
+        return f"{symbol}: insufficient data for explanation"
+    return "; ".join(parts)
+
+
+def score_instruments(
+    data: dict[str, list[OhlcvBar]],
+    *,
+    reference_time: datetime | None = None,
+    stale_days: int = _STALE_DAYS,
+    min_history: int = _MIN_HISTORY,
+) -> list[InstrumentScore]:
+    if not data:
+        return []
+
+    symbols = list(data)
+    reports = {
+        s: check_data_quality(
+            data[s],
+            stale_days=stale_days,
+            min_history=min_history,
+            reference_time=reference_time,
+        )
+        for s in symbols
+    }
+    features_map = {s: compute_features(data[s]) for s in symbols}
+    feature_cols = _build_feature_columns(symbols, features_map)
+
+    scores: list[InstrumentScore] = []
+    for idx, symbol in enumerate(symbols):
+        feats = features_map[symbol]
+        gates = _collect_risk_gates(reports[symbol], feats)
+        rank_values = _compute_rank_values(feature_cols, idx)
+        combined = sum(rank_values) / len(rank_values)
+        scores.append(
+            InstrumentScore(
+                symbol=symbol,
+                rank=0,
+                score=round(combined, 2),
+                features=feats,
+                risk_gates=gates,
+                is_reliable=not bool(gates),
+                explanation=_build_explanation(symbol, feats, gates),
+            )
+        )
+
+    scores.sort(key=lambda s: s.score, reverse=True)
+    for rank, s in enumerate(scores, start=1):
+        s.rank = rank
+
+    return scores
+
+
+def _build_feature_columns(
+    symbols: list[str],
+    features_map: dict[str, InstrumentFeatures],
+) -> list[tuple[list[float | None], bool]]:
+    """Return per-feature cross-sectional value lists with direction flags.
+
+    Each tuple is (values, higher_is_better).
+    """
+    fm = features_map
+    return [
+        ([fm[s].ret_1d for s in symbols], True),
+        ([fm[s].ret_5d for s in symbols], True),
+        ([fm[s].ret_20d for s in symbols], True),
+        ([fm[s].ret_60d for s in symbols], True),
+        ([fm[s].ma20_dist for s in symbols], True),
+        ([fm[s].ma50_dist for s in symbols], True),
+        ([fm[s].vol_20d for s in symbols], False),
+        ([fm[s].mdd_60d for s in symbols], False),
+        ([fm[s].rsi_14 for s in symbols], True),
+        ([fm[s].zscore_20d for s in symbols], True),
+    ]
+
+
+def _compute_rank_values(
+    feature_cols: list[tuple[list[float | None], bool]],
+    idx: int,
+) -> list[float]:
+    result: list[float] = []
+    for values, higher_is_better in feature_cols:
+        pct = _percentile_rank(values, idx)
+        result.append(pct if higher_is_better else 100.0 - pct)
+    return result
+
+
+# ── Artifact generation ────────────────────────────────────────────────────────
+
+
+def _get_git_commit() -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return result.stdout.strip() if result.returncode == 0 else "unknown"
+    except OSError:
+        return "unknown"
+
+
+def _features_to_dict(feats: InstrumentFeatures) -> dict[str, float | None]:
+    return {
+        "ret_1d": feats.ret_1d,
+        "ret_5d": feats.ret_5d,
+        "ret_20d": feats.ret_20d,
+        "ret_60d": feats.ret_60d,
+        "ma20_dist": feats.ma20_dist,
+        "ma50_dist": feats.ma50_dist,
+        "vol_20d": feats.vol_20d,
+        "mdd_60d": feats.mdd_60d,
+        "rsi_14": feats.rsi_14,
+        "zscore_20d": feats.zscore_20d,
+    }
+
+
+def generate_artifact(
+    scores: list[InstrumentScore],
+    data: dict[str, list[OhlcvBar]],
+    config: dict[str, Any],
+) -> dict[str, Any]:
+    now = datetime.now(tz=UTC)
+    sources = {b.source for bars in data.values() for b in bars}
+    data_source = next(iter(sources)) if sources else "unknown"
+    freshness = {
+        symbol: bars[-1].timestamp.date().isoformat() if bars else "n/a"
+        for symbol, bars in data.items()
+    }
+    instruments: list[dict[str, Any]] = [
+        {
+            "symbol": s.symbol,
+            "rank": s.rank,
+            "score": s.score,
+            "is_reliable": s.is_reliable,
+            "risk_gates": s.risk_gates,
+            "explanation": s.explanation,
+            "features": _features_to_dict(s.features),
+        }
+        for s in scores
+    ]
+    return {
+        "version": ARTIFACT_VERSION,
+        "metadata": {
+            "generated_at": now.isoformat(),
+            "git_commit": _get_git_commit(),
+            "data_source": data_source,
+            "data_freshness": freshness,
+            "scoring_version": SCORING_VERSION,
+            "config": config,
+        },
+        "instruments": instruments,
+    }
+
+
+def save_artifact(
+    artifact: dict[str, Any],
+    output_dir: Path = _DEFAULT_ANALYSIS_DIR,
+) -> Path:
+    meta = artifact.get("metadata")
+    gen_at = str(meta.get("generated_at", "")) if isinstance(meta, dict) else ""
+    date_str = gen_at[:10] if gen_at else datetime.now(tz=UTC).date().isoformat()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / f"{date_str}.json"
+    with path.open("w") as fh:
+        json.dump(artifact, fh, indent=2)
+    return path
+
+
+# ── CLI helpers ────────────────────────────────────────────────────────────────
+
+
+def _cmd_fetch(args: argparse.Namespace) -> int:
+    start = datetime.strptime(args.start, "%Y-%m-%d").replace(tzinfo=UTC)
+    end = datetime.strptime(args.end, "%Y-%m-%d").replace(tzinfo=UTC)
+    provider = StooqProvider()
+    try:
+        bars = provider.fetch_ohlcv(args.symbol, start, end, args.interval)
+    except (URLError, ValueError) as exc:
+        print(f"ERROR: fetch failed for {args.symbol}: {exc}")
+        return 1
+    if not bars:
+        print(f"ERROR: no data returned for {args.symbol}")
+        return 1
+    path = save_ohlcv(bars, Path(args.output))
+    print(f"saved {len(bars)} bars to {path}")
+    if not args.no_validate:
+        report = check_data_quality(bars)
+        for issue in report.issues:
+            print(f"WARNING: {issue}")
+    return 0
+
+
+def _cmd_check(args: argparse.Namespace) -> int:
+    try:
+        bars = load_ohlcv(args.symbol, args.interval, Path(args.data_dir))
+    except FileNotFoundError as exc:
+        print(f"ERROR: {exc}")
+        return 1
+    report = check_data_quality(bars)
+    if report.is_valid:
+        sym_interval = f"{args.symbol}/{args.interval}"
+        print(f"data quality OK: {report.bar_count} bars for {sym_interval}")
+        return 0
+    for issue in report.issues:
+        print(f"ISSUE: {issue}")
+    return 1
+
+
+def _cmd_score(args: argparse.Namespace) -> int:
+    symbols = [s.strip() for s in args.symbols.split(",") if s.strip()]
+    data: dict[str, list[OhlcvBar]] = {}
+    for sym in symbols:
+        try:
+            data[sym] = load_ohlcv(sym, args.interval, Path(args.data_dir))
+        except FileNotFoundError:
+            print(f"WARNING: no data for {sym}, skipping")
+    if not data:
+        print("ERROR: no symbols could be loaded")
+        return 1
+    results = score_instruments(data)
+    print(f"{'rank':>4}  {'symbol':<20}  {'score':>6}  {'reliable':>8}  gates")
+    for s in results:
+        reliable = "yes" if s.is_reliable else "no"
+        gates = ",".join(s.risk_gates) if s.risk_gates else "-"
+        print(f"{s.rank:>4}  {s.symbol:<20}  {s.score:>6.1f}  {reliable:>8}  {gates}")
+    return 0
+
+
+def _cmd_generate(args: argparse.Namespace) -> int:
+    symbols = [s.strip() for s in args.symbols.split(",") if s.strip()]
+    data: dict[str, list[OhlcvBar]] = {}
+    for sym in symbols:
+        try:
+            data[sym] = load_ohlcv(sym, args.interval, Path(args.data_dir))
+        except FileNotFoundError:
+            print(f"WARNING: no data for {sym}, skipping")
+    if not data:
+        print("ERROR: no symbols could be loaded")
+        return 1
+    config: dict[str, Any] = {
+        "stale_days": _STALE_DAYS,
+        "min_history": _MIN_HISTORY,
+        "interval": args.interval,
+    }
+    results = score_instruments(data)
+    artifact = generate_artifact(results, data, config)
+    path = save_artifact(artifact, Path(args.output))
+    print(f"artifact saved to {path}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_fetch = sub.add_parser("fetch", help="Fetch OHLCV data from Stooq")
+    p_fetch.add_argument("--symbol", required=True, help="Stooq symbol, e.g. AAPL.US")
+    p_fetch.add_argument("--start", required=True, help="Start date YYYY-MM-DD")
+    p_fetch.add_argument("--end", required=True, help="End date YYYY-MM-DD")
+    p_fetch.add_argument("--interval", default=_DEFAULT_INTERVAL, help="d/w/m")
+    p_fetch.add_argument("--output", default=str(_DEFAULT_PRICES_DIR))
+    p_fetch.add_argument("--no-validate", action="store_true", dest="no_validate")
+
+    p_check = sub.add_parser("check", help="Check data quality of saved OHLCV")
+    p_check.add_argument("--symbol", required=True)
+    p_check.add_argument("--interval", default=_DEFAULT_INTERVAL)
+    p_check.add_argument(
+        "--data-dir", default=str(_DEFAULT_PRICES_DIR), dest="data_dir"
+    )
+
+    p_score = sub.add_parser("score", help="Score and rank instruments")
+    p_score.add_argument("--symbols", required=True, help="Comma-separated list")
+    p_score.add_argument("--interval", default=_DEFAULT_INTERVAL)
+    p_score.add_argument(
+        "--data-dir", default=str(_DEFAULT_PRICES_DIR), dest="data_dir"
+    )
+
+    p_gen = sub.add_parser("generate", help="Generate JSON analysis artifact")
+    p_gen.add_argument("--symbols", required=True, help="Comma-separated list")
+    p_gen.add_argument("--interval", default=_DEFAULT_INTERVAL)
+    p_gen.add_argument("--data-dir", default=str(_DEFAULT_PRICES_DIR), dest="data_dir")
+    p_gen.add_argument("--output", default=str(_DEFAULT_ANALYSIS_DIR))
+
+    args = parser.parse_args(argv)
+
+    if args.command == "fetch":
+        return _cmd_fetch(args)
+    if args.command == "check":
+        return _cmd_check(args)
+    if args.command == "score":
+        return _cmd_score(args)
+    return _cmd_generate(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agents/skills/market-analysis/scripts/validate_analysis.py
+++ b/.agents/skills/market-analysis/scripts/validate_analysis.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+r"""Validate an AIMS analysis artifact JSON file against the expected schema.
+
+Usage:
+    uv run .agents/skills/market-analysis/scripts/validate_analysis.py \
+        --input data/analysis/2024-01-01.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Final
+
+ARTIFACT_VERSION: Final[str] = "1.0.0"
+DEFAULT_INPUT: Final[Path] = Path("data/analysis")
+
+_REQUIRED_TOP: Final[tuple[str, ...]] = ("version", "metadata", "instruments")
+_REQUIRED_META: Final[tuple[str, ...]] = (
+    "generated_at",
+    "git_commit",
+    "data_source",
+    "scoring_version",
+    "config",
+)
+_REQUIRED_INST: Final[tuple[str, ...]] = (
+    "symbol",
+    "rank",
+    "score",
+    "is_reliable",
+    "risk_gates",
+    "explanation",
+    "features",
+)
+
+
+def validate_artifact(data: dict[str, Any]) -> list[str]:
+    errors = [
+        f"missing required key: {key!r}" for key in _REQUIRED_TOP if key not in data
+    ]
+    if errors:
+        return errors
+
+    if data["version"] != ARTIFACT_VERSION:
+        errors.append(
+            f"unsupported version {data['version']!r} (expected {ARTIFACT_VERSION!r})"
+        )
+
+    metadata = data["metadata"]
+    if not isinstance(metadata, dict):
+        errors.append("'metadata' must be a JSON object")
+    else:
+        errors.extend(
+            f"metadata missing required key: {key!r}"
+            for key in _REQUIRED_META
+            if key not in metadata
+        )
+
+    instruments = data["instruments"]
+    if not isinstance(instruments, list):
+        errors.append("'instruments' must be a JSON array")
+    else:
+        for idx, inst in enumerate(instruments):
+            if not isinstance(inst, dict):
+                errors.append(f"instrument[{idx}] must be a JSON object")
+                continue
+            errors.extend(
+                f"instrument[{idx}] missing required key: {key!r}"
+                for key in _REQUIRED_INST
+                if key not in inst
+            )
+            score = inst.get("score")
+            if not isinstance(score, (int, float)):
+                errors.append(f"instrument[{idx}]: score must be a number")
+            elif not 0.0 <= float(score) <= 100.0:
+                errors.append(f"instrument[{idx}]: score {score!r} outside [0, 100]")
+            rank = inst.get("rank")
+            if not isinstance(rank, int) or isinstance(rank, bool):
+                errors.append(f"instrument[{idx}]: rank must be an integer")
+            elif rank < 1:
+                errors.append(f"instrument[{idx}]: rank {rank} must be >= 1")
+
+    return errors
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input",
+        type=Path,
+        required=True,
+        help="Path to analysis artifact JSON file",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+    try:
+        with args.input.open() as fh:
+            data = json.load(fh)
+    except FileNotFoundError:
+        print(f"ERROR: file not found: {args.input}")
+        raise SystemExit(1) from None
+    except json.JSONDecodeError as exc:
+        print(f"ERROR: invalid JSON in {args.input}: {exc}")
+        raise SystemExit(1) from exc
+    errors = validate_artifact(data)
+    if errors:
+        for error in errors:
+            print(error)
+        raise SystemExit(1)
+    print(f"validated {args.input}: OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/market-analysis/scripts/validate_analysis.py
+++ b/.agents/skills/market-analysis/scripts/validate_analysis.py
@@ -21,9 +21,12 @@ _REQUIRED_META: Final[tuple[str, ...]] = (
     "generated_at",
     "git_commit",
     "data_source",
+    "data_freshness",
     "scoring_version",
     "config",
 )
+_FRESHNESS_SENTINEL: Final[str] = "n/a"
+_DATE_LEN: Final[int] = 10
 _REQUIRED_INST: Final[tuple[str, ...]] = (
     "symbol",
     "rank",
@@ -56,6 +59,23 @@ def validate_artifact(data: dict[str, Any]) -> list[str]:
             for key in _REQUIRED_META
             if key not in metadata
         )
+        freshness = metadata.get("data_freshness")
+        if freshness is not None:
+            if not isinstance(freshness, dict):
+                errors.append("metadata.data_freshness must be a JSON object")
+            else:
+                for sym, val in freshness.items():
+                    if not isinstance(val, str):
+                        errors.append(
+                            f"metadata.data_freshness[{sym!r}] must be a string"
+                        )
+                    elif val != _FRESHNESS_SENTINEL and (
+                        len(val) != _DATE_LEN or val[4] != "-" or val[7] != "-"
+                    ):
+                        errors.append(
+                            f"metadata.data_freshness[{sym!r}]: {val!r} is not"
+                            f" a YYYY-MM-DD date or {_FRESHNESS_SENTINEL!r}"
+                        )
 
     instruments = data["instruments"]
     if not isinstance(instruments, list):

--- a/.agents/skills/update-cfd-instruments/SKILL.md
+++ b/.agents/skills/update-cfd-instruments/SKILL.md
@@ -31,14 +31,14 @@ data/mappings/cfd_ticker_mappings.csv
 
 The file uses the following columns:
 
-| Column | Description |
-|---|---|
-| `mapping_type` | `broker_instrument`, `instrument`, or `gmo_stock_base` |
-| `broker` | Broker name (for `broker_instrument` and `gmo_stock_base`) |
-| `category` | CFD category (informational; used to label `gmo_stock_base` rows) |
-| `instrument_name` | Instrument name key (for `broker_instrument` and `instrument`) |
-| `base_name` | Base name after stripping exchange suffix (for `gmo_stock_base`) |
-| `ticker_symbol` | Resulting ticker symbol |
+| Column            | Description                                                       |
+| ----------------- | ----------------------------------------------------------------- |
+| `mapping_type`    | `broker_instrument`, `instrument`, or `gmo_stock_base`            |
+| `broker`          | Broker name (for `broker_instrument` and `gmo_stock_base`)        |
+| `category`        | CFD category (informational; used to label `gmo_stock_base` rows) |
+| `instrument_name` | Instrument name key (for `broker_instrument` and `instrument`)    |
+| `base_name`       | Base name after stripping exchange suffix (for `gmo_stock_base`)  |
+| `ticker_symbol`   | Resulting ticker symbol                                           |
 
 Lookup precedence in the updater:
 

--- a/.gitignore
+++ b/.gitignore
@@ -233,3 +233,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Claude Code
+.claude/

--- a/data/schema/analysis.schema.json
+++ b/data/schema/analysis.schema.json
@@ -8,9 +8,15 @@
     "generated_at",
     "git_commit",
     "data_source",
+    "data_freshness",
     "scoring_version",
     "config"
   ],
+  "notes": {
+    "data_source": "Sorted comma-separated provider names, e.g. 'stooq' or 'csv,stooq'.",
+    "data_freshness": "Object mapping symbol to latest bar date (YYYY-MM-DD) or 'n/a' if no bars.",
+    "rank": "Display rank after reliability-aware ordering: reliable instruments (is_reliable=true) rank first by score descending; unreliable instruments follow."
+  },
   "required_instrument_keys": [
     "symbol",
     "rank",

--- a/data/schema/analysis.schema.json
+++ b/data/schema/analysis.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AIMS analysis artifact",
+  "description": "Schema reference for validate_analysis.py. Validation is implemented in Python rather than a JSON Schema library to avoid runtime dependencies.",
+  "artifact_version": "1.0.0",
+  "required_top_keys": ["version", "metadata", "instruments"],
+  "required_metadata_keys": [
+    "generated_at",
+    "git_commit",
+    "data_source",
+    "scoring_version",
+    "config"
+  ],
+  "required_instrument_keys": [
+    "symbol",
+    "rank",
+    "score",
+    "is_reliable",
+    "risk_gates",
+    "explanation",
+    "features"
+  ],
+  "score_range": [0.0, 100.0],
+  "rank_minimum": 1
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ package = false
 [tool.pytest.ini_options]
 addopts = [
   "--cov=.agents/skills/update-cfd-instruments/scripts",
+  "--cov=.agents/skills/market-analysis/scripts",
   "--cov-branch",
   "--cov-report=term-missing",
   "--cov-fail-under=100",
@@ -129,6 +130,26 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
+".agents/skills/market-analysis/scripts/*.py" = [
+  "C901",     # Scoring/feature functions have inherent complexity
+  "D100",     # Module docstrings are in the module-level string
+  "D101",     # Class docstrings suppressed for brevity
+  "D102",     # Method docstrings suppressed for brevity
+  "D103",     # Function docstrings suppressed for brevity
+  "D107",     # __init__ docstrings suppressed for brevity
+  "DOC201",   # Return docs omitted in favour of type annotations
+  "DOC501",   # Raised exceptions documented inline
+  "INP001",   # Not a package; scripts are standalone entrypoints
+  "PLR0912",  # Feature/scoring functions can have many branches
+  "PLR0914",  # Local variable count is dominated by feature columns
+  "PLR0915",  # Main analysis scripts can have many statements
+  "PLR2004",  # Magic values are intrinsic to financial formulae
+  "S310",     # urllib fetch is intentional for Stooq data download
+  "S404",     # subprocess import is intentional for git commit lookup
+  "S603",     # subprocess.run with list arg is safe
+  "S607",     # git partial path is intentional
+  "T201",     # CLI status output via print is intentional
+]
 ".agents/skills/update-cfd-instruments/scripts/*.py" = [
   "C901",     # Agent scraper scripts can have parser/state-machine complexity
   "D100",     # Missing module docstring
@@ -144,11 +165,14 @@ ignore = [
   "T201",     # CLI status output is intentional
 ]
 "tests/*.py" = [
-  "D100",   # Test modules are named by behavior rather than docstrings
-  "D103",   # Test function names describe the assertion
+  "D100",    # Test modules are named by behavior rather than docstrings
+  "D103",    # Test function names describe the assertion
   "PLC1901", # Explicit empty string comparisons are clearer in assertions
-  "RUF001", # Japanese fixture text must match source pages
-  "S101",   # Pytest uses assert introspection
+  "PLR2004", # Magic values are natural and readable in test assertions
+  "RUF001",  # Japanese fixture text must match source pages
+  "RUF069",  # Exact float literals in test assertions are intentional
+  "S101",    # Pytest uses assert introspection
+  "SLF001",  # Tests intentionally access private implementation members
 ]
 
 [tool.ruff.lint.pydocstyle]
@@ -159,8 +183,11 @@ max-args = 10
 max-public-methods = 40
 
 [tool.pyright]
-include = [".agents/skills/update-cfd-instruments/scripts"]
-exclude = ["build", ".venv"]
+include = [
+  ".agents/skills/update-cfd-instruments/scripts",
+  ".agents/skills/market-analysis/scripts",
+]
+exclude = ["build", ".venv", ".claude", "tests"]
 venvPath = "."
 venv = ".venv"
 typeCheckingMode = "strict"

--- a/tests/test_market_analysis.py
+++ b/tests/test_market_analysis.py
@@ -1,0 +1,1141 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import math
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING
+from urllib.error import URLError
+
+import pytest
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+    from pytest_mock import MockerFixture
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / ".agents"
+    / "skills"
+    / "market-analysis"
+    / "scripts"
+    / "market_analysis.py"
+)
+
+
+@pytest.fixture(scope="module")
+def ma() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("market_analysis", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        pytest.fail("Failed to load market_analysis.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+
+def _bar(
+    ma: ModuleType,
+    symbol: str,
+    close: float,
+    ts: datetime,
+    *,
+    open_: float | None = None,
+    high: float | None = None,
+    low: float | None = None,
+    interval: str = "d",
+) -> object:
+    o = open_ if open_ is not None else close
+    h = high if high is not None else close
+    lo = low if low is not None else close
+    return ma.OhlcvBar(
+        symbol=symbol,
+        timestamp=ts,
+        open=o,
+        high=h,
+        low=lo,
+        close=close,
+        volume=1000.0,
+        source="test",
+        interval=interval,
+    )
+
+
+def _make_bars(
+    ma: ModuleType,
+    symbol: str,
+    closes: list[float],
+    *,
+    interval: str = "d",
+    start: datetime | None = None,
+) -> list[object]:
+    base = start if start is not None else datetime(2023, 1, 2, tzinfo=UTC)
+    bars = []
+    for i, c in enumerate(closes):
+        ts = base + timedelta(days=i)
+        bars.append(_bar(ma, symbol, c, ts, interval=interval))
+    return bars
+
+
+# ── OhlcvBar ────────────────────────────────────────────────────────────────────
+
+
+def test_ohlcvbar_is_frozen(ma: ModuleType) -> None:
+    ts = datetime(2024, 1, 2, tzinfo=UTC)
+    bar = ma.OhlcvBar("A", ts, 1.0, 2.0, 0.5, 1.5, 100.0, "test", "d")
+    with pytest.raises(AttributeError):
+        bar.close = 99.0  # type: ignore[misc]
+
+
+def test_ohlcvbar_utc_timestamp(ma: ModuleType) -> None:
+    ts = datetime(2024, 1, 2, tzinfo=UTC)
+    bar = ma.OhlcvBar("X", ts, 1.0, 1.0, 1.0, 1.0, 0.0, "test", "d")
+    assert bar.timestamp.tzinfo is not None
+
+
+# ── StooqProvider._parse_csv ────────────────────────────────────────────────────
+
+
+def test_parse_csv_valid(ma: ModuleType) -> None:
+    provider = ma.StooqProvider()
+    content = "Date,Open,High,Low,Close,Volume\n2024-01-02,100,110,90,105,1000\n"
+    bars = provider._parse_csv(content, "AAPL.US", "d")
+    assert len(bars) == 1
+    assert bars[0].close == 105.0
+    assert bars[0].timestamp == datetime(2024, 1, 2, tzinfo=UTC)
+
+
+def test_parse_csv_skips_missing_date(ma: ModuleType) -> None:
+    provider = ma.StooqProvider()
+    content = "Date,Open,High,Low,Close,Volume\n,100,110,90,105,1000\n"
+    bars = provider._parse_csv(content, "X", "d")
+    assert bars == []
+
+
+def test_parse_csv_skips_malformed_row(ma: ModuleType) -> None:
+    provider = ma.StooqProvider()
+    content = "Date,Open,High,Low,Close,Volume\n2024-01-02,bad,110,90,105,1000\n"
+    bars = provider._parse_csv(content, "X", "d")
+    assert bars == []
+
+
+def test_parse_csv_sorted_ascending(ma: ModuleType) -> None:
+    provider = ma.StooqProvider()
+    content = (
+        "Date,Open,High,Low,Close,Volume\n"
+        "2024-01-03,103,113,93,108,1100\n"
+        "2024-01-02,100,110,90,105,1000\n"
+    )
+    bars = provider._parse_csv(content, "X", "d")
+    assert bars[0].timestamp < bars[1].timestamp
+
+
+def test_stooq_provider_fetch_ohlcv(ma: ModuleType, mocker: MockerFixture) -> None:
+    csv_content = "Date,Open,High,Low,Close,Volume\n2024-01-02,100,110,90,105,1000\n"
+    mock_resp = mocker.MagicMock()
+    mock_resp.read.return_value = csv_content.encode()
+    mock_resp.__enter__ = mocker.MagicMock(return_value=mock_resp)
+    mock_resp.__exit__ = mocker.MagicMock(return_value=False)
+    mocker.patch("market_analysis.urlopen", return_value=mock_resp)
+    provider = ma.StooqProvider()
+    start = datetime(2024, 1, 1, tzinfo=UTC)
+    end = datetime(2024, 1, 31, tzinfo=UTC)
+    bars = provider.fetch_ohlcv("AAPL.US", start, end)
+    assert len(bars) == 1
+    assert bars[0].source == "stooq"
+
+
+# ── CsvFileProvider ────────────────────────────────────────────────────────────
+
+
+def test_csv_file_provider_filters_range(ma: ModuleType, tmp_path: Path) -> None:
+    closes = [float(100 + i) for i in range(5)]
+    bars = _make_bars(ma, "TEST", closes)
+    ma.save_ohlcv(bars, tmp_path)
+    provider = ma.CsvFileProvider(tmp_path)
+    start = datetime(2023, 1, 3, tzinfo=UTC)
+    end = datetime(2023, 1, 4, tzinfo=UTC)
+    result = provider.fetch_ohlcv("TEST", start, end)
+    assert len(result) == 2
+    assert all(start <= b.timestamp <= end for b in result)
+
+
+# ── ohlcv_csv_path ─────────────────────────────────────────────────────────────
+
+
+def test_ohlcv_csv_path_slash(ma: ModuleType, tmp_path: Path) -> None:
+    path = ma.ohlcv_csv_path("BTC/USD", "d", tmp_path)
+    assert "BTC-USD" in path.name
+
+
+def test_ohlcv_csv_path_caret(ma: ModuleType, tmp_path: Path) -> None:
+    path = ma.ohlcv_csv_path("^SPX", "d", tmp_path)
+    assert "_SPX" in path.name
+
+
+# ── save_ohlcv / load_ohlcv ────────────────────────────────────────────────────
+
+
+def test_save_ohlcv_roundtrip(ma: ModuleType, tmp_path: Path) -> None:
+    bars = _make_bars(ma, "AAPL.US", [100.0, 101.0, 102.0])
+    path = ma.save_ohlcv(bars, tmp_path)
+    assert path.exists()
+    loaded = ma.load_ohlcv("AAPL.US", "d", tmp_path)
+    assert len(loaded) == 3
+    assert loaded[0].close == 100.0
+    assert loaded[0].timestamp.tzinfo is not None
+
+
+def test_save_ohlcv_raises_on_empty(ma: ModuleType) -> None:
+    with pytest.raises(ValueError, match="empty"):
+        ma.save_ohlcv([])
+
+
+def test_load_ohlcv_raises_file_not_found(ma: ModuleType, tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        ma.load_ohlcv("NOTEXIST", "d", tmp_path)
+
+
+def test_load_ohlcv_naive_timestamp_gets_utc(ma: ModuleType, tmp_path: Path) -> None:
+    # Write a CSV with a naive timestamp (no +00:00) to test the tzinfo fix
+    path = tmp_path / "TEST_d.csv"
+    path.write_text(
+        "symbol,timestamp,open,high,low,close,volume,source,interval\n"
+        "TEST,2024-01-02T00:00:00,100,100,100,100,0,test,d\n"
+    )
+    loaded = ma.load_ohlcv("TEST", "d", tmp_path)
+    assert loaded[0].timestamp.tzinfo is not None
+
+
+# ── check_data_quality ─────────────────────────────────────────────────────────
+
+
+def test_quality_empty_bars(ma: ModuleType) -> None:
+    report = ma.check_data_quality([])
+    assert not report.is_valid
+    assert any("empty" in i for i in report.issues)
+
+
+def test_quality_stale_data(ma: ModuleType) -> None:
+    bars = _make_bars(ma, "X", [100.0] * 70)
+    ref = bars[-1].timestamp + timedelta(days=10)
+    report = ma.check_data_quality(bars, stale_days=5, reference_time=ref)
+    assert any("stale" in i for i in report.issues)
+
+
+def test_quality_not_stale(ma: ModuleType) -> None:
+    bars = _make_bars(ma, "X", [100.0] * 70)
+    ref = bars[-1].timestamp + timedelta(days=2)
+    report = ma.check_data_quality(bars, stale_days=5, reference_time=ref)
+    assert not any("stale" in i for i in report.issues)
+
+
+def test_quality_insufficient_history(ma: ModuleType) -> None:
+    bars = _make_bars(ma, "X", [100.0] * 5)
+    ref = bars[-1].timestamp + timedelta(days=1)
+    report = ma.check_data_quality(bars, min_history=10, reference_time=ref)
+    assert any("insufficient" in i for i in report.issues)
+
+
+def test_quality_sufficient_history(ma: ModuleType) -> None:
+    bars = _make_bars(ma, "X", [100.0] * 70)
+    ref = bars[-1].timestamp + timedelta(days=1)
+    report = ma.check_data_quality(bars, min_history=60, reference_time=ref)
+    assert not any("insufficient" in i for i in report.issues)
+
+
+def test_quality_malformed_nonpositive(ma: ModuleType) -> None:
+    bars = _make_bars(ma, "X", [100.0] * 70)
+    ref = bars[-1].timestamp + timedelta(days=1)
+    bad_ts = bars[0].timestamp
+    bad = ma.OhlcvBar("X", bad_ts, -1.0, 100.0, 0.5, 100.0, 0.0, "test", "d")
+    report = ma.check_data_quality([bad, *bars[1:]], min_history=1, reference_time=ref)
+    assert any("non-positive" in i for i in report.issues)
+
+
+def test_quality_malformed_high_lt_low(ma: ModuleType) -> None:
+    bars = _make_bars(ma, "X", [100.0] * 70)
+    ref = bars[-1].timestamp + timedelta(days=1)
+    bad_ts = bars[0].timestamp
+    bad = ma.OhlcvBar("X", bad_ts, 100.0, 90.0, 110.0, 100.0, 0.0, "test", "d")
+    report = ma.check_data_quality([bad, *bars[1:]], min_history=1, reference_time=ref)
+    assert any("high < low" in i for i in report.issues)
+
+
+def test_quality_malformed_open_outside_range(ma: ModuleType) -> None:
+    bars = _make_bars(ma, "X", [100.0] * 70)
+    ref = bars[-1].timestamp + timedelta(days=1)
+    bad_ts = bars[0].timestamp
+    bad = ma.OhlcvBar("X", bad_ts, 200.0, 110.0, 90.0, 100.0, 0.0, "test", "d")
+    report = ma.check_data_quality([bad, *bars[1:]], min_history=1, reference_time=ref)
+    assert any("open outside" in i for i in report.issues)
+
+
+def test_quality_malformed_close_outside_range(ma: ModuleType) -> None:
+    bars = _make_bars(ma, "X", [100.0] * 70)
+    ref = bars[-1].timestamp + timedelta(days=1)
+    bad_ts = bars[0].timestamp
+    bad = ma.OhlcvBar("X", bad_ts, 100.0, 110.0, 90.0, 5.0, 0.0, "test", "d")
+    report = ma.check_data_quality([bad, *bars[1:]], min_history=1, reference_time=ref)
+    assert any("close outside" in i for i in report.issues)
+
+
+def test_quality_all_clear(ma: ModuleType) -> None:
+    bars = _make_bars(ma, "X", [100.0 + i for i in range(70)])
+    ref = bars[-1].timestamp + timedelta(days=1)
+    report = ma.check_data_quality(bars, min_history=60, reference_time=ref)
+    assert report.is_valid
+
+
+def test_quality_duplicate_timestamps(ma: ModuleType) -> None:
+    ts = datetime(2024, 1, 2, tzinfo=UTC)
+    bar = ma.OhlcvBar("X", ts, 100.0, 110.0, 90.0, 100.0, 0.0, "test", "d")
+    report = ma.check_data_quality(
+        [bar, bar], min_history=1, reference_time=ts + timedelta(days=1)
+    )
+    assert any("duplicate" in i for i in report.issues)
+
+
+def test_quality_large_gap_detected(ma: ModuleType) -> None:
+    ts1 = datetime(2024, 1, 2, tzinfo=UTC)
+    ts2 = datetime(2024, 2, 2, tzinfo=UTC)
+    bar1 = ma.OhlcvBar("X", ts1, 100.0, 100.0, 100.0, 100.0, 0.0, "test", "d")
+    bar2 = ma.OhlcvBar("X", ts2, 100.0, 100.0, 100.0, 100.0, 0.0, "test", "d")
+    ref = ts2 + timedelta(days=1)
+    report = ma.check_data_quality([bar1, bar2], min_history=1, reference_time=ref)
+    assert any("gap" in i or "missing" in i for i in report.issues)
+
+
+def test_quality_no_gap_with_two_bars(ma: ModuleType) -> None:
+    ts1 = datetime(2024, 1, 2, tzinfo=UTC)
+    ts2 = datetime(2024, 1, 3, tzinfo=UTC)
+    bar1 = ma.OhlcvBar("X", ts1, 100.0, 100.0, 100.0, 100.0, 0.0, "test", "d")
+    bar2 = ma.OhlcvBar("X", ts2, 100.0, 100.0, 100.0, 100.0, 0.0, "test", "d")
+    ref = ts2 + timedelta(days=1)
+    report = ma.check_data_quality([bar1, bar2], min_history=1, reference_time=ref)
+    assert not any("gap" in i or "missing" in i for i in report.issues)
+
+
+def test_quality_single_bar_no_gap_check(ma: ModuleType) -> None:
+    ts = datetime(2024, 1, 2, tzinfo=UTC)
+    bar = ma.OhlcvBar("X", ts, 100.0, 100.0, 100.0, 100.0, 0.0, "test", "d")
+    ref = ts + timedelta(days=1)
+    report = ma.check_data_quality([bar], min_history=1, reference_time=ref)
+    assert not any("gap" in i or "missing" in i for i in report.issues)
+
+
+# ── Feature helpers ────────────────────────────────────────────────────────────
+
+
+def test_compute_return_insufficient(ma: ModuleType) -> None:
+    assert ma._compute_return([100.0], 1) is None
+
+
+def test_compute_return_sufficient(ma: ModuleType) -> None:
+    result = ma._compute_return([100.0, 110.0], 1)
+    assert result is not None
+    assert abs(result - 0.10) < 1e-9
+
+
+def test_compute_ma_distance_insufficient(ma: ModuleType) -> None:
+    assert ma._compute_ma_distance([100.0] * 19, 20) is None
+
+
+def test_compute_ma_distance_sufficient(ma: ModuleType) -> None:
+    closes = [100.0] * 19 + [120.0]
+    result = ma._compute_ma_distance(closes, 20)
+    assert result is not None
+    assert result > 0
+
+
+def test_compute_realized_vol_insufficient(ma: ModuleType) -> None:
+    assert ma._compute_realized_vol([100.0] * 20, 20) is None
+
+
+def test_compute_realized_vol_sufficient(ma: ModuleType) -> None:
+    closes = [100.0 + i for i in range(22)]
+    result = ma._compute_realized_vol(closes, 20)
+    assert result is not None
+    assert result >= 0
+
+
+def test_compute_max_drawdown_empty(ma: ModuleType) -> None:
+    assert ma._compute_max_drawdown([], 60) is None
+
+
+def test_compute_max_drawdown_monotone_up(ma: ModuleType) -> None:
+    closes = [float(100 + i) for i in range(10)]
+    result = ma._compute_max_drawdown(closes, 60)
+    assert result is not None
+    assert result == pytest.approx(0.0)
+
+
+def test_compute_max_drawdown_with_drop(ma: ModuleType) -> None:
+    closes = [1.0, 3.0, 2.0]
+    result = ma._compute_max_drawdown(closes, 60)
+    assert result is not None
+    assert result == pytest.approx(1.0 / 3.0)
+
+
+def test_compute_rsi_insufficient(ma: ModuleType) -> None:
+    assert ma._compute_rsi([100.0] * 14, 14) is None
+
+
+def test_compute_rsi_all_gains(ma: ModuleType) -> None:
+    closes = [float(100 + i) for i in range(16)]
+    result = ma._compute_rsi(closes, 14)
+    assert result == pytest.approx(100.0)
+
+
+def test_compute_rsi_mixed(ma: ModuleType) -> None:
+    closes = [
+        100.0,
+        110.0,
+        105.0,
+        108.0,
+        103.0,
+        107.0,
+        102.0,
+        106.0,
+        101.0,
+        105.0,
+        100.0,
+        104.0,
+        99.0,
+        103.0,
+        98.0,
+    ]
+    result = ma._compute_rsi(closes, 14)
+    assert result is not None
+    assert 0.0 < result < 100.0
+
+
+def test_compute_zscore_insufficient(ma: ModuleType) -> None:
+    assert ma._compute_zscore([100.0] * 19, 20) is None
+
+
+def test_compute_zscore_flat(ma: ModuleType) -> None:
+    result = ma._compute_zscore([100.0] * 20, 20)
+    assert result == pytest.approx(0.0)
+
+
+def test_compute_zscore_varying(ma: ModuleType) -> None:
+    closes = [float(100 + (i % 3)) for i in range(20)]
+    result = ma._compute_zscore(closes, 20)
+    assert result is not None
+
+
+def test_compute_features_few_bars(ma: ModuleType) -> None:
+    bars = _make_bars(ma, "X", [100.0, 101.0, 102.0])
+    feats = ma.compute_features(bars)
+    assert feats.ret_1d is not None
+    assert feats.ret_60d is None
+    assert feats.ma20_dist is None
+    assert feats.rsi_14 is None
+
+
+def test_compute_features_full(ma: ModuleType) -> None:
+    closes = [float(100 + i) for i in range(80)]
+    bars = _make_bars(ma, "X", closes)
+    feats = ma.compute_features(bars)
+    assert feats.ret_1d is not None
+    assert feats.ret_60d is not None
+    assert feats.ma20_dist is not None
+    assert feats.ma50_dist is not None
+    assert feats.rsi_14 is not None
+    assert feats.zscore_20d is not None
+
+
+# ── _percentile_rank ──────────────────────────────────────────────────────────
+
+
+def test_percentile_rank_all_none(ma: ModuleType) -> None:
+    assert ma._percentile_rank([None, None], 0) == pytest.approx(50.0)
+
+
+def test_percentile_rank_this_none(ma: ModuleType) -> None:
+    assert ma._percentile_rank([1.0, None, 2.0], 1) == pytest.approx(50.0)
+
+
+def test_percentile_rank_lowest(ma: ModuleType) -> None:
+    assert ma._percentile_rank([1.0, 2.0, 3.0], 0) == pytest.approx(0.0)
+
+
+def test_percentile_rank_highest(ma: ModuleType) -> None:
+    result = ma._percentile_rank([1.0, 2.0, 3.0], 2)
+    assert result == pytest.approx(200.0 / 3.0)
+
+
+# ── _collect_risk_gates ────────────────────────────────────────────────────────
+
+
+def _empty_features(ma: ModuleType) -> object:
+    return ma.InstrumentFeatures(
+        ret_1d=None,
+        ret_5d=None,
+        ret_20d=None,
+        ret_60d=None,
+        ma20_dist=None,
+        ma50_dist=None,
+        vol_20d=None,
+        mdd_60d=None,
+        rsi_14=None,
+        zscore_20d=None,
+    )
+
+
+def _report(ma: ModuleType, issues: list[str]) -> object:
+    return ma.DataQualityReport(symbol="X", interval="d", bar_count=1, issues=issues)
+
+
+def test_collect_gates_no_issues_no_vol(ma: ModuleType) -> None:
+    gates = ma._collect_risk_gates(_report(ma, []), _empty_features(ma))
+    assert gates == []
+
+
+def test_collect_gates_stale(ma: ModuleType) -> None:
+    gates = ma._collect_risk_gates(
+        _report(ma, ["stale data: ..."]), _empty_features(ma)
+    )
+    assert ma.RISK_GATE_STALE in gates
+
+
+def test_collect_gates_insufficient(ma: ModuleType) -> None:
+    gates = ma._collect_risk_gates(
+        _report(ma, ["insufficient history: 5 bars"]), _empty_features(ma)
+    )
+    assert ma.RISK_GATE_INSUFFICIENT in gates
+
+
+def test_collect_gates_missing_bars(ma: ModuleType) -> None:
+    gates = ma._collect_risk_gates(
+        _report(ma, ["possible missing bars: 30-day gap"]), _empty_features(ma)
+    )
+    assert ma.RISK_GATE_MISSING_BARS in gates
+
+
+def test_collect_gates_malformed(ma: ModuleType) -> None:
+    gates = ma._collect_risk_gates(
+        _report(ma, ["malformed OHLC at index 0"]), _empty_features(ma)
+    )
+    assert ma.RISK_GATE_MALFORMED in gates
+
+
+def test_collect_gates_high_vol(ma: ModuleType) -> None:
+    feats = ma.InstrumentFeatures(
+        ret_1d=None,
+        ret_5d=None,
+        ret_20d=None,
+        ret_60d=None,
+        ma20_dist=None,
+        ma50_dist=None,
+        vol_20d=2.0,
+        mdd_60d=None,
+        rsi_14=None,
+        zscore_20d=None,
+    )
+    gates = ma._collect_risk_gates(_report(ma, []), feats)
+    assert ma.RISK_GATE_HIGH_VOL in gates
+
+
+def test_collect_gates_low_vol_not_flagged(ma: ModuleType) -> None:
+    feats = ma.InstrumentFeatures(
+        ret_1d=None,
+        ret_5d=None,
+        ret_20d=None,
+        ret_60d=None,
+        ma20_dist=None,
+        ma50_dist=None,
+        vol_20d=0.3,
+        mdd_60d=None,
+        rsi_14=None,
+        zscore_20d=None,
+    )
+    gates = ma._collect_risk_gates(_report(ma, []), feats)
+    assert ma.RISK_GATE_HIGH_VOL not in gates
+
+
+# ── _build_explanation ─────────────────────────────────────────────────────────
+
+
+def _full_features(ma: ModuleType) -> object:
+    return ma.InstrumentFeatures(
+        ret_1d=0.01,
+        ret_5d=0.02,
+        ret_20d=0.05,
+        ret_60d=0.10,
+        ma20_dist=0.03,
+        ma50_dist=0.02,
+        vol_20d=0.20,
+        mdd_60d=0.05,
+        rsi_14=60.0,
+        zscore_20d=0.5,
+    )
+
+
+def test_build_explanation_with_gates(ma: ModuleType) -> None:
+    expl = ma._build_explanation("X", _empty_features(ma), ["stale_data"])
+    assert "Suppressed" in expl
+    assert "stale_data" in expl
+
+
+def test_build_explanation_no_features(ma: ModuleType) -> None:
+    expl = ma._build_explanation("X", _empty_features(ma), [])
+    assert "insufficient" in expl
+
+
+def test_build_explanation_full_features(ma: ModuleType) -> None:
+    expl = ma._build_explanation("X", _full_features(ma), [])
+    assert "20d" in expl
+    assert "MA20" in expl
+    assert "RSI14" in expl
+
+
+# ── score_instruments ──────────────────────────────────────────────────────────
+
+
+def test_score_instruments_empty(ma: ModuleType) -> None:
+    assert ma.score_instruments({}) == []
+
+
+def test_score_single_instrument(ma: ModuleType) -> None:
+    bars = _make_bars(ma, "A", [float(100 + i) for i in range(80)])
+    ref = bars[-1].timestamp + timedelta(days=1)
+    results = ma.score_instruments({"A": bars}, reference_time=ref)
+    assert len(results) == 1
+    assert results[0].rank == 1
+
+
+def test_score_multiple_instruments(ma: ModuleType) -> None:
+    up = _make_bars(ma, "UP", [float(100 + i) for i in range(80)])
+    down = _make_bars(ma, "DOWN", [float(100 - i * 0.5) for i in range(80)])
+    ref = up[-1].timestamp + timedelta(days=1)
+    results = ma.score_instruments({"UP": up, "DOWN": down}, reference_time=ref)
+    assert len(results) == 2
+    assert results[0].rank == 1
+    assert results[1].rank == 2
+    symbols = [r.symbol for r in results]
+    assert symbols[0] == "UP"
+
+
+def test_score_risk_gate_stale(ma: ModuleType) -> None:
+    bars = _make_bars(ma, "X", [100.0] * 70)
+    ref = bars[-1].timestamp + timedelta(days=30)
+    results = ma.score_instruments({"X": bars}, reference_time=ref, stale_days=5)
+    assert not results[0].is_reliable
+    assert ma.RISK_GATE_STALE in results[0].risk_gates
+
+
+def test_score_risk_gate_insufficient(ma: ModuleType) -> None:
+    bars = _make_bars(ma, "X", [100.0] * 5)
+    ref = bars[-1].timestamp + timedelta(days=1)
+    results = ma.score_instruments({"X": bars}, reference_time=ref, min_history=60)
+    assert not results[0].is_reliable
+    assert ma.RISK_GATE_INSUFFICIENT in results[0].risk_gates
+
+
+def test_score_risk_gate_high_vol(ma: ModuleType) -> None:
+    factor = math.exp(0.1)
+    closes = [100.0 * (factor if i % 2 == 0 else 1.0 / factor) for i in range(80)]
+    bars = _make_bars(ma, "X", closes)
+    ref = bars[-1].timestamp + timedelta(days=1)
+    results = ma.score_instruments({"X": bars}, reference_time=ref)
+    if results[0].features.vol_20d is not None and results[0].features.vol_20d > 1.0:
+        assert ma.RISK_GATE_HIGH_VOL in results[0].risk_gates
+
+
+def test_score_risk_gate_missing_bars(ma: ModuleType) -> None:
+    ts1 = datetime(2023, 1, 2, tzinfo=UTC)
+    ts2 = datetime(2023, 6, 1, tzinfo=UTC)
+    bars = [
+        ma.OhlcvBar("X", ts1, 100.0, 100.0, 100.0, 100.0, 0.0, "test", "d"),
+        ma.OhlcvBar("X", ts2, 100.0, 100.0, 100.0, 100.0, 0.0, "test", "d"),
+    ]
+    ref = ts2 + timedelta(days=1)
+    results = ma.score_instruments({"X": bars}, reference_time=ref, min_history=1)
+    assert ma.RISK_GATE_MISSING_BARS in results[0].risk_gates
+
+
+def test_score_risk_gate_malformed(ma: ModuleType) -> None:
+    bars = _make_bars(ma, "X", [100.0] * 70)
+    ref = bars[-1].timestamp + timedelta(days=1)
+    bad_ts = bars[0].timestamp
+    bad = ma.OhlcvBar("X", bad_ts, -1.0, 100.0, 100.0, 100.0, 0.0, "test", "d")
+    mixed = [bad, *bars[1:]]
+    results = ma.score_instruments({"X": mixed}, reference_time=ref)
+    assert ma.RISK_GATE_MALFORMED in results[0].risk_gates
+
+
+# ── _get_git_commit ─────────────────────────────────────────────────────────────
+
+
+def test_get_git_commit_success(ma: ModuleType, mocker: MockerFixture) -> None:
+    mock_result = mocker.MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = "abc1234\n"
+    mocker.patch("subprocess.run", return_value=mock_result)
+    commit = ma._get_git_commit()
+    assert commit == "abc1234"
+
+
+def test_get_git_commit_nonzero(ma: ModuleType, mocker: MockerFixture) -> None:
+    mock_result = mocker.MagicMock()
+    mock_result.returncode = 1
+    mock_result.stdout = ""
+    mocker.patch("subprocess.run", return_value=mock_result)
+    assert ma._get_git_commit() == "unknown"
+
+
+def test_get_git_commit_oserror(ma: ModuleType, mocker: MockerFixture) -> None:
+    mocker.patch("subprocess.run", side_effect=OSError("git not found"))
+    assert ma._get_git_commit() == "unknown"
+
+
+# ── generate_artifact / save_artifact ─────────────────────────────────────────
+
+
+def test_generate_artifact_structure(ma: ModuleType, mocker: MockerFixture) -> None:
+    mocker.patch.object(ma, "_get_git_commit", return_value="abc1234")
+    bars = _make_bars(ma, "A", [float(100 + i) for i in range(80)])
+    ref = bars[-1].timestamp + timedelta(days=1)
+    scores = ma.score_instruments({"A": bars}, reference_time=ref)
+    artifact = ma.generate_artifact(scores, {"A": bars}, {"stale_days": 5})
+    assert artifact["version"] == "1.0.0"
+    assert "metadata" in artifact
+    assert "instruments" in artifact
+    meta = artifact["metadata"]
+    assert meta["git_commit"] == "abc1234"
+    assert "generated_at" in meta
+    assert meta["data_source"] == "test"
+
+
+def test_generate_artifact_empty_data_source(
+    ma: ModuleType, mocker: MockerFixture
+) -> None:
+    mocker.patch.object(ma, "_get_git_commit", return_value="unknown")
+    artifact = ma.generate_artifact([], {}, {})
+    assert artifact["metadata"]["data_source"] == "unknown"
+
+
+def test_save_artifact_path_contains_date(
+    ma: ModuleType, mocker: MockerFixture, tmp_path: Path
+) -> None:
+    mocker.patch.object(ma, "_get_git_commit", return_value="abc")
+    bars = _make_bars(ma, "A", [float(100 + i) for i in range(80)])
+    ref = bars[-1].timestamp + timedelta(days=1)
+    scores = ma.score_instruments({"A": bars}, reference_time=ref)
+    artifact = ma.generate_artifact(scores, {"A": bars}, {})
+    path = ma.save_artifact(artifact, tmp_path)
+    assert path.suffix == ".json"
+    loaded = json.loads(path.read_text())
+    assert loaded["version"] == "1.0.0"
+
+
+def test_save_artifact_no_generated_at(ma: ModuleType, tmp_path: Path) -> None:
+    artifact: dict = {"version": "1.0.0", "instruments": []}
+    path = ma.save_artifact(artifact, tmp_path)
+    assert path.exists()
+
+
+# ── CLI: _cmd_fetch ───────────────────────────────────────────────────────────
+
+
+def test_cmd_fetch_success(
+    ma: ModuleType, mocker: MockerFixture, tmp_path: Path
+) -> None:
+    csv_content = "Date,Open,High,Low,Close,Volume\n2024-01-02,100,110,90,105,1000\n"
+    mock_resp = mocker.MagicMock()
+    mock_resp.read.return_value = csv_content.encode()
+    mock_resp.__enter__ = mocker.MagicMock(return_value=mock_resp)
+    mock_resp.__exit__ = mocker.MagicMock(return_value=False)
+    mocker.patch("market_analysis.urlopen", return_value=mock_resp)
+    mocker.patch.object(
+        sys,
+        "argv",
+        [
+            "market_analysis.py",
+            "fetch",
+            "--symbol",
+            "AAPL.US",
+            "--start",
+            "2024-01-01",
+            "--end",
+            "2024-01-31",
+            "--output",
+            str(tmp_path),
+        ],
+    )
+    result = ma.main()
+    assert result == 0
+
+
+def test_cmd_fetch_url_error(
+    ma: ModuleType, mocker: MockerFixture, tmp_path: Path
+) -> None:
+    mocker.patch("market_analysis.urlopen", side_effect=URLError("network error"))
+    mocker.patch.object(
+        sys,
+        "argv",
+        [
+            "market_analysis.py",
+            "fetch",
+            "--symbol",
+            "AAPL.US",
+            "--start",
+            "2024-01-01",
+            "--end",
+            "2024-01-31",
+            "--output",
+            str(tmp_path),
+        ],
+    )
+    result = ma.main()
+    assert result == 1
+
+
+def test_cmd_fetch_no_data(
+    ma: ModuleType, mocker: MockerFixture, tmp_path: Path
+) -> None:
+    csv_content = "Date,Open,High,Low,Close,Volume\n"
+    mock_resp = mocker.MagicMock()
+    mock_resp.read.return_value = csv_content.encode()
+    mock_resp.__enter__ = mocker.MagicMock(return_value=mock_resp)
+    mock_resp.__exit__ = mocker.MagicMock(return_value=False)
+    mocker.patch("market_analysis.urlopen", return_value=mock_resp)
+    mocker.patch.object(
+        sys,
+        "argv",
+        [
+            "market_analysis.py",
+            "fetch",
+            "--symbol",
+            "AAPL.US",
+            "--start",
+            "2024-01-01",
+            "--end",
+            "2024-01-31",
+            "--output",
+            str(tmp_path),
+        ],
+    )
+    result = ma.main()
+    assert result == 1
+
+
+def test_cmd_fetch_no_validate_flag(
+    ma: ModuleType, mocker: MockerFixture, tmp_path: Path
+) -> None:
+    csv_content = "Date,Open,High,Low,Close,Volume\n2024-01-02,100,110,90,105,1000\n"
+    mock_resp = mocker.MagicMock()
+    mock_resp.read.return_value = csv_content.encode()
+    mock_resp.__enter__ = mocker.MagicMock(return_value=mock_resp)
+    mock_resp.__exit__ = mocker.MagicMock(return_value=False)
+    mocker.patch("market_analysis.urlopen", return_value=mock_resp)
+    mocker.patch.object(
+        sys,
+        "argv",
+        [
+            "market_analysis.py",
+            "fetch",
+            "--symbol",
+            "AAPL.US",
+            "--start",
+            "2024-01-01",
+            "--end",
+            "2024-01-31",
+            "--output",
+            str(tmp_path),
+            "--no-validate",
+        ],
+    )
+    result = ma.main()
+    assert result == 0
+
+
+def test_cmd_fetch_reports_quality_issues(
+    ma: ModuleType,
+    mocker: MockerFixture,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    csv_content = "Date,Open,High,Low,Close,Volume\n2020-01-02,100,110,90,105,1000\n"
+    mock_resp = mocker.MagicMock()
+    mock_resp.read.return_value = csv_content.encode()
+    mock_resp.__enter__ = mocker.MagicMock(return_value=mock_resp)
+    mock_resp.__exit__ = mocker.MagicMock(return_value=False)
+    mocker.patch("market_analysis.urlopen", return_value=mock_resp)
+    mocker.patch.object(
+        sys,
+        "argv",
+        [
+            "market_analysis.py",
+            "fetch",
+            "--symbol",
+            "AAPL.US",
+            "--start",
+            "2020-01-01",
+            "--end",
+            "2020-01-31",
+            "--output",
+            str(tmp_path),
+        ],
+    )
+    result = ma.main()
+    assert result == 0
+    output = capsys.readouterr().out
+    assert "WARNING" in output
+
+
+# ── CLI: _cmd_check ───────────────────────────────────────────────────────────
+
+
+def test_cmd_check_valid(ma: ModuleType, mocker: MockerFixture, tmp_path: Path) -> None:
+    bars = _make_bars(ma, "A", [float(100 + i) for i in range(70)])
+    ma.save_ohlcv(bars, tmp_path)
+    ref_ts = bars[-1].timestamp + timedelta(days=1)
+    mocker.patch.object(
+        ma,
+        "check_data_quality",
+        return_value=ma.DataQualityReport("A", "d", len(bars)),
+    )
+    mocker.patch.object(
+        sys,
+        "argv",
+        [
+            "market_analysis.py",
+            "check",
+            "--symbol",
+            "A",
+            "--data-dir",
+            str(tmp_path),
+        ],
+    )
+    _ = ref_ts
+    result = ma.main()
+    assert result == 0
+
+
+def test_cmd_check_file_not_found(
+    ma: ModuleType, mocker: MockerFixture, tmp_path: Path
+) -> None:
+    mocker.patch.object(
+        sys,
+        "argv",
+        [
+            "market_analysis.py",
+            "check",
+            "--symbol",
+            "NOEXIST",
+            "--data-dir",
+            str(tmp_path),
+        ],
+    )
+    result = ma.main()
+    assert result == 1
+
+
+# ── CLI: _cmd_check (direct) ──────────────────────────────────────────────────
+
+
+def test_cmd_check_direct_valid(ma: ModuleType, tmp_path: Path) -> None:
+    today = datetime.now(tz=UTC)
+    bars = _make_bars(
+        ma, "B", [float(100 + i) for i in range(70)], start=today - timedelta(days=69)
+    )
+    ma.save_ohlcv(bars, tmp_path)
+
+    class Args:
+        symbol = "B"
+        interval = "d"
+        data_dir = str(tmp_path)
+
+    result = ma._cmd_check(Args())
+    assert result == 0
+
+
+def test_cmd_check_direct_invalid(ma: ModuleType, tmp_path: Path) -> None:
+    bars = _make_bars(ma, "B", [100.0] * 3)
+    ma.save_ohlcv(bars, tmp_path)
+
+    class Args:
+        symbol = "B"
+        interval = "d"
+        data_dir = str(tmp_path)
+
+    result = ma._cmd_check(Args())
+    assert result == 1
+
+
+def test_cmd_check_direct_not_found(ma: ModuleType, tmp_path: Path) -> None:
+    class Args:
+        symbol = "NOFILE"
+        interval = "d"
+        data_dir = str(tmp_path)
+
+    result = ma._cmd_check(Args())
+    assert result == 1
+
+
+# ── CLI: _cmd_score ───────────────────────────────────────────────────────────
+
+
+def test_cmd_score_no_data(ma: ModuleType, tmp_path: Path) -> None:
+    class Args:
+        symbols = "NOEXIST"
+        interval = "d"
+        data_dir = str(tmp_path)
+
+    result = ma._cmd_score(Args())
+    assert result == 1
+
+
+def test_cmd_score_success(ma: ModuleType, tmp_path: Path) -> None:
+    bars = _make_bars(ma, "C", [float(100 + i) for i in range(70)])
+    ma.save_ohlcv(bars, tmp_path)
+
+    class Args:
+        symbols = "C"
+        interval = "d"
+        data_dir = str(tmp_path)
+
+    result = ma._cmd_score(Args())
+    assert result == 0
+
+
+def test_cmd_score_partial_missing(
+    ma: ModuleType, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    bars = _make_bars(ma, "D", [float(100 + i) for i in range(70)])
+    ma.save_ohlcv(bars, tmp_path)
+
+    class Args:
+        symbols = "D,MISSING"
+        interval = "d"
+        data_dir = str(tmp_path)
+
+    result = ma._cmd_score(Args())
+    assert result == 0
+    assert "WARNING" in capsys.readouterr().out
+
+
+# ── CLI: _cmd_generate ────────────────────────────────────────────────────────
+
+
+def test_cmd_generate_no_data(ma: ModuleType, tmp_path: Path) -> None:
+    class Args:
+        symbols = "NOEXIST"
+        interval = "d"
+        data_dir = str(tmp_path)
+        output = str(tmp_path / "analysis")
+
+    result = ma._cmd_generate(Args())
+    assert result == 1
+
+
+def test_cmd_generate_success(
+    ma: ModuleType, mocker: MockerFixture, tmp_path: Path
+) -> None:
+    mocker.patch.object(ma, "_get_git_commit", return_value="abc")
+    bars = _make_bars(ma, "E", [float(100 + i) for i in range(70)])
+    ma.save_ohlcv(bars, tmp_path)
+
+    class Args:
+        symbols = "E"
+        interval = "d"
+        data_dir = str(tmp_path)
+        output = str(tmp_path / "analysis")
+
+    result = ma._cmd_generate(Args())
+    assert result == 0
+    analysis_dir = tmp_path / "analysis"
+    json_files = list(analysis_dir.glob("*.json"))
+    assert len(json_files) == 1
+
+
+# ── CLI: main routing ─────────────────────────────────────────────────────────
+
+
+def test_main_routes_fetch(ma: ModuleType, mocker: MockerFixture) -> None:
+    called = []
+    mocker.patch.object(
+        ma, "_cmd_fetch", side_effect=lambda _a: called.append("fetch") or 0
+    )
+    mocker.patch.object(
+        sys,
+        "argv",
+        [
+            "market_analysis.py",
+            "fetch",
+            "--symbol",
+            "X",
+            "--start",
+            "2024-01-01",
+            "--end",
+            "2024-01-31",
+        ],
+    )
+    ma.main()
+    assert called == ["fetch"]
+
+
+def test_main_routes_check(ma: ModuleType, mocker: MockerFixture) -> None:
+    called = []
+    mocker.patch.object(
+        ma, "_cmd_check", side_effect=lambda _a: called.append("check") or 0
+    )
+    mocker.patch.object(
+        sys,
+        "argv",
+        [
+            "market_analysis.py",
+            "check",
+            "--symbol",
+            "X",
+        ],
+    )
+    ma.main()
+    assert called == ["check"]
+
+
+def test_main_routes_score(ma: ModuleType, mocker: MockerFixture) -> None:
+    called = []
+    mocker.patch.object(
+        ma, "_cmd_score", side_effect=lambda _a: called.append("score") or 0
+    )
+    mocker.patch.object(
+        sys,
+        "argv",
+        [
+            "market_analysis.py",
+            "score",
+            "--symbols",
+            "X",
+        ],
+    )
+    ma.main()
+    assert called == ["score"]
+
+
+def test_main_routes_generate(ma: ModuleType, mocker: MockerFixture) -> None:
+    called = []
+    mocker.patch.object(
+        ma, "_cmd_generate", side_effect=lambda _a: called.append("generate") or 0
+    )
+    mocker.patch.object(
+        sys,
+        "argv",
+        [
+            "market_analysis.py",
+            "generate",
+            "--symbols",
+            "X",
+        ],
+    )
+    ma.main()
+    assert called == ["generate"]

--- a/tests/test_market_analysis.py
+++ b/tests/test_market_analysis.py
@@ -672,6 +672,42 @@ def test_score_risk_gate_malformed(ma: ModuleType) -> None:
     assert ma.RISK_GATE_MALFORMED in results[0].risk_gates
 
 
+def test_reliable_instruments_rank_above_unreliable(ma: ModuleType) -> None:
+    # Reliable instrument with a low score
+    low_bars = _make_bars(ma, "LOW", [float(100 - i * 0.1) for i in range(80)])
+    ref = low_bars[-1].timestamp + timedelta(days=1)
+    # Use old timestamps so STALE is stale relative to ref, LOW is fresh
+    stale_bars_old = _make_bars(
+        ma,
+        "STALE",
+        [float(100 + i) for i in range(80)],
+        start=datetime(2022, 1, 1, tzinfo=UTC),
+    )
+    results = ma.score_instruments(
+        {"STALE": stale_bars_old, "LOW": low_bars},
+        reference_time=ref,
+        stale_days=5,
+    )
+    reliable = [r for r in results if r.is_reliable]
+    unreliable = [r for r in results if not r.is_reliable]
+    assert reliable
+    assert unreliable
+    assert max(r.rank for r in reliable) < min(r.rank for r in unreliable)
+
+
+def test_score_ordering_reliable_before_unreliable(ma: ModuleType) -> None:
+    good = _make_bars(ma, "GOOD", [float(100 + i) for i in range(80)])
+    bad = _make_bars(ma, "BAD", [100.0] * 3)
+    ref = good[-1].timestamp + timedelta(days=1)
+    results = ma.score_instruments(
+        {"GOOD": good, "BAD": bad},
+        reference_time=ref,
+        min_history=60,
+    )
+    ranks = {r.symbol: r.rank for r in results}
+    assert ranks["GOOD"] < ranks["BAD"]
+
+
 # ── _get_git_commit ─────────────────────────────────────────────────────────────
 
 
@@ -713,6 +749,9 @@ def test_generate_artifact_structure(ma: ModuleType, mocker: MockerFixture) -> N
     assert meta["git_commit"] == "abc1234"
     assert "generated_at" in meta
     assert meta["data_source"] == "test"
+    assert "data_freshness" in meta
+    assert isinstance(meta["data_freshness"], dict)
+    assert "A" in meta["data_freshness"]
 
 
 def test_generate_artifact_empty_data_source(
@@ -721,6 +760,20 @@ def test_generate_artifact_empty_data_source(
     mocker.patch.object(ma, "_get_git_commit", return_value="unknown")
     artifact = ma.generate_artifact([], {}, {})
     assert artifact["metadata"]["data_source"] == "unknown"
+
+
+def test_generate_artifact_multi_source_deterministic(
+    ma: ModuleType, mocker: MockerFixture
+) -> None:
+    mocker.patch.object(ma, "_get_git_commit", return_value="abc")
+    bar_a = _make_bars(ma, "A", [100.0], start=datetime(2024, 1, 2, tzinfo=UTC))
+    bar_b = [
+        ma.OhlcvBar(
+            "B", datetime(2024, 1, 2, tzinfo=UTC), 1.0, 1.0, 1.0, 1.0, 0.0, "csv", "d"
+        )
+    ]
+    artifact = ma.generate_artifact([], {"A": bar_a, "B": bar_b}, {})
+    assert artifact["metadata"]["data_source"] == "csv,test"
 
 
 def test_save_artifact_path_contains_date(

--- a/tests/test_validate_analysis.py
+++ b/tests/test_validate_analysis.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+    from pytest_mock import MockerFixture
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / ".agents"
+    / "skills"
+    / "market-analysis"
+    / "scripts"
+    / "validate_analysis.py"
+)
+
+
+@pytest.fixture(scope="module")
+def va() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("validate_analysis", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        pytest.fail("Failed to load validate_analysis.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+VALID_INSTRUMENT: dict[str, Any] = {
+    "symbol": "AAPL.US",
+    "rank": 1,
+    "score": 75.0,
+    "is_reliable": True,
+    "risk_gates": [],
+    "explanation": "Strong momentum.",
+    "features": {"ret_1d": 0.01},
+}
+
+VALID_ARTIFACT: dict[str, Any] = {
+    "version": "1.0.0",
+    "metadata": {
+        "generated_at": "2024-01-01T00:00:00+00:00",
+        "git_commit": "abc1234",
+        "data_source": "stooq",
+        "scoring_version": "1.0.0",
+        "config": {"stale_days": 5},
+    },
+    "instruments": [VALID_INSTRUMENT],
+}
+
+
+def write_artifact(tmp_path: Path, artifact: dict[str, Any]) -> Path:
+    path = tmp_path / "test.json"
+    path.write_text(json.dumps(artifact))
+    return path
+
+
+# ── validate_artifact ──────────────────────────────────────────────────────────
+
+
+def test_validate_valid(va: ModuleType) -> None:
+    errors = va.validate_artifact(dict(VALID_ARTIFACT))
+    assert errors == []
+
+
+def test_validate_missing_version(va: ModuleType) -> None:
+    data = {k: v for k, v in VALID_ARTIFACT.items() if k != "version"}
+    errors = va.validate_artifact(data)
+    assert any("version" in e for e in errors)
+
+
+def test_validate_missing_metadata(va: ModuleType) -> None:
+    data = {k: v for k, v in VALID_ARTIFACT.items() if k != "metadata"}
+    errors = va.validate_artifact(data)
+    assert any("metadata" in e for e in errors)
+
+
+def test_validate_missing_instruments(va: ModuleType) -> None:
+    data = {k: v for k, v in VALID_ARTIFACT.items() if k != "instruments"}
+    errors = va.validate_artifact(data)
+    assert any("instruments" in e for e in errors)
+
+
+def test_validate_multiple_missing_top_keys(va: ModuleType) -> None:
+    errors = va.validate_artifact({})
+    assert len([e for e in errors if "missing required key" in e]) == 3
+
+
+def test_validate_wrong_version(va: ModuleType) -> None:
+    data = {**VALID_ARTIFACT, "version": "2.0.0"}
+    errors = va.validate_artifact(data)
+    assert any("unsupported version" in e for e in errors)
+
+
+def test_validate_metadata_not_dict(va: ModuleType) -> None:
+    data = {**VALID_ARTIFACT, "metadata": "bad"}
+    errors = va.validate_artifact(data)
+    assert any("metadata" in e and "object" in e for e in errors)
+
+
+def test_validate_metadata_missing_key(va: ModuleType) -> None:
+    bad_meta = {
+        k: v for k, v in VALID_ARTIFACT["metadata"].items() if k != "git_commit"
+    }
+    data = {**VALID_ARTIFACT, "metadata": bad_meta}
+    errors = va.validate_artifact(data)
+    assert any("git_commit" in e for e in errors)
+
+
+def test_validate_instruments_not_list(va: ModuleType) -> None:
+    data = {**VALID_ARTIFACT, "instruments": {"a": 1}}
+    errors = va.validate_artifact(data)
+    assert any("array" in e for e in errors)
+
+
+def test_validate_instrument_not_dict(va: ModuleType) -> None:
+    data = {**VALID_ARTIFACT, "instruments": ["not_a_dict"]}
+    errors = va.validate_artifact(data)
+    assert any("object" in e for e in errors)
+
+
+def test_validate_instrument_missing_key(va: ModuleType) -> None:
+    bad_inst = {k: v for k, v in VALID_INSTRUMENT.items() if k != "symbol"}
+    data = {**VALID_ARTIFACT, "instruments": [bad_inst]}
+    errors = va.validate_artifact(data)
+    assert any("symbol" in e for e in errors)
+
+
+def test_validate_score_not_numeric(va: ModuleType) -> None:
+    bad_inst = {**VALID_INSTRUMENT, "score": "high"}
+    data = {**VALID_ARTIFACT, "instruments": [bad_inst]}
+    errors = va.validate_artifact(data)
+    assert any("score" in e and "number" in e for e in errors)
+
+
+def test_validate_score_out_of_range(va: ModuleType) -> None:
+    bad_inst = {**VALID_INSTRUMENT, "score": 150.0}
+    data = {**VALID_ARTIFACT, "instruments": [bad_inst]}
+    errors = va.validate_artifact(data)
+    assert any("score" in e and "outside" in e for e in errors)
+
+
+def test_validate_score_zero_valid(va: ModuleType) -> None:
+    inst = {**VALID_INSTRUMENT, "score": 0.0}
+    data = {**VALID_ARTIFACT, "instruments": [inst]}
+    errors = va.validate_artifact(data)
+    score_errors = [e for e in errors if "score" in e]
+    assert score_errors == []
+
+
+def test_validate_rank_not_integer(va: ModuleType) -> None:
+    bad_inst = {**VALID_INSTRUMENT, "rank": "first"}
+    data = {**VALID_ARTIFACT, "instruments": [bad_inst]}
+    errors = va.validate_artifact(data)
+    assert any("rank" in e and "integer" in e for e in errors)
+
+
+def test_validate_rank_boolean_rejected(va: ModuleType) -> None:
+    bad_inst = {**VALID_INSTRUMENT, "rank": True}
+    data = {**VALID_ARTIFACT, "instruments": [bad_inst]}
+    errors = va.validate_artifact(data)
+    assert any("rank" in e and "integer" in e for e in errors)
+
+
+def test_validate_rank_zero(va: ModuleType) -> None:
+    bad_inst = {**VALID_INSTRUMENT, "rank": 0}
+    data = {**VALID_ARTIFACT, "instruments": [bad_inst]}
+    errors = va.validate_artifact(data)
+    assert any("rank" in e and ">= 1" in e for e in errors)
+
+
+def test_validate_rank_negative(va: ModuleType) -> None:
+    bad_inst = {**VALID_INSTRUMENT, "rank": -1}
+    data = {**VALID_ARTIFACT, "instruments": [bad_inst]}
+    errors = va.validate_artifact(data)
+    assert any("rank" in e and ">= 1" in e for e in errors)
+
+
+def test_validate_multiple_instruments(va: ModuleType) -> None:
+    inst2 = {**VALID_INSTRUMENT, "symbol": "MSFT.US", "rank": 2}
+    data = {**VALID_ARTIFACT, "instruments": [VALID_INSTRUMENT, inst2]}
+    errors = va.validate_artifact(data)
+    assert errors == []
+
+
+def test_validate_empty_instruments_list(va: ModuleType) -> None:
+    data = {**VALID_ARTIFACT, "instruments": []}
+    errors = va.validate_artifact(data)
+    assert errors == []
+
+
+# ── parse_args ─────────────────────────────────────────────────────────────────
+
+
+def test_parse_args_custom(va: ModuleType, mocker: MockerFixture) -> None:
+    mocker.patch.object(
+        sys,
+        "argv",
+        ["validate_analysis.py", "--input", "data/analysis/2024-01-01.json"],
+    )
+    args = va.parse_args()
+    assert args.input == Path("data/analysis/2024-01-01.json")
+
+
+# ── main ───────────────────────────────────────────────────────────────────────
+
+
+def test_main_valid(
+    va: ModuleType,
+    mocker: MockerFixture,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = write_artifact(tmp_path, VALID_ARTIFACT)
+    mocker.patch.object(sys, "argv", ["validate_analysis.py", "--input", str(path)])
+    va.main()
+    assert "OK" in capsys.readouterr().out
+
+
+def test_main_invalid_artifact(
+    va: ModuleType,
+    mocker: MockerFixture,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    bad = {**VALID_ARTIFACT, "version": "9.9.9"}
+    path = write_artifact(tmp_path, bad)
+    mocker.patch.object(sys, "argv", ["validate_analysis.py", "--input", str(path)])
+    with pytest.raises(SystemExit) as exc:
+        va.main()
+    assert exc.value.code == 1
+    assert capsys.readouterr().out.strip()
+
+
+def test_main_file_not_found(
+    va: ModuleType,
+    mocker: MockerFixture,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    missing = tmp_path / "no_such_file.json"
+    mocker.patch.object(sys, "argv", ["validate_analysis.py", "--input", str(missing)])
+    with pytest.raises(SystemExit) as exc:
+        va.main()
+    assert exc.value.code == 1
+    assert "not found" in capsys.readouterr().out
+
+
+def test_main_bad_json(
+    va: ModuleType,
+    mocker: MockerFixture,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = tmp_path / "bad.json"
+    path.write_text("not valid json {{{")
+    mocker.patch.object(sys, "argv", ["validate_analysis.py", "--input", str(path)])
+    with pytest.raises(SystemExit) as exc:
+        va.main()
+    assert exc.value.code == 1
+    assert "JSON" in capsys.readouterr().out

--- a/tests/test_validate_analysis.py
+++ b/tests/test_validate_analysis.py
@@ -50,6 +50,7 @@ VALID_ARTIFACT: dict[str, Any] = {
         "generated_at": "2024-01-01T00:00:00+00:00",
         "git_commit": "abc1234",
         "data_source": "stooq",
+        "data_freshness": {"AAPL.US": "2024-01-01"},
         "scoring_version": "1.0.0",
         "config": {"stale_days": 5},
     },
@@ -195,6 +196,69 @@ def test_validate_empty_instruments_list(va: ModuleType) -> None:
     data = {**VALID_ARTIFACT, "instruments": []}
     errors = va.validate_artifact(data)
     assert errors == []
+
+
+# ── data_freshness validation ──────────────────────────────────────────────────
+
+
+def test_validate_data_freshness_valid(va: ModuleType) -> None:
+    data = {
+        **VALID_ARTIFACT,
+        "metadata": {
+            **VALID_ARTIFACT["metadata"],
+            "data_freshness": {"X": "2024-01-01"},
+        },
+    }
+    errors = va.validate_artifact(data)
+    assert not any("freshness" in e for e in errors)
+
+
+def test_validate_data_freshness_sentinel_valid(va: ModuleType) -> None:
+    data = {
+        **VALID_ARTIFACT,
+        "metadata": {**VALID_ARTIFACT["metadata"], "data_freshness": {"X": "n/a"}},
+    }
+    errors = va.validate_artifact(data)
+    assert not any("freshness" in e for e in errors)
+
+
+def test_validate_data_freshness_missing(va: ModuleType) -> None:
+    bad_meta = {
+        k: v for k, v in VALID_ARTIFACT["metadata"].items() if k != "data_freshness"
+    }
+    data = {**VALID_ARTIFACT, "metadata": bad_meta}
+    errors = va.validate_artifact(data)
+    assert any("data_freshness" in e for e in errors)
+
+
+def test_validate_data_freshness_not_dict(va: ModuleType) -> None:
+    data = {
+        **VALID_ARTIFACT,
+        "metadata": {**VALID_ARTIFACT["metadata"], "data_freshness": "2024-01-01"},
+    }
+    errors = va.validate_artifact(data)
+    assert any("data_freshness" in e and "object" in e for e in errors)
+
+
+def test_validate_data_freshness_invalid_value(va: ModuleType) -> None:
+    data = {
+        **VALID_ARTIFACT,
+        "metadata": {
+            **VALID_ARTIFACT["metadata"],
+            "data_freshness": {"X": "not-a-date"},
+        },
+    }
+    errors = va.validate_artifact(data)
+    assert any("data_freshness" in e for e in errors)
+
+
+def test_validate_data_freshness_non_string_value(va: ModuleType) -> None:
+    data = {
+        **VALID_ARTIFACT,
+        "metadata": {**VALID_ARTIFACT["metadata"], "data_freshness": {"X": 20240101}},
+    }
+    errors = va.validate_artifact(data)
+    assert any("data_freshness" in e for e in errors)
 
 
 # ── parse_args ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Market data abstraction (#28)**: `MarketDataProvider` ABC with `StooqProvider` (urllib-based Stooq CSV API, no auth) and `CsvFileProvider` (offline/test); `OhlcvBar` frozen dataclass with normalized schema (symbol, timestamp UTC, OHLCV, source, interval); save/load CSV roundtrip under `data/prices/`; data-quality checks: empty, stale, insufficient history, malformed OHLC, duplicate timestamps, gaps >7 days
- **Scoring engine (#29)**: Multi-horizon returns (1d/5d/20d/60d), MA distance (MA20/MA50), realized volatility, max drawdown, RSI-14, z-score-20d; cross-sectional percentile ranking; five risk gates (`stale_data`, `insufficient_history`, `missing_bars`, `malformed_input`, `high_volatility`); reliability-aware ordering — all reliable instruments rank above any unreliable instrument regardless of score; structured explanation strings per instrument
- **JSON analysis artifacts (#30)**: Versioned output (`version: "1.0.0"`) with run metadata (generated_at UTC, git_commit, data_source as sorted comma-separated string, data_freshness per symbol as YYYY-MM-DD or "n/a", scoring_version, config); instrument-level features/score/rank/risk_gates/explanation; written to `data/analysis/YYYY-MM-DD.json`; stdlib-only validator (`validate_analysis.py`) validates data_freshness structure and values
- **Tooling**: `data/schema/analysis.schema.json` reference schema; `SKILL.md` usage guide; pyproject.toml wired for coverage, ruff, and pyright on new scripts

## Review fixes (second commit)

- **Reliability-aware ranking**: sort key changed to `(not is_reliable, -score)` — reliable instruments always rank above unreliable ones; regression tests added
- **Deterministic `data_source`**: replaced `next(iter(set(...)))` with `",".join(sorted(...))` so output is stable with multiple providers; test added
- **`data_freshness` required and validated**: added to `_REQUIRED_META` in `validate_analysis.py`; validates it is a JSON object with YYYY-MM-DD or `"n/a"` string values; schema and test fixtures updated; four new validation tests added

## Test plan

- [ ] `uv run ruff check .` — no errors
- [ ] `uv run ruff format --check .` — no reformats needed
- [ ] `uv run pyright` — 0 errors, 0 warnings
- [ ] `uv run pytest` — 173 tests pass, 100% branch coverage on all four scripts
- [ ] Verify `fetch` sub-command downloads and saves OHLCV CSV for a real symbol (requires network)
- [ ] Verify `check` sub-command reports data quality on a saved file
- [ ] Verify `score` sub-command ranks symbols cross-sectionally, reliable instruments first
- [ ] Verify `generate` sub-command writes a dated JSON artifact and `validate_analysis.py` accepts it

https://claude.ai/code/session_01XuecRrtFYeUGQq9kQmHrHL