### PR TITLE
feat: implement Hugo report gen, daily workflow, Slack notify, and ops docs (#31 #32 #33 #34)

### DIFF
--- a/.agents/skills/market-analysis/SKILL.md
+++ b/.agents/skills/market-analysis/SKILL.md
@@ -23,6 +23,14 @@ Four sub-commands:
 
 Validate a generated JSON artifact against the expected schema.
 
+### `generate_report.py`
+
+Generate a Hugo Markdown report from a JSON analysis artifact and write it to `content/results/`.
+
+### `notify_slack.py`
+
+Send a Slack notification (success or failure) via an incoming webhook. Reads `SLACK_WEBHOOK_URL` from the environment; exits silently if the variable is not set.
+
 ## Usage
 
 ```sh
@@ -48,6 +56,24 @@ uv run .agents/skills/market-analysis/scripts/market_analysis.py \
 # Validate the generated artifact
 uv run .agents/skills/market-analysis/scripts/validate_analysis.py \
     --input data/analysis/$(date +%Y-%m-%d).json
+
+# Generate a Hugo Markdown report from the artifact
+uv run .agents/skills/market-analysis/scripts/generate_report.py \
+    --input data/analysis/$(date +%Y-%m-%d).json \
+    --output content/results/
+
+# Send a Slack success notification
+SLACK_WEBHOOK_URL="https://hooks.slack.com/services/..." \
+uv run .agents/skills/market-analysis/scripts/notify_slack.py \
+    --artifact data/analysis/$(date +%Y-%m-%d).json \
+    --report-url https://dceoy.github.io/aims/results/$(date +%Y-%m-%d)-market-analysis/
+
+# Send a Slack failure notification
+SLACK_WEBHOOK_URL="https://hooks.slack.com/services/..." \
+uv run .agents/skills/market-analysis/scripts/notify_slack.py \
+    --failure \
+    --run-url https://github.com/dceoy/aims/actions/runs/12345 \
+    --message "Analysis failed"
 ```
 
 ## Data layout

--- a/.agents/skills/market-analysis/scripts/generate_report.py
+++ b/.agents/skills/market-analysis/scripts/generate_report.py
@@ -55,7 +55,9 @@ def _format_pct(value: float | None) -> str:
 def _market_regime(scores: list[float]) -> str:
     if not scores:
         return "Unavailable"
-    median = sorted(scores)[len(scores) // 2]
+    s = sorted(scores)
+    n = len(s)
+    median = s[n // 2] if n % 2 == 1 else (s[n // 2 - 1] + s[n // 2]) / 2
     if median >= 65.0:
         return "Bullish"
     if median <= 40.0:

--- a/.agents/skills/market-analysis/scripts/generate_report.py
+++ b/.agents/skills/market-analysis/scripts/generate_report.py
@@ -37,6 +37,7 @@ _GATE_DESCRIPTIONS: Final[dict[str, str]] = {
     "high_volatility": (
         "High volatility: one or more instruments show extreme volatility."
     ),
+    "missing_data": "Missing data: no price history available for this instrument.",
 }
 
 
@@ -255,6 +256,26 @@ def _section_disclaimer() -> str:
     return f"## Disclaimer\n\n> {_DISCLAIMER}"
 
 
+def _validate_for_report(artifact: dict[str, Any]) -> None:
+    meta = artifact.get("metadata")
+    if not isinstance(meta, dict):
+        msg = "artifact is missing a valid 'metadata' section"
+        raise ValueError(msg)  # noqa: TRY004
+    generated_at = meta.get("generated_at")
+    if not isinstance(generated_at, str) or not generated_at:
+        msg = "artifact 'generated_at' is missing or not a string"
+        raise ValueError(msg)
+    if generated_at.startswith("1970-01-01"):
+        msg = (
+            f"'generated_at' is the epoch sentinel;"
+            f" artifact is not publishable: {generated_at!r}"
+        )
+        raise ValueError(msg)
+    if "instruments" not in artifact:
+        msg = "artifact is missing the 'instruments' key"
+        raise ValueError(msg)
+
+
 def generate_report(artifact: dict[str, Any]) -> str:
     meta = artifact.get("metadata", {})
     generated_at = meta.get("generated_at", "")
@@ -312,6 +333,7 @@ def generate_and_save(
 ) -> Path:
     with artifact_path.open(encoding="utf-8") as fh:
         artifact: dict[str, Any] = json.load(fh)
+    _validate_for_report(artifact)
     content = generate_report(artifact)
     filename = report_filename(artifact)
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -347,6 +369,9 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     except json.JSONDecodeError as exc:
         print(f"ERROR: invalid JSON in {args.input}: {exc}")
+        return 1
+    except ValueError as exc:
+        print(f"ERROR: artifact validation failed: {exc}")
         return 1
     return 0
 

--- a/.agents/skills/market-analysis/scripts/generate_report.py
+++ b/.agents/skills/market-analysis/scripts/generate_report.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+r"""Generate a Hugo Markdown report from an AIMS analysis artifact.
+
+Usage:
+    uv run .agents/skills/market-analysis/scripts/generate_report.py \
+        --input data/analysis/2024-01-01.json \
+        --output content/results/
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Final
+
+_DEFAULT_OUTPUT_DIR: Final[Path] = Path("content/results")
+
+_DISCLAIMER: Final[str] = (
+    "This report is generated automatically from publicly available market data"
+    " for informational purposes only. It does not constitute investment advice,"
+    " a solicitation, or a recommendation to buy or sell any financial instrument."
+    " Past performance is not indicative of future results. Always consult a"
+    " qualified financial adviser before making investment decisions."
+)
+
+_GATE_DESCRIPTIONS: Final[dict[str, str]] = {
+    "stale_data": (
+        "Stale data: one or more instruments have data older than the threshold."
+    ),
+    "insufficient_history": (
+        "Insufficient history: some instruments lack enough historical data for"
+        " reliable scoring."
+    ),
+    "missing_bars": "Missing bars: data gaps detected in price history.",
+    "malformed_input": "Malformed input: price data quality issues detected.",
+    "high_volatility": (
+        "High volatility: one or more instruments show extreme volatility."
+    ),
+}
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _format_pct(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    sign = "+" if value >= 0 else ""
+    return f"{sign}{value * 100:.1f}%"
+
+
+def _market_regime(scores: list[float]) -> str:
+    if not scores:
+        return "Unavailable"
+    median = sorted(scores)[len(scores) // 2]
+    if median >= 65.0:
+        return "Bullish"
+    if median <= 40.0:
+        return "Bearish"
+    return "Neutral"
+
+
+def _build_front_matter(artifact: dict[str, Any], date_str: str) -> str:
+    meta = artifact.get("metadata", {})
+    generated_at = meta.get("generated_at", "1970-01-01T00:00:00+00:00")
+    if not isinstance(generated_at, str):
+        generated_at = "1970-01-01T00:00:00+00:00"
+
+    data_source = str(meta.get("data_source", ""))
+    scoring_version = str(meta.get("scoring_version", ""))
+    git_commit = str(meta.get("git_commit", ""))
+
+    instruments = artifact.get("instruments", [])
+    reliable = [i for i in instruments if i.get("is_reliable")]
+    reliable_scores = [float(i["score"]) for i in reliable if "score" in i]
+    regime = _market_regime(reliable_scores)
+    n_reliable = len(reliable)
+    total = len(instruments)
+
+    all_symbols = sorted(str(i.get("symbol", "")) for i in instruments)
+    symbols_toml = ", ".join(f'"{_toml_escape(s)}"' for s in all_symbols)
+
+    source_file = f"data/analysis/{date_str}.json"
+
+    if reliable:
+        top = max(reliable, key=lambda i: float(i.get("score", 0)))
+        top_symbol = _toml_escape(str(top.get("symbol", "")))
+        top_score = float(top.get("score", 0))
+        summary = (
+            f"{regime} market: {n_reliable} reliable instruments."
+            f" Top signal: {top_symbol} (score {top_score:.1f})."
+        )
+    else:
+        summary = "No reliable instruments."
+
+    lines = [
+        "+++",
+        f'title = "Market Analysis {date_str}"',
+        f'date = "{_toml_escape(generated_at)}"',
+        "draft = false",
+        f'summary = "{_toml_escape(summary)}"',
+        f"ticker_symbols = [{symbols_toml}]",
+        f'source_files = ["{_toml_escape(source_file)}"]',
+        f'market_regime = "{_toml_escape(regime)}"',
+        f'data_source = "{_toml_escape(data_source)}"',
+        f'scoring_version = "{_toml_escape(scoring_version)}"',
+        f'git_commit = "{_toml_escape(git_commit)}"',
+        "+++",
+    ]
+    _ = total  # referenced in body, not front matter
+    return "\n".join(lines)
+
+
+def _section_market_regime(
+    regime: str,
+    n_reliable: int,
+    total: int,
+) -> str:
+    return (
+        f"## Market Regime\n\n**{regime}** — based on cross-sectional momentum"
+        f" scores of {n_reliable} reliable instrument(s) out of {total} total."
+    )
+
+
+def _section_top_opportunities(reliable: list[dict[str, Any]]) -> str:
+    header = "## Top Opportunities"
+    top5 = sorted(reliable, key=lambda i: float(i.get("score", 0)), reverse=True)[:5]
+    if not top5:
+        return f"{header}\n\n_No reliable instruments available._"
+    lines = []
+    for inst in top5:
+        symbol = str(inst.get("symbol", ""))
+        score = float(inst.get("score", 0))
+        features = inst.get("features") or {}
+        ret_20d = features.get("ret_20d")
+        rsi_raw = features.get("rsi_14")
+        rsi_str = f"{rsi_raw:.0f}" if isinstance(rsi_raw, (int, float)) else "n/a"
+        explanation = str(inst.get("explanation", ""))
+        lines.append(
+            f"- **{symbol}** — score {score:.1f},"
+            f" 20d return {_format_pct(ret_20d)},"
+            f" RSI14={rsi_str}. {explanation}"
+        )
+    return f"{header}\n\n" + "\n".join(lines)
+
+
+def _section_instruments_to_avoid(unreliable: list[dict[str, Any]]) -> str:
+    header = "## Instruments to Avoid"
+    if not unreliable:
+        return f"{header}\n\n_All instruments passed quality checks._"
+    preamble = (
+        "These instruments have quality or risk issues and are excluded from ranking:"
+    )
+    lines = []
+    for inst in unreliable:
+        symbol = str(inst.get("symbol", ""))
+        gates = inst.get("risk_gates") or []
+        gates_str = ", ".join(str(g) for g in gates)
+        lines.append(f"- **{symbol}** — {gates_str}")
+    return f"{header}\n\n{preamble}\n\n" + "\n".join(lines)
+
+
+def _section_key_risks(instruments: list[dict[str, Any]]) -> str:
+    header = "## Key Risks"
+    gate_counts: dict[str, int] = {}
+    for inst in instruments:
+        for gate in inst.get("risk_gates") or []:
+            gate_str = str(gate)
+            gate_counts[gate_str] = gate_counts.get(gate_str, 0) + 1
+    if not gate_counts:
+        return f"{header}\n\n_No risk gates triggered._"
+    lines = []
+    for gate in sorted(gate_counts):
+        count = gate_counts[gate]
+        desc = _GATE_DESCRIPTIONS.get(gate, gate)
+        lines.append(f"- **{gate}** ({count} instrument(s)): {desc}")
+    return f"{header}\n\n" + "\n".join(lines)
+
+
+def _section_instrument_scores(instruments: list[dict[str, Any]]) -> str:
+    header = "## Instrument Scores"
+    col_header = "| Rank | Symbol | Score | Reliable | Risk Gates | Explanation |"
+    col_sep = "| ---: | ------ | ----: | :------: | ---------- | ----------- |"
+    rows = [col_header, col_sep]
+    for inst in instruments:
+        rank = inst.get("rank", "")
+        symbol = str(inst.get("symbol", ""))
+        score = float(inst.get("score", 0))
+        reliable = "Yes" if inst.get("is_reliable") else "No"
+        gates = inst.get("risk_gates") or []
+        gates_str = ", ".join(str(g) for g in gates) if gates else "—"
+        explanation = str(inst.get("explanation", ""))
+        rows.append(
+            f"| {rank} | {symbol} | {score:.1f} | {reliable} |"
+            f" {gates_str} | {explanation} |"
+        )
+    return f"{header}\n\n" + "\n".join(rows)
+
+
+def _section_data_freshness(
+    data_source: str,
+    freshness: dict[str, str],
+) -> str:
+    header = "## Data Freshness"
+    parts: list[str] = [f"Data source: **{data_source}**"]
+
+    if freshness:
+        table_rows = ["| Symbol | Latest Bar |", "| ------ | ---------- |"]
+        stale_symbols = []
+        for sym in sorted(freshness):
+            val = freshness[sym]
+            table_rows.append(f"| {sym} | {val} |")
+            if val == "n/a":
+                stale_symbols.append(sym)
+        parts.append("\n".join(table_rows))
+        if stale_symbols:
+            stale_joined = ", ".join(sorted(stale_symbols))
+            n = len(stale_symbols)
+            parts.append(
+                f"> **Warning:** {n} instrument(s) have no data: {stale_joined}."
+            )
+    else:
+        parts.append("_No freshness data available._")
+
+    return f"{header}\n\n" + "\n\n".join(parts)
+
+
+def _section_methodology(scoring_version: str, git_commit: str) -> str:
+    header = "## Methodology"
+    feature_list = (
+        "Instruments are scored and ranked cross-sectionally using the following"
+        " features:\n\n"
+        "- **Momentum**: 1-day, 5-day, 20-day, and 60-day returns\n"
+        "- **Trend**: Distance from 20-day and 50-day moving averages\n"
+        "- **Volatility**: 20-day realized annualized volatility (lower is better)\n"
+        "- **Drawdown**: Maximum drawdown over 60 days (lower is better)\n"
+        "- **RSI**: 14-day Relative Strength Index\n"
+        "- **Z-score**: Price z-score relative to 20-day mean"
+    )
+    percentile_note = (
+        "Each feature is converted to a cross-sectional percentile rank."
+        " The composite score is the mean percentile across all features (0–100)."  # noqa: RUF001
+    )
+    version_line = (
+        f"Scoring engine version: **{scoring_version}** | Git commit: **{git_commit}**"
+    )
+    ops_ref = "For methodology details, see OPERATIONS.md in the repository root."
+    content = f"{feature_list}\n\n{percentile_note}\n\n{version_line}\n\n{ops_ref}"
+    return f"{header}\n\n{content}"
+
+
+def _section_disclaimer() -> str:
+    return f"## Disclaimer\n\n> {_DISCLAIMER}"
+
+
+def generate_report(artifact: dict[str, Any]) -> str:
+    meta = artifact.get("metadata", {})
+    generated_at = meta.get("generated_at", "")
+    if not isinstance(generated_at, str) or not generated_at:
+        generated_at = "1970-01-01T00:00:00+00:00"
+    date_str = generated_at[:10]
+
+    data_source = str(meta.get("data_source", ""))
+    scoring_version = str(meta.get("scoring_version", ""))
+    git_commit = str(meta.get("git_commit", ""))
+    freshness_raw = meta.get("data_freshness", {})
+    freshness: dict[str, str] = (
+        {str(k): str(v) for k, v in freshness_raw.items()}
+        if isinstance(freshness_raw, dict)
+        else {}
+    )
+
+    instruments = artifact.get("instruments", [])
+    reliable = [i for i in instruments if i.get("is_reliable")]
+    unreliable = [i for i in instruments if not i.get("is_reliable")]
+    reliable_scores = [float(i["score"]) for i in reliable if "score" in i]
+    regime = _market_regime(reliable_scores)
+    n_reliable = len(reliable)
+    total = len(instruments)
+
+    front_matter = _build_front_matter(artifact, date_str)
+
+    sections = [
+        _section_market_regime(regime, n_reliable, total),
+        _section_top_opportunities(reliable),
+        _section_instruments_to_avoid(unreliable),
+        _section_key_risks(instruments),
+        _section_instrument_scores(instruments),
+        _section_data_freshness(data_source, freshness),
+        _section_methodology(scoring_version, git_commit),
+        _section_disclaimer(),
+    ]
+    body = "\n\n".join(sections)
+    return f"{front_matter}\n\n{body}\n"
+
+
+def report_filename(artifact: dict[str, Any]) -> str:
+    meta = artifact.get("metadata", {})
+    generated_at = meta.get("generated_at", "")
+    if not isinstance(generated_at, str) or not generated_at:
+        date_str = "1970-01-01"
+    else:
+        date_str = generated_at[:10]
+    return f"{date_str}-market-analysis.md"
+
+
+def generate_and_save(
+    artifact_path: Path,
+    output_dir: Path = _DEFAULT_OUTPUT_DIR,
+) -> Path:
+    with artifact_path.open(encoding="utf-8") as fh:
+        artifact: dict[str, Any] = json.load(fh)
+    content = generate_report(artifact)
+    filename = report_filename(artifact)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / filename
+    output_path.write_text(content, encoding="utf-8")
+    print(f"Report written to {output_path}")
+    return output_path
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input",
+        type=Path,
+        required=True,
+        help="Path to analysis artifact JSON file",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=_DEFAULT_OUTPUT_DIR,
+        help=f"Output directory (default: {_DEFAULT_OUTPUT_DIR})",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        generate_and_save(args.input, args.output)
+    except FileNotFoundError:
+        print(f"ERROR: file not found: {args.input}")
+        return 1
+    except json.JSONDecodeError as exc:
+        print(f"ERROR: invalid JSON in {args.input}: {exc}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/market-analysis/scripts/market_analysis.py
+++ b/.agents/skills/market-analysis/scripts/market_analysis.py
@@ -48,6 +48,7 @@ RISK_GATE_HIGH_VOL: Final[str] = "high_volatility"
 RISK_GATE_INSUFFICIENT: Final[str] = "insufficient_history"
 RISK_GATE_MISSING_BARS: Final[str] = "missing_bars"
 RISK_GATE_MALFORMED: Final[str] = "malformed_input"
+RISK_GATE_MISSING_DATA: Final[str] = "missing_data"
 
 _OHLCV_FIELDS: Final[tuple[str, ...]] = (
     "symbol",
@@ -607,14 +608,22 @@ def generate_artifact(
     scores: list[InstrumentScore],
     data: dict[str, list[OhlcvBar]],
     config: dict[str, Any],
+    *,
+    analysis_date: str | None = None,
+    missing_symbols: list[str] | None = None,
 ) -> dict[str, Any]:
     now = datetime.now(tz=UTC)
+    generated_at = (
+        f"{analysis_date}T00:00:00+00:00" if analysis_date else now.isoformat()
+    )
     sources = sorted({b.source for bars in data.values() for b in bars})
     data_source = ",".join(sources) if sources else "unknown"
-    freshness = {
+    freshness: dict[str, str] = {
         symbol: bars[-1].timestamp.date().isoformat() if bars else "n/a"
         for symbol, bars in data.items()
     }
+    for sym in sorted(missing_symbols or []):
+        freshness[sym] = "n/a"
     instruments: list[dict[str, Any]] = [
         {
             "symbol": s.symbol,
@@ -627,10 +636,34 @@ def generate_artifact(
         }
         for s in scores
     ]
+    empty_feats = InstrumentFeatures(
+        ret_1d=None,
+        ret_5d=None,
+        ret_20d=None,
+        ret_60d=None,
+        ma20_dist=None,
+        ma50_dist=None,
+        vol_20d=None,
+        mdd_60d=None,
+        rsi_14=None,
+        zscore_20d=None,
+    )
+    next_rank = max((s.rank for s in scores), default=0) + 1
+    for sym in sorted(missing_symbols or []):
+        instruments.append({
+            "symbol": sym,
+            "rank": next_rank,
+            "score": 0.0,
+            "is_reliable": False,
+            "risk_gates": [RISK_GATE_MISSING_DATA],
+            "explanation": f"Suppressed: {RISK_GATE_MISSING_DATA}",
+            "features": _features_to_dict(empty_feats),
+        })
+        next_rank += 1
     return {
         "version": ARTIFACT_VERSION,
         "metadata": {
-            "generated_at": now.isoformat(),
+            "generated_at": generated_at,
             "git_commit": _get_git_commit(),
             "data_source": data_source,
             "data_freshness": freshness,
@@ -650,7 +683,7 @@ def save_artifact(
     date_str = gen_at[:10] if gen_at else datetime.now(tz=UTC).date().isoformat()
     output_dir.mkdir(parents=True, exist_ok=True)
     path = output_dir / f"{date_str}.json"
-    with path.open("w") as fh:
+    with path.open("w", encoding="utf-8") as fh:
         json.dump(artifact, fh, indent=2)
     return path
 
@@ -718,11 +751,13 @@ def _cmd_score(args: argparse.Namespace) -> int:
 def _cmd_generate(args: argparse.Namespace) -> int:
     symbols = [s.strip() for s in args.symbols.split(",") if s.strip()]
     data: dict[str, list[OhlcvBar]] = {}
+    missing: list[str] = []
     for sym in symbols:
         try:
             data[sym] = load_ohlcv(sym, args.interval, Path(args.data_dir))
         except FileNotFoundError:
-            print(f"WARNING: no data for {sym}, skipping")
+            print(f"WARNING: no data for {sym}, marking as missing")
+            missing.append(sym)
     if not data:
         print("ERROR: no symbols could be loaded")
         return 1
@@ -732,9 +767,19 @@ def _cmd_generate(args: argparse.Namespace) -> int:
         "interval": args.interval,
     }
     results = score_instruments(data)
-    artifact = generate_artifact(results, data, config)
+    analysis_date: str | None = getattr(args, "analysis_date", None) or None
+    artifact = generate_artifact(
+        results,
+        data,
+        config,
+        analysis_date=analysis_date,
+        missing_symbols=missing or None,
+    )
     path = save_artifact(artifact, Path(args.output))
     print(f"artifact saved to {path}")
+    if missing:
+        syms = ", ".join(sorted(missing))
+        print(f"WARNING: {len(missing)} symbol(s) had no data: {syms}")
     return 0
 
 
@@ -769,6 +814,12 @@ def main(argv: list[str] | None = None) -> int:
     p_gen.add_argument("--interval", default=_DEFAULT_INTERVAL)
     p_gen.add_argument("--data-dir", default=str(_DEFAULT_PRICES_DIR), dest="data_dir")
     p_gen.add_argument("--output", default=str(_DEFAULT_ANALYSIS_DIR))
+    p_gen.add_argument(
+        "--analysis-date",
+        default=None,
+        dest="analysis_date",
+        help="Override analysis date (YYYY-MM-DD; default: today UTC)",
+    )
 
     args = parser.parse_args(argv)
 

--- a/.agents/skills/market-analysis/scripts/market_analysis.py
+++ b/.agents/skills/market-analysis/scripts/market_analysis.py
@@ -766,8 +766,13 @@ def _cmd_generate(args: argparse.Namespace) -> int:
         "min_history": _MIN_HISTORY,
         "interval": args.interval,
     }
-    results = score_instruments(data)
     analysis_date: str | None = getattr(args, "analysis_date", None) or None
+    reference_time: datetime | None = None
+    if analysis_date:
+        reference_time = datetime.strptime(analysis_date, "%Y-%m-%d").replace(
+            tzinfo=UTC
+        )
+    results = score_instruments(data, reference_time=reference_time)
     artifact = generate_artifact(
         results,
         data,

--- a/.agents/skills/market-analysis/scripts/notify_slack.py
+++ b/.agents/skills/market-analysis/scripts/notify_slack.py
@@ -32,7 +32,9 @@ _TIMEOUT: Final[int] = 15
 def _market_regime(scores: list[float]) -> str:
     if not scores:
         return "Unavailable"
-    median = sorted(scores)[len(scores) // 2]
+    s = sorted(scores)
+    n = len(s)
+    median = s[n // 2] if n % 2 == 1 else (s[n // 2 - 1] + s[n // 2]) / 2
     if median >= 65.0:
         return "Bullish"
     if median <= 40.0:
@@ -40,7 +42,12 @@ def _market_regime(scores: list[float]) -> str:
     return "Neutral"
 
 
-def build_success_payload(artifact: dict[str, Any], report_url: str) -> dict[str, Any]:
+def build_success_payload(
+    artifact: dict[str, Any],
+    report_url: str = "",
+    *,
+    pr_url: str | None = None,
+) -> dict[str, Any]:
     meta = artifact.get("metadata", {})
     generated_at = meta.get("generated_at", "")
     date_str = generated_at[:10] if isinstance(generated_at, str) else "n/a"
@@ -79,7 +86,18 @@ def build_success_payload(artifact: dict[str, Any], report_url: str) -> dict[str
             "text": f"*⚠️ No data:* {', '.join(stale)}",
         })
 
-    text = f"AIMS Market Analysis {date_str}: {regime} market."
+    if pr_url is not None:
+        text = f"AIMS Market Analysis {date_str}: {regime} market. Analysis PR created."
+        button_text = "View PR"
+        button_url = pr_url
+    elif report_url:
+        text = f"AIMS Market Analysis {date_str}: {regime} market."
+        button_text = "View Report"
+        button_url = report_url
+    else:
+        text = f"AIMS Market Analysis {date_str}: {regime} market."
+        button_text = None
+        button_url = None
 
     blocks: list[dict[str, Any]] = [
         {
@@ -87,18 +105,19 @@ def build_success_payload(artifact: dict[str, Any], report_url: str) -> dict[str
             "text": {"type": "plain_text", "text": "📊 AIMS Market Analysis"},
         },
         {"type": "section", "fields": fields},
-        {
+    ]
+    if button_url is not None:
+        blocks.append({
             "type": "actions",
             "elements": [
                 {
                     "type": "button",
-                    "text": {"type": "plain_text", "text": "View Report"},
-                    "url": report_url,
+                    "text": {"type": "plain_text", "text": button_text},
+                    "url": button_url,
                     "style": "primary",
                 }
             ],
-        },
-    ]
+        })
 
     return {"text": text, "blocks": blocks}
 
@@ -175,6 +194,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default="Daily market analysis failed",
         help="Failure message (used in failure mode)",
     )
+    parser.add_argument(
+        "--pr-url",
+        type=str,
+        default=None,
+        help="URL to the analysis pull request (used in success mode)",
+    )
     return parser.parse_args(argv)
 
 
@@ -202,7 +227,9 @@ def main(argv: list[str] | None = None) -> int:
             print(f"ERROR: invalid JSON in {args.artifact}: {exc}")
             return 1
         report_url = args.report_url or ""
-        payload = build_success_payload(artifact, report_url)
+        payload = build_success_payload(
+            artifact, report_url, pr_url=args.pr_url or None
+        )
 
     try:
         send_notification(webhook_url, payload)

--- a/.agents/skills/market-analysis/scripts/notify_slack.py
+++ b/.agents/skills/market-analysis/scripts/notify_slack.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+r"""Send Slack notifications for AIMS pipeline results via incoming webhook.
+
+Usage:
+    # Success
+    uv run .agents/skills/market-analysis/scripts/notify_slack.py \
+        --artifact data/analysis/2024-01-01.json \
+        --report-url https://dceoy.github.io/aims/results/2024-01-01-market-analysis/
+
+    # Failure
+    uv run .agents/skills/market-analysis/scripts/notify_slack.py \
+        --failure \
+        --run-url https://github.com/dceoy/aims/actions/runs/12345 \
+        --message "Daily analysis failed"
+
+Reads SLACK_WEBHOOK_URL from the environment.
+If SLACK_WEBHOOK_URL is not set, prints a warning and exits 0 (no-op).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import urllib.error
+import urllib.request
+from typing import Any, Final
+
+_TIMEOUT: Final[int] = 15
+
+
+def _market_regime(scores: list[float]) -> str:
+    if not scores:
+        return "Unavailable"
+    median = sorted(scores)[len(scores) // 2]
+    if median >= 65.0:
+        return "Bullish"
+    if median <= 40.0:
+        return "Bearish"
+    return "Neutral"
+
+
+def build_success_payload(artifact: dict[str, Any], report_url: str) -> dict[str, Any]:
+    meta = artifact.get("metadata", {})
+    generated_at = meta.get("generated_at", "")
+    date_str = generated_at[:10] if isinstance(generated_at, str) else "n/a"
+    data_source = str(meta.get("data_source", ""))
+
+    instruments = artifact.get("instruments", [])
+    reliable = [i for i in instruments if i.get("is_reliable")]
+    reliable_scores = [float(i["score"]) for i in reliable if "score" in i]
+    regime = _market_regime(reliable_scores)
+
+    top3 = sorted(reliable, key=lambda i: float(i.get("score", 0)), reverse=True)[:3]
+    signals = ", ".join(
+        f"{i.get('symbol', '')} ({float(i.get('score', 0)):.1f})" for i in top3
+    )
+
+    freshness_raw = meta.get("data_freshness", {})
+    freshness: dict[str, str] = (
+        {str(k): str(v) for k, v in freshness_raw.items()}
+        if isinstance(freshness_raw, dict)
+        else {}
+    )
+    stale = sorted(sym for sym, val in freshness.items() if val == "n/a")
+
+    regime_emoji = {"Bullish": "📈", "Bearish": "📉", "Neutral": "➡️"}.get(regime, "❓")
+
+    fields: list[dict[str, str]] = [
+        {"type": "mrkdwn", "text": f"*Date:* {date_str}"},
+        {"type": "mrkdwn", "text": f"*Source:* {data_source}"},
+        {"type": "mrkdwn", "text": f"*Regime:* {regime_emoji} {regime}"},
+    ]
+    if signals:
+        fields.append({"type": "mrkdwn", "text": f"*Top signals:* {signals}"})
+    if stale:
+        fields.append({
+            "type": "mrkdwn",
+            "text": f"*⚠️ No data:* {', '.join(stale)}",
+        })
+
+    text = f"AIMS Market Analysis {date_str}: {regime} market."
+
+    blocks: list[dict[str, Any]] = [
+        {
+            "type": "header",
+            "text": {"type": "plain_text", "text": "📊 AIMS Market Analysis"},
+        },
+        {"type": "section", "fields": fields},
+        {
+            "type": "actions",
+            "elements": [
+                {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": "View Report"},
+                    "url": report_url,
+                    "style": "primary",
+                }
+            ],
+        },
+    ]
+
+    return {"text": text, "blocks": blocks}
+
+
+def build_failure_payload(
+    run_url: str,
+    message: str = "Daily market analysis failed",
+) -> dict[str, Any]:
+    text = f"❌ {message}"
+    blocks: list[dict[str, Any]] = [
+        {
+            "type": "header",
+            "text": {"type": "plain_text", "text": "❌ AIMS Pipeline Failure"},
+        },
+        {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": f"*{message}*"},
+        },
+        {
+            "type": "actions",
+            "elements": [
+                {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": "View Run"},
+                    "url": run_url,
+                    "style": "danger",
+                }
+            ],
+        },
+    ]
+    return {"text": text, "blocks": blocks}
+
+
+def send_notification(webhook_url: str, payload: dict[str, Any]) -> None:
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        webhook_url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=_TIMEOUT) as _resp:
+        pass
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--failure",
+        action="store_true",
+        help="Send a failure notification instead of a success notification",
+    )
+    parser.add_argument(
+        "--artifact",
+        type=str,
+        default=None,
+        help="Path to analysis artifact JSON (required in success mode)",
+    )
+    parser.add_argument(
+        "--report-url",
+        type=str,
+        default=None,
+        help="URL to the generated Hugo report page",
+    )
+    parser.add_argument(
+        "--run-url",
+        type=str,
+        default=None,
+        help="URL to the GitHub Actions run (used in failure mode)",
+    )
+    parser.add_argument(
+        "--message",
+        type=str,
+        default="Daily market analysis failed",
+        help="Failure message (used in failure mode)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    webhook_url = os.environ.get("SLACK_WEBHOOK_URL", "")
+    if not webhook_url:
+        print("WARNING: SLACK_WEBHOOK_URL not set; skipping notification.")
+        return 0
+
+    if args.failure:
+        run_url = args.run_url or ""
+        payload = build_failure_payload(run_url, args.message)
+    else:
+        if not args.artifact:
+            print("ERROR: --artifact is required in success mode.")
+            return 1
+        try:
+            with open(args.artifact, encoding="utf-8") as fh:  # noqa: PTH123
+                artifact: dict[str, Any] = json.load(fh)
+        except FileNotFoundError:
+            print(f"ERROR: artifact file not found: {args.artifact}")
+            return 1
+        except json.JSONDecodeError as exc:
+            print(f"ERROR: invalid JSON in {args.artifact}: {exc}")
+            return 1
+        report_url = args.report_url or ""
+        payload = build_success_payload(artifact, report_url)
+
+    try:
+        send_notification(webhook_url, payload)
+    except urllib.error.URLError as exc:
+        print(f"ERROR: failed to send Slack notification: {exc}")
+        return 1
+    print("Slack notification sent.")
+    return 0
+
+
+SAMPLE_SUCCESS_PAYLOAD: dict[str, Any] = {
+    "text": "AIMS Market Analysis 2024-01-01: Bullish market.",
+    "blocks": [
+        {
+            "type": "header",
+            "text": {"type": "plain_text", "text": "📊 AIMS Market Analysis"},
+        },
+        {
+            "type": "section",
+            "fields": [
+                {"type": "mrkdwn", "text": "*Date:* 2024-01-01"},
+                {"type": "mrkdwn", "text": "*Source:* stooq"},
+                {"type": "mrkdwn", "text": "*Regime:* 📈 Bullish"},
+                {"type": "mrkdwn", "text": "*Top signals:* ^SPX (72.5)"},
+            ],
+        },
+        {
+            "type": "actions",
+            "elements": [
+                {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": "View Report"},
+                    "url": "https://dceoy.github.io/aims/results/2024-01-01-market-analysis/",
+                    "style": "primary",
+                }
+            ],
+        },
+    ],
+}
+
+SAMPLE_FAILURE_PAYLOAD: dict[str, Any] = {
+    "text": "❌ Daily market analysis failed",
+    "blocks": [
+        {
+            "type": "header",
+            "text": {"type": "plain_text", "text": "❌ AIMS Pipeline Failure"},
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "*Daily market analysis failed*",
+            },
+        },
+        {
+            "type": "actions",
+            "elements": [
+                {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": "View Run"},
+                    "url": "https://github.com/dceoy/aims/actions/runs/12345",
+                    "style": "danger",
+                }
+            ],
+        },
+    ],
+}
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/daily-market-analysis.yml
+++ b/.github/workflows/daily-market-analysis.yml
@@ -4,25 +4,6 @@ on:
   schedule:
     - cron: "0 1 * * *"
   workflow_dispatch:
-    inputs:
-      analysis_date:
-        description: "Analysis date (YYYY-MM-DD, default: today UTC)"
-        required: false
-        type: string
-      interval:
-        description: "Price bar interval"
-        required: false
-        default: d
-        type: choice
-        options:
-          - d
-          - w
-          - m
-      dry_run:
-        description: "Skip commit and Slack notification"
-        required: false
-        default: "false"
-        type: boolean
 permissions:
   contents: read
 jobs:
@@ -30,10 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    env:
-      ANALYSIS_DATE: ${{ inputs.analysis_date || '' }}
-      INTERVAL: ${{ inputs.interval || 'd' }}
-      DRY_RUN: ${{ inputs.dry_run || 'false' }}
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4  # zizmor: ignore[unpinned-uses]
       - uses: astral-sh/setup-uv@v5  # zizmor: ignore[unpinned-uses]
@@ -49,12 +27,7 @@ jobs:
             --schema data/schema/cfd_instruments.schema.json
       - name: Set analysis date
         id: date
-        run: |
-          if [ -n "$ANALYSIS_DATE" ]; then
-            echo "date=$ANALYSIS_DATE" >> "$GITHUB_OUTPUT"
-          else
-            echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
-          fi
+        run: echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
       - name: Load symbols
         id: symbols
         run: |
@@ -81,8 +54,7 @@ jobs:
           for SYM in "${SYMS[@]}"; do
             uv run python .agents/skills/market-analysis/scripts/market_analysis.py \
               fetch --symbol "$SYM" --start "$START" --end "$DATE" \
-              --interval "$INTERVAL" \
-              || echo "WARNING: fetch failed for $SYM, continuing"
+              --interval d
           done
       - name: Generate analysis artifact
         if: steps.symbols.outputs.symbols != ''
@@ -90,7 +62,8 @@ jobs:
           uv run python .agents/skills/market-analysis/scripts/market_analysis.py \
             generate \
             --symbols "${{ steps.symbols.outputs.symbols }}" \
-            --interval "$INTERVAL" \
+            --interval d \
+            --analysis-date "${{ steps.date.outputs.date }}" \
             --output data/analysis/
       - name: Validate artifact
         if: steps.symbols.outputs.symbols != ''
@@ -113,20 +86,35 @@ jobs:
           extended: true
       - name: Build Hugo site (validation)
         run: hugo --gc --minify
-      - name: Commit generated artifacts
-        if: env.DRY_RUN != 'true' && steps.symbols.outputs.symbols != ''
+      - name: Create pull request
+        if: steps.symbols.outputs.symbols != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          BRANCH="generated/analysis-${{ steps.date.outputs.date }}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin "$BRANCH" 2>/dev/null || true
+          git checkout -B "$BRANCH"
           git add data/analysis/ content/results/
           if git diff --cached --quiet; then
             echo "No changes to commit."
           else
             git commit -m "feat(analysis): daily market analysis ${{ steps.date.outputs.date }}"
-            git push
+            git push --force-with-lease -u origin "$BRANCH"
+            PR_NUMBER="$(gh pr list --head "$BRANCH" --json number --jq '.[0].number // empty')"
+            if [ -n "$PR_NUMBER" ]; then
+              echo "PR #$PR_NUMBER already exists for $BRANCH; branch updated."
+            else
+              gh pr create \
+                --title "feat(analysis): daily market analysis ${{ steps.date.outputs.date }}" \
+                --body "Automated daily market analysis for ${{ steps.date.outputs.date }}." \
+                --base main \
+                --head "$BRANCH"
+            fi
           fi
       - name: Notify Slack (success)
-        if: env.DRY_RUN != 'true' && steps.symbols.outputs.symbols != ''
+        if: steps.symbols.outputs.symbols != ''
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |

--- a/.github/workflows/daily-market-analysis.yml
+++ b/.github/workflows/daily-market-analysis.yml
@@ -83,7 +83,8 @@ jobs:
           for SYM in "${SYMS[@]}"; do
             uv run python .agents/skills/market-analysis/scripts/market_analysis.py \
               fetch --symbol "$SYM" --start "$START" --end "$DATE" \
-              --interval "$INTERVAL"
+              --interval "$INTERVAL" \
+              || echo "WARNING: fetch failed for $SYM; symbol will be marked missing in artifact"
           done
       - name: Generate analysis artifact
         if: steps.symbols.outputs.symbols != ''

--- a/.github/workflows/daily-market-analysis.yml
+++ b/.github/workflows/daily-market-analysis.yml
@@ -1,9 +1,29 @@
 ---
 name: Daily market analysis
+# checkov:skip=CKV_GHA_7: inputs are analysis params (date/interval/dry_run) for authorised manual backfills
 on:
   schedule:
     - cron: "0 1 * * *"
   workflow_dispatch:
+    inputs:
+      analysis_date:
+        description: "Analysis date (YYYY-MM-DD; default: today UTC)"
+        required: false
+        type: string
+      interval:
+        description: "Price bar interval (d/w/m)"
+        required: false
+        default: d
+        type: choice
+        options:
+          - d
+          - w
+          - m
+      dry_run:
+        description: "Skip PR creation and Slack success notification"
+        required: false
+        default: "false"
+        type: boolean
 permissions:
   contents: read
 jobs:
@@ -12,6 +32,10 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    env:
+      ANALYSIS_DATE: ${{ inputs.analysis_date || '' }}
+      INTERVAL: ${{ inputs.interval || 'd' }}
+      DRY_RUN: ${{ inputs.dry_run || 'false' }}
     steps:
       - uses: actions/checkout@v4  # zizmor: ignore[unpinned-uses]
       - uses: astral-sh/setup-uv@v5  # zizmor: ignore[unpinned-uses]
@@ -27,7 +51,12 @@ jobs:
             --schema data/schema/cfd_instruments.schema.json
       - name: Set analysis date
         id: date
-        run: echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+        run: |
+          if [ -n "$ANALYSIS_DATE" ]; then
+            echo "date=$ANALYSIS_DATE" >> "$GITHUB_OUTPUT"
+          else
+            echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+          fi
       - name: Load symbols
         id: symbols
         run: |
@@ -54,7 +83,7 @@ jobs:
           for SYM in "${SYMS[@]}"; do
             uv run python .agents/skills/market-analysis/scripts/market_analysis.py \
               fetch --symbol "$SYM" --start "$START" --end "$DATE" \
-              --interval d
+              --interval "$INTERVAL"
           done
       - name: Generate analysis artifact
         if: steps.symbols.outputs.symbols != ''
@@ -62,7 +91,7 @@ jobs:
           uv run python .agents/skills/market-analysis/scripts/market_analysis.py \
             generate \
             --symbols "${{ steps.symbols.outputs.symbols }}" \
-            --interval d \
+            --interval "$INTERVAL" \
             --analysis-date "${{ steps.date.outputs.date }}" \
             --output data/analysis/
       - name: Validate artifact
@@ -87,7 +116,8 @@ jobs:
       - name: Build Hugo site (validation)
         run: hugo --gc --minify
       - name: Create pull request
-        if: steps.symbols.outputs.symbols != ''
+        id: pr
+        if: steps.symbols.outputs.symbols != '' && env.DRY_RUN != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -99,29 +129,32 @@ jobs:
           git add data/analysis/ content/results/
           if git diff --cached --quiet; then
             echo "No changes to commit."
+            echo "pr_url=" >> "$GITHUB_OUTPUT"
           else
             git commit -m "feat(analysis): daily market analysis ${{ steps.date.outputs.date }}"
             git push --force-with-lease -u origin "$BRANCH"
             PR_NUMBER="$(gh pr list --head "$BRANCH" --json number --jq '.[0].number // empty')"
             if [ -n "$PR_NUMBER" ]; then
               echo "PR #$PR_NUMBER already exists for $BRANCH; branch updated."
+              PR_URL=$(gh pr view "$PR_NUMBER" --json url --jq '.url')
+              echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
             else
-              gh pr create \
+              PR_URL=$(gh pr create \
                 --title "feat(analysis): daily market analysis ${{ steps.date.outputs.date }}" \
                 --body "Automated daily market analysis for ${{ steps.date.outputs.date }}." \
                 --base main \
-                --head "$BRANCH"
+                --head "$BRANCH")
+              echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
             fi
           fi
       - name: Notify Slack (success)
-        if: steps.symbols.outputs.symbols != ''
+        if: steps.symbols.outputs.symbols != '' && env.DRY_RUN != 'true'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          REPORT_URL="https://dceoy.github.io/aims/results/${{ steps.date.outputs.date }}-market-analysis/"
           uv run python .agents/skills/market-analysis/scripts/notify_slack.py \
             --artifact "data/analysis/${{ steps.date.outputs.date }}.json" \
-            --report-url "$REPORT_URL"
+            --pr-url "${{ steps.pr.outputs.pr_url }}"
       - name: Notify Slack (failure)
         if: failure()
         env:

--- a/.github/workflows/daily-market-analysis.yml
+++ b/.github/workflows/daily-market-analysis.yml
@@ -1,0 +1,146 @@
+---
+name: Daily market analysis
+on:
+  schedule:
+    - cron: "0 1 * * *"
+  workflow_dispatch:
+    inputs:
+      analysis_date:
+        description: "Analysis date (YYYY-MM-DD, default: today UTC)"
+        required: false
+        type: string
+      interval:
+        description: "Price bar interval"
+        required: false
+        default: d
+        type: choice
+        options:
+          - d
+          - w
+          - m
+      dry_run:
+        description: "Skip commit and Slack notification"
+        required: false
+        default: "false"
+        type: boolean
+permissions:
+  contents: read
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      ANALYSIS_DATE: ${{ inputs.analysis_date || '' }}
+      INTERVAL: ${{ inputs.interval || 'd' }}
+      DRY_RUN: ${{ inputs.dry_run || 'false' }}
+    steps:
+      - uses: actions/checkout@v4  # zizmor: ignore[unpinned-uses]
+      - uses: astral-sh/setup-uv@v5  # zizmor: ignore[unpinned-uses]
+        with:
+          python-version: "3.x"
+      - name: Sync dependencies
+        run: uv sync
+      - name: Validate CFD instruments
+        run: |
+          uv run python \
+            .agents/skills/update-cfd-instruments/scripts/validate_cfd_instruments.py \
+            --input data/cfd_instruments.csv \
+            --schema data/schema/cfd_instruments.schema.json
+      - name: Set analysis date
+        id: date
+        run: |
+          if [ -n "$ANALYSIS_DATE" ]; then
+            echo "date=$ANALYSIS_DATE" >> "$GITHUB_OUTPUT"
+          else
+            echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Load symbols
+        id: symbols
+        run: |
+          if [ -f data/stooq_symbols.txt ]; then
+            SYMBOLS=$(grep -v '^[[:space:]]*#' data/stooq_symbols.txt \
+              | grep -v '^[[:space:]]*$' | tr '\n' ',' | sed 's/,$//')
+          else
+            SYMBOLS=""
+          fi
+          echo "symbols=$SYMBOLS" >> "$GITHUB_OUTPUT"
+          if [ -z "$SYMBOLS" ]; then
+            echo "WARNING: data/stooq_symbols.txt is empty or missing; skipping fetch."
+          fi
+      - name: Fetch market data
+        if: steps.symbols.outputs.symbols != ''
+        run: |
+          DATE="${{ steps.date.outputs.date }}"
+          START=$(python3 -c "
+          from datetime import datetime, timedelta
+          d = datetime.strptime('${DATE}', '%Y-%m-%d')
+          print((d - timedelta(days=365)).strftime('%Y-%m-%d'))
+          ")
+          IFS=',' read -ra SYMS <<< "${{ steps.symbols.outputs.symbols }}"
+          for SYM in "${SYMS[@]}"; do
+            uv run python .agents/skills/market-analysis/scripts/market_analysis.py \
+              fetch --symbol "$SYM" --start "$START" --end "$DATE" \
+              --interval "$INTERVAL" \
+              || echo "WARNING: fetch failed for $SYM, continuing"
+          done
+      - name: Generate analysis artifact
+        if: steps.symbols.outputs.symbols != ''
+        run: |
+          uv run python .agents/skills/market-analysis/scripts/market_analysis.py \
+            generate \
+            --symbols "${{ steps.symbols.outputs.symbols }}" \
+            --interval "$INTERVAL" \
+            --output data/analysis/
+      - name: Validate artifact
+        if: steps.symbols.outputs.symbols != ''
+        run: |
+          uv run python .agents/skills/market-analysis/scripts/validate_analysis.py \
+            --input "data/analysis/${{ steps.date.outputs.date }}.json"
+      - name: Generate Hugo report
+        if: steps.symbols.outputs.symbols != ''
+        run: |
+          uv run python .agents/skills/market-analysis/scripts/generate_report.py \
+            --input "data/analysis/${{ steps.date.outputs.date }}.json" \
+            --output content/results/
+      - uses: actions/setup-go@v5  # zizmor: ignore[unpinned-uses]
+        with:
+          go-version: stable
+      - name: Install Hugo
+        uses: peaceiris/actions-hugo@v3  # zizmor: ignore[unpinned-uses]
+        with:
+          hugo-version: latest
+          extended: true
+      - name: Build Hugo site (validation)
+        run: hugo --gc --minify
+      - name: Commit generated artifacts
+        if: env.DRY_RUN != 'true' && steps.symbols.outputs.symbols != ''
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/analysis/ content/results/
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+          else
+            git commit -m "feat(analysis): daily market analysis ${{ steps.date.outputs.date }}"
+            git push
+          fi
+      - name: Notify Slack (success)
+        if: env.DRY_RUN != 'true' && steps.symbols.outputs.symbols != ''
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          REPORT_URL="https://dceoy.github.io/aims/results/${{ steps.date.outputs.date }}-market-analysis/"
+          uv run python .agents/skills/market-analysis/scripts/notify_slack.py \
+            --artifact "data/analysis/${{ steps.date.outputs.date }}.json" \
+            --report-url "$REPORT_URL"
+      - name: Notify Slack (failure)
+        if: failure()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          uv run python .agents/skills/market-analysis/scripts/notify_slack.py \
+            --failure \
+            --run-url \
+            "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --message "Daily market analysis workflow failed"

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -229,9 +229,9 @@ The `ci.yml` workflow adds:
 ERROR: fetch failed for ^SPX
 ```
 
-Stooq may be temporarily unavailable or the symbol may be invalid. Fetch failures are fatal — the workflow step will fail, the Slack failure notification fires, and the analysis is not published.
+Stooq may be temporarily unavailable or the symbol may be invalid. Per-symbol fetch failures are non-fatal — a `WARNING` is logged and the fetch loop continues. The symbol is passed to the `generate` step which marks it as `missing_data` in the artifact and report. The workflow only fails if no symbols at all can be fetched and the artifact cannot be generated.
 
-**Fix:** Check `data/stooq_symbols.txt` for typos. Verify the symbol at https://stooq.com. Remove unavailable symbols.
+**Fix:** Check `data/stooq_symbols.txt` for typos. Verify the symbol at https://stooq.com. Remove permanently unavailable symbols to keep the analysis clean.
 
 ### Artifact validation failure
 

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -171,8 +171,8 @@ Pipeline order:
 6. Validate artifact
 7. Generate Hugo Markdown report (`content/results/YYYY-MM-DD-market-analysis.md`)
 8. Build Hugo site (validation only — catches template or content errors before commit)
-9. Commit artifact and report to `main`
-10. The existing `ci.yml` picks up the push and deploys to GitHub Pages
+9. Create a pull-request branch `generated/analysis-YYYY-MM-DD` with the artifact and report
+10. A Slack notification is sent with a link to the analysis PR.
 
 ### Manual dispatch
 
@@ -182,7 +182,7 @@ The workflow supports `workflow_dispatch` with three optional inputs:
 | ----- | ------- | ----------- |
 | `analysis_date` | Today UTC | Override the analysis date (YYYY-MM-DD) |
 | `interval` | `d` | Price bar interval: `d` (daily), `w` (weekly), `m` (monthly) |
-| `dry_run` | `false` | When `true`, skips the commit and Slack notification |
+| `dry_run` | `false` | When `true`, skips PR creation and Slack success notification |
 
 ### Deployment gate
 
@@ -209,7 +209,8 @@ The `daily-market-analysis.yml` workflow uses:
 
 | Permission | Scope | Reason |
 | ---------- | ----- | ------ |
-| `contents: write` | `analyze` job | Commit and push generated artifacts to `main` |
+| `contents: write` | `analyze` job | Create and push to analysis branch; open PR |
+| `pull-requests: write` | `analyze` job | Create analysis pull requests |
 | `contents: read` | Workflow-level default | Checkout |
 
 The `ci.yml` workflow adds:
@@ -225,10 +226,10 @@ The `ci.yml` workflow adds:
 ### Fetch failed for symbol
 
 ```
-WARNING: fetch failed for ^SPX, continuing
+ERROR: fetch failed for ^SPX
 ```
 
-Stooq may be temporarily unavailable or the symbol may be invalid. The workflow continues and scores remaining symbols. If all fetches fail, `generate` will have no data and will exit with an error.
+Stooq may be temporarily unavailable or the symbol may be invalid. Fetch failures are fatal — the workflow step will fail, the Slack failure notification fires, and the analysis is not published.
 
 **Fix:** Check `data/stooq_symbols.txt` for typos. Verify the symbol at https://stooq.com. Remove unavailable symbols.
 
@@ -279,7 +280,8 @@ uv run .agents/skills/market-analysis/scripts/market_analysis.py \
 
 ```sh
 uv run .agents/skills/market-analysis/scripts/market_analysis.py \
-    generate --symbols "^SPX,^DJI,^NDX" --output data/analysis/
+    generate --symbols "^SPX,^DJI,^NDX" --output data/analysis/ \
+    --analysis-date YYYY-MM-DD
 ```
 
 ### Regenerate a report from an existing artifact

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -1,0 +1,310 @@
+# AIMS — Operations Guide
+
+This document covers data sources, scoring methodology, report generation, the publication workflow, required secrets, troubleshooting, and manual recovery.
+
+> **Disclaimer:** All analysis produced by AIMS is for informational purposes only and does not constitute investment advice, a solicitation, or a recommendation to buy or sell any financial instrument. Past performance is not indicative of future results. Always consult a qualified financial adviser before making investment decisions.
+
+---
+
+## Table of contents
+
+1. [Data sources](#1-data-sources)
+2. [Instrument master](#2-instrument-master)
+3. [Scoring methodology](#3-scoring-methodology)
+4. [Report generation](#4-report-generation)
+5. [Publication workflow](#5-publication-workflow)
+6. [GitHub Actions secrets](#6-github-actions-secrets)
+7. [Required permissions](#7-required-permissions)
+8. [Troubleshooting](#8-troubleshooting)
+9. [Manual recovery](#9-manual-recovery)
+
+---
+
+## 1. Data sources
+
+### Stooq (primary market data)
+
+AIMS fetches daily OHLCV (open/high/low/close/volume) price history from [Stooq](https://stooq.com) using its free CSV download API.
+
+**Symbol format:** Stooq uses its own symbol convention.
+Examples: `^SPX` (S&P 500), `^DJI` (Dow Jones), `^NDX` (NASDAQ 100), `^NKX` (Nikkei 225), `^DAX` (DAX).
+
+**Limitations:**
+- Daily, weekly, and monthly bars only — no intraday data.
+- Symbol availability and history depth vary; some symbols return no data.
+- No authentication required, but subject to undocumented rate limits.
+- Network access is required; fetches that fail are logged as `WARNING` and skipped.
+
+**Terms of use:** Data obtained from Stooq is subject to Stooq's own terms. AIMS does not redistribute raw Stooq data — it stores derived analysis artifacts only. Verify Stooq's terms before commercial or redistribution use.
+
+**Configured symbols:** `data/stooq_symbols.txt` — one Stooq symbol per line; lines starting with `#` are comments. Edit this file to add or remove instruments from the daily run.
+
+### CFD instrument master
+
+The canonical list of CFD products available at supported brokers is maintained in `data/cfd_instruments.csv`. It is refreshed weekly by the `update-cfd-instruments` workflow. The daily analysis workflow validates this file before running but does not modify it.
+
+---
+
+## 2. Instrument master
+
+The CFD instrument master (`data/cfd_instruments.csv`) is sourced from:
+
+- **GMO Click Securities** (`クリック証券`) — CFD lineup pages
+- **Rakuten Securities** (`楽天証券`) — CFD lineup pages
+
+Ticker symbols in the instrument master follow each broker's own convention and do not map directly to Stooq symbols. `data/mappings/cfd_ticker_mappings.csv` contains the mapping used by the updater.
+
+The master is validated against `data/schema/cfd_instruments.schema.json` after every update.
+
+**Update frequency:** Weekly (Monday 05:00 UTC) via `.github/workflows/update-cfd-instruments.yml`. Changes are submitted as pull requests for review.
+
+---
+
+## 3. Scoring methodology
+
+AIMS scores and ranks instruments cross-sectionally using ten features computed from daily OHLCV history.
+
+### Features
+
+| Feature | Window | Direction |
+| ------- | ------ | --------- |
+| Return | 1 day | Higher is better |
+| Return | 5 days | Higher is better |
+| Return | 20 days | Higher is better |
+| Return | 60 days | Higher is better |
+| Distance from MA | 20-day | Higher is better |
+| Distance from MA | 50-day | Higher is better |
+| Realized volatility | 20-day annualised | Lower is better |
+| Maximum drawdown | 60 days | Lower is better |
+| RSI | 14-day | Higher is better |
+| Z-score | 20-day | Higher is better |
+
+### Cross-sectional ranking
+
+Each feature value is converted to a cross-sectional percentile rank across all instruments in the universe for that run. Features where "lower is better" are inverted (100 minus percentile). The composite score is the unweighted mean of all ten feature ranks, ranging from 0 to 100.
+
+### Risk gates
+
+Instruments that fail quality checks are included in output but marked `is_reliable: false` and ranked below reliable instruments. They appear in the "Instruments to Avoid" section of the report.
+
+| Gate | Trigger |
+| ---- | ------- |
+| `stale_data` | Latest bar older than `stale_days` calendar days (default: 5) |
+| `insufficient_history` | Fewer than `min_history` bars (default: 60) |
+| `missing_bars` | Gap > 7 calendar days between consecutive bars |
+| `malformed_input` | Non-positive prices, high < low, or price outside [low, high] |
+| `high_volatility` | 20-day annualised volatility > 100% |
+
+### Market regime
+
+The market regime label is derived from the median composite score of reliable instruments:
+
+| Label | Median score |
+| ----- | ------------ |
+| Bullish | ≥ 65 |
+| Neutral | 40 – 64 |
+| Bearish | ≤ 40 |
+| Unavailable | No reliable instruments |
+
+### Scoring version
+
+`SCORING_VERSION = "1.0.0"` in `market_analysis.py`. Increment this when the feature set or scoring logic changes in a way that makes old and new scores incomparable.
+
+### Assumptions and limitations
+
+- Scores are cross-sectional: they reflect relative, not absolute, performance. A score of 80 in a falling market still means that instrument fell less than most others.
+- Volatility and drawdown are historical. They do not predict future risk.
+- Missing or stale data can distort percentile ranks when the universe is small.
+- Short history (< 60 bars) triggers the `insufficient_history` gate and excludes an instrument from reliable rankings.
+
+---
+
+## 4. Report generation
+
+### Script
+
+```sh
+uv run .agents/skills/market-analysis/scripts/generate_report.py \
+    --input data/analysis/YYYY-MM-DD.json \
+    --output content/results/
+```
+
+The script reads the JSON artifact produced by `market_analysis.py generate` and writes a Hugo-compatible Markdown file to `content/results/YYYY-MM-DD-market-analysis.md`.
+
+### Output format
+
+The report includes:
+
+- TOML front matter: title, date, draft status, summary, ticker symbols, market regime, scoring metadata
+- Market regime section
+- Top opportunities (up to 5 reliable instruments)
+- Instruments to avoid (unreliable instruments)
+- Key risks (triggered risk gates)
+- Full instrument scores table
+- Data freshness table (per-symbol latest bar date)
+- Methodology summary
+- Financial disclaimer
+
+### Determinism
+
+The generator is fully deterministic: identical input JSON always produces identical Markdown output. It does not call `datetime.now()` and uses only the `generated_at` timestamp from the artifact.
+
+### Draft status
+
+`draft = false` is set in all generated reports. Draft reports can be created manually using `hugo new results/YYYY-MM-DD-description.md`.
+
+---
+
+## 5. Publication workflow
+
+### Daily schedule
+
+`.github/workflows/daily-market-analysis.yml` runs at **01:00 UTC** every day.
+
+Pipeline order:
+
+1. Validate CFD instrument master
+2. Set analysis date (default: today UTC)
+3. Load symbols from `data/stooq_symbols.txt`
+4. Fetch market data from Stooq (1-year lookback)
+5. Generate JSON analysis artifact (`data/analysis/YYYY-MM-DD.json`)
+6. Validate artifact
+7. Generate Hugo Markdown report (`content/results/YYYY-MM-DD-market-analysis.md`)
+8. Build Hugo site (validation only — catches template or content errors before commit)
+9. Commit artifact and report to `main`
+10. The existing `ci.yml` picks up the push and deploys to GitHub Pages
+
+### Manual dispatch
+
+The workflow supports `workflow_dispatch` with three optional inputs:
+
+| Input | Default | Description |
+| ----- | ------- | ----------- |
+| `analysis_date` | Today UTC | Override the analysis date (YYYY-MM-DD) |
+| `interval` | `d` | Price bar interval: `d` (daily), `w` (weekly), `m` (monthly) |
+| `dry_run` | `false` | When `true`, skips the commit and Slack notification |
+
+### Deployment gate
+
+GitHub Pages deployment is handled by `ci.yml` (`hugo-deploy-to-gh-pages` job), which runs only after Python linting, type checking, and tests all pass. The daily analysis workflow commits only content files (JSON and Markdown), not Python source, so existing tests remain stable.
+
+---
+
+## 6. GitHub Actions secrets
+
+| Secret | Required | Description |
+| ------ | -------- | ----------- |
+| `SLACK_WEBHOOK_URL` | Optional | Slack incoming webhook URL for success and failure notifications. If not set, the notification steps exit silently (exit code 0). |
+| `GITHUB_TOKEN` | Built-in | Used automatically by `gh` and `git push` in the `update-cfd-instruments` and `daily-market-analysis` workflows. No manual configuration needed. |
+
+**How to add `SLACK_WEBHOOK_URL`:** Go to the repository → Settings → Secrets and variables → Actions → New repository secret. Name: `SLACK_WEBHOOK_URL`. Value: the `https://hooks.slack.com/services/…` URL from your Slack app's Incoming Webhooks configuration.
+
+**Never commit secret values.** The `notify_slack.py` script reads `SLACK_WEBHOOK_URL` only from the environment.
+
+---
+
+## 7. Required permissions
+
+The `daily-market-analysis.yml` workflow uses:
+
+| Permission | Scope | Reason |
+| ---------- | ----- | ------ |
+| `contents: write` | `analyze` job | Commit and push generated artifacts to `main` |
+| `contents: read` | Workflow-level default | Checkout |
+
+The `ci.yml` workflow adds:
+| Permission | Scope | Reason |
+| ---------- | ----- | ------ |
+| `id-token: write` | `hugo-deploy-to-gh-pages` job | OIDC token for Pages deployment |
+| `pages: write` | `hugo-deploy-to-gh-pages` job | Deploy to GitHub Pages |
+
+---
+
+## 8. Troubleshooting
+
+### Fetch failed for symbol
+
+```
+WARNING: fetch failed for ^SPX, continuing
+```
+
+Stooq may be temporarily unavailable or the symbol may be invalid. The workflow continues and scores remaining symbols. If all fetches fail, `generate` will have no data and will exit with an error.
+
+**Fix:** Check `data/stooq_symbols.txt` for typos. Verify the symbol at https://stooq.com. Remove unavailable symbols.
+
+### Artifact validation failure
+
+```
+ERROR: instrument[0] missing required key: 'symbol'
+```
+
+The generated JSON does not match the expected schema. This usually means a bug in `market_analysis.py`.
+
+**Fix:** Run the generate step locally, then run `validate_analysis.py` with `--input` to reproduce the error.
+
+### Hugo build failure
+
+```
+Error: ... template: ...
+```
+
+A generated Markdown file has invalid front matter or content that causes Hugo to fail.
+
+**Fix:** Run `hugo --gc --minify` locally with the failing content file, fix the generator, and regenerate.
+
+### Stale data warning
+
+Reports include a freshness table. Symbols with `n/a` in the freshness column had no data returned from Stooq. Symbols with old dates may be delisted or have restricted access.
+
+### 100% test coverage requirement
+
+All new Python scripts in `.agents/skills/market-analysis/scripts/` are included in the pytest coverage check. If you add new code paths, add corresponding tests.
+
+---
+
+## 9. Manual recovery
+
+### Re-run the daily workflow
+
+Trigger it from **Actions → Daily market analysis → Run workflow** with the desired `analysis_date`.
+
+### Re-fetch data for a symbol
+
+```sh
+uv run .agents/skills/market-analysis/scripts/market_analysis.py \
+    fetch --symbol ^SPX --start 2023-01-01 --end 2024-12-31
+```
+
+### Regenerate an artifact from saved data
+
+```sh
+uv run .agents/skills/market-analysis/scripts/market_analysis.py \
+    generate --symbols "^SPX,^DJI,^NDX" --output data/analysis/
+```
+
+### Regenerate a report from an existing artifact
+
+```sh
+uv run .agents/skills/market-analysis/scripts/generate_report.py \
+    --input data/analysis/2024-01-01.json \
+    --output content/results/
+```
+
+### Send a test Slack notification
+
+```sh
+SLACK_WEBHOOK_URL="https://hooks.slack.com/services/..." \
+uv run .agents/skills/market-analysis/scripts/notify_slack.py \
+    --artifact data/analysis/2024-01-01.json \
+    --report-url https://dceoy.github.io/aims/results/2024-01-01-market-analysis/
+```
+
+### Delete a published report
+
+1. Delete `content/results/YYYY-MM-DD-market-analysis.md` and `data/analysis/YYYY-MM-DD.json`.
+2. Commit and push to `main`.
+3. CI will rebuild and redeploy without the deleted report.
+
+### Refresh CFD instruments manually
+
+Trigger **Actions → Update CFD instruments → Run workflow**.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,6 @@ hugo server --buildDrafts
 
 ## Automated analysis pipeline
 
-Daily market analysis runs automatically via `.github/workflows/daily-market-analysis.yml`. It fetches market data, scores instruments, generates JSON artifacts and Hugo Markdown reports, builds the site, and commits the results.
+Daily market analysis runs automatically via `.github/workflows/daily-market-analysis.yml`. It fetches market data, scores instruments, generates JSON artifacts and Hugo Markdown reports, builds the site, and creates a pull request with the results for review and merging.
 
 See [OPERATIONS.md](OPERATIONS.md) for data sources, scoring methodology, required secrets, and operational runbooks.

--- a/README.md
+++ b/README.md
@@ -26,3 +26,9 @@ Preview drafts locally with:
 ```bash
 hugo server --buildDrafts
 ```
+
+## Automated analysis pipeline
+
+Daily market analysis runs automatically via `.github/workflows/daily-market-analysis.yml`. It fetches market data, scores instruments, generates JSON artifacts and Hugo Markdown reports, builds the site, and commits the results.
+
+See [OPERATIONS.md](OPERATIONS.md) for data sources, scoring methodology, required secrets, and operational runbooks.

--- a/data/stooq_symbols.txt
+++ b/data/stooq_symbols.txt
@@ -1,0 +1,16 @@
+# Stooq symbols for daily market analysis
+# One symbol per line; blank lines and lines starting with # are ignored.
+# Stooq symbol format reference: https://stooq.com/
+#
+# Common index symbols:
+#   US:  ^SPX (S&P 500), ^DJI (Dow Jones), ^NDX (NASDAQ 100), ^RUT (Russell 2000)
+#   JP:  ^NKX (Nikkei 225), ^TPX (TOPIX)
+#   EU:  ^DAX (DAX), ^FTM (FTSE 100), ^CAC (CAC 40)
+#
+# Note: symbol availability and history depth vary by source; symbols that return
+# no data are skipped automatically during fetch with a WARNING log.
+^SPX
+^DJI
+^NDX
+^NKX
+^DAX

--- a/tests/fixtures/analysis_2024-01-01.json
+++ b/tests/fixtures/analysis_2024-01-01.json
@@ -1,0 +1,81 @@
+{
+  "version": "1.0.0",
+  "metadata": {
+    "generated_at": "2024-01-01T01:00:00+00:00",
+    "git_commit": "abc1234",
+    "data_source": "stooq",
+    "data_freshness": {
+      "^SPX": "2024-01-01",
+      "^DJI": "2023-12-29",
+      "^NDX": "n/a"
+    },
+    "scoring_version": "1.0.0",
+    "config": {
+      "stale_days": 5,
+      "min_history": 60,
+      "interval": "d"
+    }
+  },
+  "instruments": [
+    {
+      "symbol": "^SPX",
+      "rank": 1,
+      "score": 72.5,
+      "is_reliable": true,
+      "risk_gates": [],
+      "explanation": "20d up +5.3%; above MA20 by 2.1%; RSI14=62",
+      "features": {
+        "ret_1d": 0.012,
+        "ret_5d": 0.031,
+        "ret_20d": 0.053,
+        "ret_60d": 0.089,
+        "ma20_dist": 0.021,
+        "ma50_dist": 0.018,
+        "vol_20d": 0.127,
+        "mdd_60d": 0.031,
+        "rsi_14": 62.0,
+        "zscore_20d": 1.2
+      }
+    },
+    {
+      "symbol": "^DJI",
+      "rank": 2,
+      "score": 58.3,
+      "is_reliable": true,
+      "risk_gates": [],
+      "explanation": "20d up +2.1%; above MA20 by 0.8%; RSI14=55",
+      "features": {
+        "ret_1d": 0.005,
+        "ret_5d": 0.015,
+        "ret_20d": 0.021,
+        "ret_60d": 0.042,
+        "ma20_dist": 0.008,
+        "ma50_dist": 0.012,
+        "vol_20d": 0.089,
+        "mdd_60d": 0.018,
+        "rsi_14": 55.0,
+        "zscore_20d": 0.7
+      }
+    },
+    {
+      "symbol": "^NDX",
+      "rank": 3,
+      "score": 31.7,
+      "is_reliable": false,
+      "risk_gates": ["insufficient_history"],
+      "explanation": "Suppressed: insufficient_history",
+      "features": {
+        "ret_1d": null,
+        "ret_5d": null,
+        "ret_20d": null,
+        "ret_60d": null,
+        "ma20_dist": null,
+        "ma50_dist": null,
+        "vol_20d": null,
+        "mdd_60d": null,
+        "rsi_14": null,
+        "zscore_20d": null
+      }
+    }
+  ]
+}

--- a/tests/golden/2024-01-01-market-analysis.md
+++ b/tests/golden/2024-01-01-market-analysis.md
@@ -1,0 +1,72 @@
++++
+title = "Market Analysis 2024-01-01"
+date = "2024-01-01T01:00:00+00:00"
+draft = false
+summary = "Bullish market: 2 reliable instruments. Top signal: ^SPX (score 72.5)."
+ticker_symbols = ["^DJI", "^NDX", "^SPX"]
+source_files = ["data/analysis/2024-01-01.json"]
+market_regime = "Bullish"
+data_source = "stooq"
+scoring_version = "1.0.0"
+git_commit = "abc1234"
++++
+
+## Market Regime
+
+**Bullish** — based on cross-sectional momentum scores of 2 reliable instrument(s) out of 3 total.
+
+## Top Opportunities
+
+- **^SPX** — score 72.5, 20d return +5.3%, RSI14=62. 20d up +5.3%; above MA20 by 2.1%; RSI14=62
+- **^DJI** — score 58.3, 20d return +2.1%, RSI14=55. 20d up +2.1%; above MA20 by 0.8%; RSI14=55
+
+## Instruments to Avoid
+
+These instruments have quality or risk issues and are excluded from ranking:
+
+- **^NDX** — insufficient_history
+
+## Key Risks
+
+- **insufficient_history** (1 instrument(s)): Insufficient history: some instruments lack enough historical data for reliable scoring.
+
+## Instrument Scores
+
+| Rank | Symbol | Score | Reliable | Risk Gates | Explanation |
+| ---: | ------ | ----: | :------: | ---------- | ----------- |
+| 1 | ^SPX | 72.5 | Yes | — | 20d up +5.3%; above MA20 by 2.1%; RSI14=62 |
+| 2 | ^DJI | 58.3 | Yes | — | 20d up +2.1%; above MA20 by 0.8%; RSI14=55 |
+| 3 | ^NDX | 31.7 | No | insufficient_history | Suppressed: insufficient_history |
+
+## Data Freshness
+
+Data source: **stooq**
+
+| Symbol | Latest Bar |
+| ------ | ---------- |
+| ^DJI | 2023-12-29 |
+| ^NDX | n/a |
+| ^SPX | 2024-01-01 |
+
+> **Warning:** 1 instrument(s) have no data: ^NDX.
+
+## Methodology
+
+Instruments are scored and ranked cross-sectionally using the following features:
+
+- **Momentum**: 1-day, 5-day, 20-day, and 60-day returns
+- **Trend**: Distance from 20-day and 50-day moving averages
+- **Volatility**: 20-day realized annualized volatility (lower is better)
+- **Drawdown**: Maximum drawdown over 60 days (lower is better)
+- **RSI**: 14-day Relative Strength Index
+- **Z-score**: Price z-score relative to 20-day mean
+
+Each feature is converted to a cross-sectional percentile rank. The composite score is the mean percentile across all features (0–100).
+
+Scoring engine version: **1.0.0** | Git commit: **abc1234**
+
+For methodology details, see OPERATIONS.md in the repository root.
+
+## Disclaimer
+
+> This report is generated automatically from publicly available market data for informational purposes only. It does not constitute investment advice, a solicitation, or a recommendation to buy or sell any financial instrument. Past performance is not indicative of future results. Always consult a qualified financial adviser before making investment decisions.

--- a/tests/test_generate_report.py
+++ b/tests/test_generate_report.py
@@ -1,0 +1,424 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / ".agents"
+    / "skills"
+    / "market-analysis"
+    / "scripts"
+    / "generate_report.py"
+)
+
+FIXTURE_PATH = Path(__file__).resolve().parent / "fixtures" / "analysis_2024-01-01.json"
+GOLDEN_PATH = (
+    Path(__file__).resolve().parent / "golden" / "2024-01-01-market-analysis.md"
+)
+
+
+@pytest.fixture(scope="module")
+def gr() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("generate_report", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        pytest.fail("Failed to load generate_report.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def fixture_artifact() -> dict[str, Any]:
+    with FIXTURE_PATH.open() as fh:
+        return json.load(fh)
+
+
+# ── Golden file test ────────────────────────────────────────────────────────────
+
+
+def test_generate_report_golden(
+    gr: ModuleType, fixture_artifact: dict[str, Any]
+) -> None:
+    actual = gr.generate_report(fixture_artifact)
+    expected = GOLDEN_PATH.read_text()
+    assert actual == expected
+
+
+# ── Edge-case artifact tests ────────────────────────────────────────────────────
+
+
+def test_generate_report_no_instruments(gr: ModuleType) -> None:
+    artifact: dict[str, Any] = {
+        "version": "1.0.0",
+        "metadata": {
+            "generated_at": "2024-06-01T00:00:00+00:00",
+            "git_commit": "deadbeef",
+            "data_source": "stooq",
+            "data_freshness": {},
+            "scoring_version": "1.0.0",
+            "config": {},
+        },
+        "instruments": [],
+    }
+    result = gr.generate_report(artifact)
+    assert "No reliable instruments" in result
+    assert "No risk gates triggered" in result
+    assert "All instruments passed quality checks" in result
+
+
+def test_generate_report_all_reliable(gr: ModuleType) -> None:
+    artifact: dict[str, Any] = {
+        "version": "1.0.0",
+        "metadata": {
+            "generated_at": "2024-06-01T00:00:00+00:00",
+            "git_commit": "deadbeef",
+            "data_source": "stooq",
+            "data_freshness": {"AAPL": "2024-06-01"},
+            "scoring_version": "1.0.0",
+            "config": {},
+        },
+        "instruments": [
+            {
+                "symbol": "AAPL",
+                "rank": 1,
+                "score": 70.0,
+                "is_reliable": True,
+                "risk_gates": [],
+                "explanation": "Strong",
+                "features": {
+                    "ret_1d": 0.01,
+                    "ret_5d": 0.02,
+                    "ret_20d": 0.05,
+                    "ret_60d": 0.10,
+                    "ma20_dist": 0.02,
+                    "ma50_dist": 0.01,
+                    "vol_20d": 0.10,
+                    "mdd_60d": 0.02,
+                    "rsi_14": 60.0,
+                    "zscore_20d": 1.0,
+                },
+            }
+        ],
+    }
+    result = gr.generate_report(artifact)
+    assert "All instruments passed quality checks." in result
+
+
+def test_generate_report_no_reliable(gr: ModuleType) -> None:
+    artifact: dict[str, Any] = {
+        "version": "1.0.0",
+        "metadata": {
+            "generated_at": "2024-06-01T00:00:00+00:00",
+            "git_commit": "deadbeef",
+            "data_source": "stooq",
+            "data_freshness": {},
+            "scoring_version": "1.0.0",
+            "config": {},
+        },
+        "instruments": [
+            {
+                "symbol": "BAD",
+                "rank": 1,
+                "score": 20.0,
+                "is_reliable": False,
+                "risk_gates": ["stale_data"],
+                "explanation": "Suppressed",
+                "features": {
+                    "ret_1d": None,
+                    "ret_5d": None,
+                    "ret_20d": None,
+                    "ret_60d": None,
+                    "ma20_dist": None,
+                    "ma50_dist": None,
+                    "vol_20d": None,
+                    "mdd_60d": None,
+                    "rsi_14": None,
+                    "zscore_20d": None,
+                },
+            }
+        ],
+    }
+    result = gr.generate_report(artifact)
+    assert "Unavailable" in result
+    assert "No reliable instruments." in result
+
+
+def test_generate_report_missing_generated_at(gr: ModuleType) -> None:
+    artifact: dict[str, Any] = {
+        "version": "1.0.0",
+        "metadata": {
+            "git_commit": "abc",
+            "data_source": "stooq",
+            "data_freshness": {},
+            "scoring_version": "1.0.0",
+            "config": {},
+        },
+        "instruments": [],
+    }
+    result = gr.generate_report(artifact)
+    assert "1970-01-01" in result
+
+
+def test_generate_report_non_string_generated_at(gr: ModuleType) -> None:
+    artifact: dict[str, Any] = {
+        "version": "1.0.0",
+        "metadata": {
+            "generated_at": 12345,
+            "git_commit": "abc",
+            "data_source": "stooq",
+            "data_freshness": {},
+            "scoring_version": "1.0.0",
+            "config": {},
+        },
+        "instruments": [],
+    }
+    result = gr.generate_report(artifact)
+    assert "1970-01-01" in result
+
+
+def test_generate_report_no_stale_warning(gr: ModuleType) -> None:
+    artifact: dict[str, Any] = {
+        "version": "1.0.0",
+        "metadata": {
+            "generated_at": "2024-06-01T00:00:00+00:00",
+            "git_commit": "abc",
+            "data_source": "stooq",
+            "data_freshness": {"AAPL": "2024-06-01"},
+            "scoring_version": "1.0.0",
+            "config": {},
+        },
+        "instruments": [],
+    }
+    result = gr.generate_report(artifact)
+    assert "Warning" not in result
+
+
+# ── report_filename tests ───────────────────────────────────────────────────────
+
+
+def test_report_filename(gr: ModuleType, fixture_artifact: dict[str, Any]) -> None:
+    assert gr.report_filename(fixture_artifact) == "2024-01-01-market-analysis.md"
+
+
+def test_report_filename_missing_generated_at(gr: ModuleType) -> None:
+    artifact: dict[str, Any] = {"metadata": {}}
+    assert gr.report_filename(artifact) == "1970-01-01-market-analysis.md"
+
+
+def test_report_filename_non_string_generated_at(gr: ModuleType) -> None:
+    artifact: dict[str, Any] = {"metadata": {"generated_at": 999}}
+    assert gr.report_filename(artifact) == "1970-01-01-market-analysis.md"
+
+
+# ── generate_and_save tests ─────────────────────────────────────────────────────
+
+
+def test_generate_and_save(gr: ModuleType, tmp_path: Path) -> None:
+    # Copy fixture to tmp_path
+    artifact_path = tmp_path / "analysis_2024-01-01.json"
+    artifact_path.write_text(FIXTURE_PATH.read_text())
+    output_dir = tmp_path / "results"
+    result_path = gr.generate_and_save(artifact_path, output_dir)
+    assert result_path.exists()
+    assert result_path.name == "2024-01-01-market-analysis.md"
+
+
+def test_generate_and_save_file_not_found(gr: ModuleType, tmp_path: Path) -> None:
+    missing = tmp_path / "nonexistent.json"
+    with pytest.raises(FileNotFoundError):
+        gr.generate_and_save(missing, tmp_path)
+
+
+def test_generate_and_save_missing_generated_at(gr: ModuleType, tmp_path: Path) -> None:
+    artifact: dict[str, Any] = {
+        "version": "1.0.0",
+        "metadata": {
+            "git_commit": "abc",
+            "data_source": "stooq",
+            "data_freshness": {},
+            "scoring_version": "1.0.0",
+            "config": {},
+        },
+        "instruments": [],
+    }
+    artifact_path = tmp_path / "artifact.json"
+    artifact_path.write_text(json.dumps(artifact))
+    output_dir = tmp_path / "results"
+    result_path = gr.generate_and_save(artifact_path, output_dir)
+    assert result_path.name == "1970-01-01-market-analysis.md"
+
+
+# ── main() tests ────────────────────────────────────────────────────────────────
+
+
+def test_main_success(gr: ModuleType, tmp_path: Path) -> None:
+    artifact_path = tmp_path / "analysis_2024-01-01.json"
+    artifact_path.write_text(FIXTURE_PATH.read_text())
+    output_dir = tmp_path / "results"
+    result = gr.main(["--input", str(artifact_path), "--output", str(output_dir)])
+    assert result == 0
+
+
+def test_main_file_not_found(gr: ModuleType, tmp_path: Path) -> None:
+    missing = tmp_path / "nonexistent.json"
+    result = gr.main(["--input", str(missing), "--output", str(tmp_path)])
+    assert result == 1
+
+
+def test_main_bad_json(gr: ModuleType, tmp_path: Path) -> None:
+    bad_file = tmp_path / "bad.json"
+    bad_file.write_text("this is not json {{{{")
+    result = gr.main(["--input", str(bad_file), "--output", str(tmp_path)])
+    assert result == 1
+
+
+# ── _market_regime tests ────────────────────────────────────────────────────────
+
+
+def test_market_regime_bullish(gr: ModuleType) -> None:
+    assert gr._market_regime([65.0, 70.0, 80.0]) == "Bullish"
+
+
+def test_market_regime_neutral(gr: ModuleType) -> None:
+    assert gr._market_regime([50.0, 55.0, 60.0]) == "Neutral"
+
+
+def test_market_regime_bearish(gr: ModuleType) -> None:
+    assert gr._market_regime([20.0, 30.0, 40.0]) == "Bearish"
+
+
+def test_market_regime_empty(gr: ModuleType) -> None:
+    assert gr._market_regime([]) == "Unavailable"
+
+
+def test_market_regime_single_bullish(gr: ModuleType) -> None:
+    assert gr._market_regime([66.0]) == "Bullish"
+
+
+def test_market_regime_single_bearish(gr: ModuleType) -> None:
+    assert gr._market_regime([39.0]) == "Bearish"
+
+
+def test_market_regime_boundary_neutral_low(gr: ModuleType) -> None:
+    # exactly 40.0 is Bearish (<=40.0)
+    assert gr._market_regime([40.0]) == "Bearish"
+
+
+def test_market_regime_boundary_neutral_high(gr: ModuleType) -> None:
+    # exactly 65.0 is Bullish (>=65.0)
+    assert gr._market_regime([65.0]) == "Bullish"
+
+
+# ── _format_pct tests ───────────────────────────────────────────────────────────
+
+
+def test_format_pct_none(gr: ModuleType) -> None:
+    assert gr._format_pct(None) == "n/a"
+
+
+def test_format_pct_positive(gr: ModuleType) -> None:
+    assert gr._format_pct(0.053) == "+5.3%"
+
+
+def test_format_pct_negative(gr: ModuleType) -> None:
+    assert gr._format_pct(-0.042) == "-4.2%"
+
+
+def test_format_pct_zero(gr: ModuleType) -> None:
+    assert gr._format_pct(0.0) == "+0.0%"
+
+
+# ── _instrument_table edge cases ────────────────────────────────────────────────
+
+
+def test_instrument_table_empty(gr: ModuleType) -> None:
+    result = gr._section_instrument_scores([])
+    assert "| Rank | Symbol | Score | Reliable | Risk Gates | Explanation |" in result
+    assert "| ---: | ------ | ----: | :------: | ---------- | ----------- |" in result
+
+
+# ── _freshness_table edge cases ─────────────────────────────────────────────────
+
+
+def test_freshness_table_empty(gr: ModuleType) -> None:
+    result = gr._section_data_freshness("stooq", {})
+    assert "_No freshness data available._" in result
+
+
+# ── _toml_escape tests ──────────────────────────────────────────────────────────
+
+
+def test_toml_escape_backslash(gr: ModuleType) -> None:
+    assert gr._toml_escape("a\\b") == "a\\\\b"
+
+
+def test_toml_escape_quote(gr: ModuleType) -> None:
+    assert gr._toml_escape('a"b') == 'a\\"b'
+
+
+def test_toml_escape_both(gr: ModuleType) -> None:
+    assert gr._toml_escape('a\\"b') == 'a\\\\\\"b'
+
+
+# ── Section edge case tests ─────────────────────────────────────────────────────
+
+
+def test_section_top_opportunities_unknown_gate(gr: ModuleType) -> None:
+    result = gr._section_key_risks([
+        {
+            "symbol": "X",
+            "risk_gates": ["custom_gate"],
+            "is_reliable": False,
+        }
+    ])
+    assert "custom_gate" in result
+
+
+def test_section_key_risks_none_gates(gr: ModuleType) -> None:
+    result = gr._section_key_risks([{"symbol": "X", "risk_gates": None}])
+    assert "_No risk gates triggered._" in result
+
+
+def test_section_top_opportunities_with_null_rsi(gr: ModuleType) -> None:
+    reliable = [
+        {
+            "symbol": "AAPL",
+            "rank": 1,
+            "score": 70.0,
+            "is_reliable": True,
+            "risk_gates": [],
+            "explanation": "Strong",
+            "features": {
+                "ret_1d": 0.01,
+                "ret_5d": 0.02,
+                "ret_20d": 0.05,
+                "ret_60d": 0.10,
+                "ma20_dist": 0.02,
+                "ma50_dist": 0.01,
+                "vol_20d": 0.10,
+                "mdd_60d": 0.02,
+                "rsi_14": None,
+                "zscore_20d": 1.0,
+            },
+        }
+    ]
+    result = gr._section_top_opportunities(reliable)
+    assert "RSI14=n/a" in result
+
+
+def test_generate_report_returns_string(
+    gr: ModuleType, fixture_artifact: dict[str, Any]
+) -> None:
+    result = gr.generate_report(fixture_artifact)
+    assert isinstance(result, str)
+    assert "Market Analysis 2024-01-01" in result

--- a/tests/test_generate_report.py
+++ b/tests/test_generate_report.py
@@ -254,8 +254,8 @@ def test_generate_and_save_missing_generated_at(gr: ModuleType, tmp_path: Path) 
     artifact_path = tmp_path / "artifact.json"
     artifact_path.write_text(json.dumps(artifact))
     output_dir = tmp_path / "results"
-    result_path = gr.generate_and_save(artifact_path, output_dir)
-    assert result_path.name == "1970-01-01-market-analysis.md"
+    with pytest.raises(ValueError, match="generated_at"):
+        gr.generate_and_save(artifact_path, output_dir)
 
 
 # ── main() tests ────────────────────────────────────────────────────────────────
@@ -422,3 +422,101 @@ def test_generate_report_returns_string(
     result = gr.generate_report(fixture_artifact)
     assert isinstance(result, str)
     assert "Market Analysis 2024-01-01" in result
+
+
+# ── _validate_for_report tests ──────────────────────────────────────────────────
+
+
+def test_validate_for_report_valid(
+    gr: ModuleType, fixture_artifact: dict[str, Any]
+) -> None:
+    gr._validate_for_report(fixture_artifact)  # must not raise
+
+
+def test_validate_for_report_no_metadata(gr: ModuleType) -> None:
+    with pytest.raises(ValueError, match="metadata"):
+        gr._validate_for_report({"instruments": []})
+
+
+def test_validate_for_report_metadata_not_dict(gr: ModuleType) -> None:
+    with pytest.raises(ValueError, match="metadata"):
+        gr._validate_for_report({"metadata": "bad", "instruments": []})
+
+
+def test_validate_for_report_missing_generated_at(gr: ModuleType) -> None:
+    with pytest.raises(ValueError, match="generated_at"):
+        gr._validate_for_report({"metadata": {}, "instruments": []})
+
+
+def test_validate_for_report_non_string_generated_at(gr: ModuleType) -> None:
+    with pytest.raises(ValueError, match="generated_at"):
+        gr._validate_for_report({
+            "metadata": {"generated_at": 12345},
+            "instruments": [],
+        })
+
+
+def test_validate_for_report_epoch_generated_at(gr: ModuleType) -> None:
+    with pytest.raises(ValueError, match="epoch sentinel"):
+        gr._validate_for_report({
+            "metadata": {"generated_at": "1970-01-01T00:00:00+00:00"},
+            "instruments": [],
+        })
+
+
+def test_validate_for_report_missing_instruments(gr: ModuleType) -> None:
+    with pytest.raises(ValueError, match="instruments"):
+        gr._validate_for_report({
+            "metadata": {"generated_at": "2024-01-01T00:00:00+00:00"}
+        })
+
+
+def test_main_validation_error(gr: ModuleType, tmp_path: Path) -> None:
+    artifact: dict[str, Any] = {
+        "version": "1.0.0",
+        "metadata": {},
+        "instruments": [],
+    }
+    artifact_path = tmp_path / "artifact.json"
+    artifact_path.write_text(json.dumps(artifact))
+    result = gr.main(["--input", str(artifact_path), "--output", str(tmp_path)])
+    assert result == 1
+
+
+def test_generate_report_missing_data_gate(gr: ModuleType) -> None:
+    artifact: dict[str, Any] = {
+        "version": "1.0.0",
+        "metadata": {
+            "generated_at": "2024-06-01T00:00:00+00:00",
+            "git_commit": "abc",
+            "data_source": "stooq",
+            "data_freshness": {"MISS": "n/a"},
+            "scoring_version": "1.0.0",
+            "config": {},
+        },
+        "instruments": [
+            {
+                "symbol": "MISS",
+                "rank": 1,
+                "score": 0.0,
+                "is_reliable": False,
+                "risk_gates": ["missing_data"],
+                "explanation": "Suppressed: missing_data",
+                "features": {
+                    "ret_1d": None,
+                    "ret_5d": None,
+                    "ret_20d": None,
+                    "ret_60d": None,
+                    "ma20_dist": None,
+                    "ma50_dist": None,
+                    "vol_20d": None,
+                    "mdd_60d": None,
+                    "rsi_14": None,
+                    "zscore_20d": None,
+                },
+            }
+        ],
+    }
+    result = gr.generate_report(artifact)
+    assert "Missing data" in result
+    assert "MISS" in result

--- a/tests/test_generate_report.py
+++ b/tests/test_generate_report.py
@@ -319,6 +319,19 @@ def test_market_regime_boundary_neutral_high(gr: ModuleType) -> None:
     assert gr._market_regime([65.0]) == "Bullish"
 
 
+# Even-length median
+def test_market_regime_even_neutral(gr: ModuleType) -> None:
+    assert gr._market_regime([30.0, 70.0]) == "Neutral"  # (30+70)/2=50
+
+
+def test_market_regime_even_bullish(gr: ModuleType) -> None:
+    assert gr._market_regime([64.0, 68.0]) == "Bullish"  # (64+68)/2=66
+
+
+def test_market_regime_even_bearish(gr: ModuleType) -> None:
+    assert gr._market_regime([32.0, 48.0]) == "Bearish"  # (32+48)/2=40
+
+
 # ── _format_pct tests ───────────────────────────────────────────────────────────
 
 

--- a/tests/test_market_analysis.py
+++ b/tests/test_market_analysis.py
@@ -754,6 +754,42 @@ def test_generate_artifact_structure(ma: ModuleType, mocker: MockerFixture) -> N
     assert "A" in meta["data_freshness"]
 
 
+def test_generate_artifact_with_analysis_date(
+    ma: ModuleType, mocker: MockerFixture
+) -> None:
+    mocker.patch.object(ma, "_get_git_commit", return_value="abc")
+    bars = _make_bars(ma, "A", [float(100 + i) for i in range(80)])
+    ref = bars[-1].timestamp + timedelta(days=1)
+    scores = ma.score_instruments({"A": bars}, reference_time=ref)
+    artifact = ma.generate_artifact(scores, {"A": bars}, {}, analysis_date="2024-03-15")
+    assert artifact["metadata"]["generated_at"].startswith("2024-03-15")
+
+
+def test_generate_artifact_with_missing_symbols(
+    ma: ModuleType, mocker: MockerFixture
+) -> None:
+    mocker.patch.object(ma, "_get_git_commit", return_value="abc")
+    bars = _make_bars(ma, "A", [float(100 + i) for i in range(80)])
+    ref = bars[-1].timestamp + timedelta(days=1)
+    scores = ma.score_instruments({"A": bars}, reference_time=ref)
+    artifact = ma.generate_artifact(
+        scores, {"A": bars}, {}, missing_symbols=["MISS1", "MISS2"]
+    )
+    symbols = {inst["symbol"] for inst in artifact["instruments"]}
+    assert "MISS1" in symbols
+    assert "MISS2" in symbols
+    for inst in artifact["instruments"]:
+        if inst["symbol"] in {"MISS1", "MISS2"}:
+            assert inst["is_reliable"] is False
+            assert ma.RISK_GATE_MISSING_DATA in inst["risk_gates"]
+    assert artifact["metadata"]["data_freshness"]["MISS1"] == "n/a"
+    assert artifact["metadata"]["data_freshness"]["MISS2"] == "n/a"
+
+
+def test_risk_gate_missing_data_constant(ma: ModuleType) -> None:
+    assert ma.RISK_GATE_MISSING_DATA == "missing_data"
+
+
 def test_generate_artifact_empty_data_source(
     ma: ModuleType, mocker: MockerFixture
 ) -> None:
@@ -1086,6 +1122,7 @@ def test_cmd_generate_no_data(ma: ModuleType, tmp_path: Path) -> None:
         interval = "d"
         data_dir = str(tmp_path)
         output = str(tmp_path / "analysis")
+        analysis_date = None
 
     result = ma._cmd_generate(Args())
     assert result == 1
@@ -1103,12 +1140,86 @@ def test_cmd_generate_success(
         interval = "d"
         data_dir = str(tmp_path)
         output = str(tmp_path / "analysis")
+        analysis_date = None
 
     result = ma._cmd_generate(Args())
     assert result == 0
     analysis_dir = tmp_path / "analysis"
     json_files = list(analysis_dir.glob("*.json"))
     assert len(json_files) == 1
+
+
+def test_cmd_generate_with_analysis_date(
+    ma: ModuleType, mocker: MockerFixture, tmp_path: Path
+) -> None:
+    mocker.patch.object(ma, "_get_git_commit", return_value="abc")
+    bars = _make_bars(ma, "F", [float(100 + i) for i in range(70)])
+    ma.save_ohlcv(bars, tmp_path)
+
+    class Args:
+        symbols = "F"
+        interval = "d"
+        data_dir = str(tmp_path)
+        output = str(tmp_path / "analysis")
+        analysis_date = "2024-03-15"
+
+    result = ma._cmd_generate(Args())
+    assert result == 0
+    analysis_dir = tmp_path / "analysis"
+    assert (analysis_dir / "2024-03-15.json").exists()
+
+
+def test_cmd_generate_partial_missing_in_artifact(
+    ma: ModuleType,
+    mocker: MockerFixture,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    mocker.patch.object(ma, "_get_git_commit", return_value="abc")
+    bars = _make_bars(ma, "G", [float(100 + i) for i in range(70)])
+    ma.save_ohlcv(bars, tmp_path)
+
+    class Args:
+        symbols = "G,MISSING"
+        interval = "d"
+        data_dir = str(tmp_path)
+        output = str(tmp_path / "analysis")
+        analysis_date = None
+
+    result = ma._cmd_generate(Args())
+    assert result == 0
+    out = capsys.readouterr().out
+    assert "WARNING" in out
+    analysis_dir = tmp_path / "analysis"
+    artifact_files = list(analysis_dir.glob("*.json"))
+    assert len(artifact_files) == 1
+    artifact = json.loads(artifact_files[0].read_text())
+    symbols = {inst["symbol"] for inst in artifact["instruments"]}
+    assert "MISSING" in symbols
+    missing_inst = next(i for i in artifact["instruments"] if i["symbol"] == "MISSING")
+    assert missing_inst["is_reliable"] is False
+    assert ma.RISK_GATE_MISSING_DATA in missing_inst["risk_gates"]
+
+
+def test_main_generate_with_analysis_date(
+    ma: ModuleType, mocker: MockerFixture, tmp_path: Path
+) -> None:
+    mocker.patch.object(ma, "_get_git_commit", return_value="abc")
+    bars = _make_bars(ma, "H", [float(100 + i) for i in range(70)])
+    ma.save_ohlcv(bars, tmp_path)
+    result = ma.main([
+        "generate",
+        "--symbols",
+        "H",
+        "--data-dir",
+        str(tmp_path),
+        "--output",
+        str(tmp_path / "analysis"),
+        "--analysis-date",
+        "2024-05-01",
+    ])
+    assert result == 0
+    assert (tmp_path / "analysis" / "2024-05-01.json").exists()
 
 
 # ── CLI: main routing ─────────────────────────────────────────────────────────

--- a/tests/test_market_analysis.py
+++ b/tests/test_market_analysis.py
@@ -1303,3 +1303,60 @@ def test_main_routes_generate(ma: ModuleType, mocker: MockerFixture) -> None:
     )
     ma.main()
     assert called == ["generate"]
+
+
+def test_cmd_generate_analysis_date_as_reference_time(
+    ma: ModuleType, mocker: MockerFixture, tmp_path: Path
+) -> None:
+    """Bars fresh relative to analysis_date must be reliable.
+
+    analysis_date controls reference_time: bars that would be stale
+    relative to today but fresh relative to analysis_date must be reliable.
+    """
+    mocker.patch.object(ma, "_get_git_commit", return_value="abc")
+    # 70 bars ending exactly on analysis_date
+    analysis_dt = datetime(2024, 1, 5, tzinfo=UTC)
+    base_dt = analysis_dt - timedelta(days=68)
+    bars = _make_bars(ma, "REF", [float(100 + i) for i in range(70)], start=base_dt)
+    ma.save_ohlcv(bars, tmp_path)
+
+    class Args:
+        symbols = "REF"
+        interval = "d"
+        data_dir = str(tmp_path)
+        output = str(tmp_path / "analysis")
+        analysis_date = "2024-01-05"
+
+    result = ma._cmd_generate(Args())
+    assert result == 0
+    artifact = json.loads((tmp_path / "analysis" / "2024-01-05.json").read_text())
+    inst = next(i for i in artifact["instruments"] if i["symbol"] == "REF")
+    # With reference_time = analysis_date, bars are fresh → reliable
+    assert inst["is_reliable"] is True
+    assert ma.RISK_GATE_STALE not in inst["risk_gates"]
+
+
+def test_cmd_generate_no_analysis_date_may_mark_stale(
+    ma: ModuleType, mocker: MockerFixture, tmp_path: Path
+) -> None:
+    """Without analysis_date, old bars are marked stale by today's date."""
+    mocker.patch.object(ma, "_get_git_commit", return_value="abc")
+    # very old bars from 2020
+    old_base = datetime(2020, 1, 1, tzinfo=UTC)
+    bars = _make_bars(ma, "STALE", [float(100 + i) for i in range(70)], start=old_base)
+    ma.save_ohlcv(bars, tmp_path)
+
+    class Args:
+        symbols = "STALE"
+        interval = "d"
+        data_dir = str(tmp_path)
+        output = str(tmp_path / "analysis")
+        analysis_date = None
+
+    result = ma._cmd_generate(Args())
+    assert result == 0
+    files = list((tmp_path / "analysis").glob("*.json"))
+    artifact = json.loads(files[0].read_text())
+    inst = next(i for i in artifact["instruments"] if i["symbol"] == "STALE")
+    # Without reference_time fix, old bars stale relative to today
+    assert ma.RISK_GATE_STALE in inst["risk_gates"]

--- a/tests/test_notify_slack.py
+++ b/tests/test_notify_slack.py
@@ -1,0 +1,420 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock, patch
+from urllib.error import URLError
+
+import pytest
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / ".agents"
+    / "skills"
+    / "market-analysis"
+    / "scripts"
+    / "notify_slack.py"
+)
+
+FIXTURE_PATH = Path(__file__).resolve().parent / "fixtures" / "analysis_2024-01-01.json"
+
+
+@pytest.fixture(scope="module")
+def ns() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("notify_slack", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        pytest.fail("Failed to load notify_slack.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def fixture_artifact() -> dict[str, Any]:
+    with FIXTURE_PATH.open() as fh:
+        return json.load(fh)
+
+
+# ── _market_regime tests ────────────────────────────────────────────────────────
+
+
+def test_notify_market_regime_bullish(ns: ModuleType) -> None:
+    assert ns._market_regime([65.0, 75.0]) == "Bullish"
+
+
+def test_notify_market_regime_neutral(ns: ModuleType) -> None:
+    assert ns._market_regime([50.0]) == "Neutral"
+
+
+def test_notify_market_regime_bearish(ns: ModuleType) -> None:
+    assert ns._market_regime([30.0]) == "Bearish"
+
+
+def test_notify_market_regime_empty(ns: ModuleType) -> None:
+    assert ns._market_regime([]) == "Unavailable"
+
+
+# ── build_success_payload tests ─────────────────────────────────────────────────
+
+
+def test_build_success_payload(
+    ns: ModuleType, fixture_artifact: dict[str, Any]
+) -> None:
+    payload = ns.build_success_payload(fixture_artifact, "https://example.com/report/")
+    assert "text" in payload
+    assert "blocks" in payload
+    text = payload["text"]
+    assert "2024-01-01" in text
+    assert "Bullish" in text
+
+
+def test_build_success_payload_regime_in_blocks(
+    ns: ModuleType, fixture_artifact: dict[str, Any]
+) -> None:
+    payload = ns.build_success_payload(fixture_artifact, "https://example.com/")
+    blocks = payload["blocks"]
+    # Find a field containing regime
+    fields_text = json.dumps(blocks, ensure_ascii=False)
+    assert "Bullish" in fields_text
+    assert "^SPX" in fields_text
+
+
+def test_build_success_payload_stale_warning(
+    ns: ModuleType, fixture_artifact: dict[str, Any]
+) -> None:
+    payload = ns.build_success_payload(fixture_artifact, "https://example.com/")
+    fields_text = json.dumps(payload["blocks"], ensure_ascii=False)
+    assert "^NDX" in fields_text
+
+
+def test_build_success_payload_no_reliable(ns: ModuleType) -> None:
+    artifact: dict[str, Any] = {
+        "version": "1.0.0",
+        "metadata": {
+            "generated_at": "2024-01-15T00:00:00+00:00",
+            "git_commit": "abc",
+            "data_source": "stooq",
+            "data_freshness": {},
+            "scoring_version": "1.0.0",
+            "config": {},
+        },
+        "instruments": [
+            {
+                "symbol": "BAD",
+                "rank": 1,
+                "score": 20.0,
+                "is_reliable": False,
+                "risk_gates": ["stale_data"],
+                "explanation": "Suppressed",
+                "features": {},
+            }
+        ],
+    }
+    payload = ns.build_success_payload(artifact, "https://example.com/")
+    assert "text" in payload
+    assert isinstance(payload["blocks"], list)
+
+
+def test_build_success_payload_no_stale(ns: ModuleType) -> None:
+    artifact: dict[str, Any] = {
+        "version": "1.0.0",
+        "metadata": {
+            "generated_at": "2024-01-01T00:00:00+00:00",
+            "git_commit": "abc",
+            "data_source": "stooq",
+            "data_freshness": {"AAPL": "2024-01-01"},
+            "scoring_version": "1.0.0",
+            "config": {},
+        },
+        "instruments": [
+            {
+                "symbol": "AAPL",
+                "rank": 1,
+                "score": 70.0,
+                "is_reliable": True,
+                "risk_gates": [],
+                "explanation": "Good",
+                "features": {"rsi_14": 60.0},
+            }
+        ],
+    }
+    payload = ns.build_success_payload(artifact, "https://example.com/")
+    fields_text = json.dumps(payload, ensure_ascii=False)
+    assert "No data" not in fields_text
+
+
+def test_build_success_payload_non_string_generated_at(ns: ModuleType) -> None:
+    artifact: dict[str, Any] = {
+        "version": "1.0.0",
+        "metadata": {
+            "generated_at": 12345,
+            "data_source": "stooq",
+            "data_freshness": {},
+            "scoring_version": "1.0.0",
+            "git_commit": "abc",
+        },
+        "instruments": [],
+    }
+    payload = ns.build_success_payload(artifact, "https://example.com/")
+    assert "text" in payload
+    assert "n/a" in payload["text"]
+
+
+def test_build_success_payload_bullish_emoji(
+    ns: ModuleType, fixture_artifact: dict[str, Any]
+) -> None:
+    payload = ns.build_success_payload(fixture_artifact, "https://example.com/")
+    fields_text = json.dumps(payload, ensure_ascii=False)
+    assert "📈" in fields_text
+
+
+def test_build_success_payload_neutral_emoji(ns: ModuleType) -> None:
+    artifact: dict[str, Any] = {
+        "version": "1.0.0",
+        "metadata": {
+            "generated_at": "2024-01-01T00:00:00+00:00",
+            "data_source": "stooq",
+            "data_freshness": {},
+            "scoring_version": "1.0.0",
+            "git_commit": "abc",
+        },
+        "instruments": [
+            {
+                "symbol": "AAPL",
+                "rank": 1,
+                "score": 55.0,
+                "is_reliable": True,
+                "risk_gates": [],
+                "explanation": "Neutral",
+                "features": {},
+            }
+        ],
+    }
+    payload = ns.build_success_payload(artifact, "https://example.com/")
+    fields_text = json.dumps(payload, ensure_ascii=False)
+    assert "➡️" in fields_text
+
+
+def test_build_success_payload_bearish_emoji(ns: ModuleType) -> None:
+    artifact: dict[str, Any] = {
+        "version": "1.0.0",
+        "metadata": {
+            "generated_at": "2024-01-01T00:00:00+00:00",
+            "data_source": "stooq",
+            "data_freshness": {},
+            "scoring_version": "1.0.0",
+            "git_commit": "abc",
+        },
+        "instruments": [
+            {
+                "symbol": "BAD",
+                "rank": 1,
+                "score": 25.0,
+                "is_reliable": True,
+                "risk_gates": [],
+                "explanation": "Bearish",
+                "features": {},
+            }
+        ],
+    }
+    payload = ns.build_success_payload(artifact, "https://example.com/")
+    fields_text = json.dumps(payload, ensure_ascii=False)
+    assert "📉" in fields_text
+
+
+def test_build_success_payload_unavailable_emoji(ns: ModuleType) -> None:
+    artifact: dict[str, Any] = {
+        "version": "1.0.0",
+        "metadata": {
+            "generated_at": "2024-01-01T00:00:00+00:00",
+            "data_source": "stooq",
+            "data_freshness": {},
+            "scoring_version": "1.0.0",
+            "git_commit": "abc",
+        },
+        "instruments": [],
+    }
+    payload = ns.build_success_payload(artifact, "https://example.com/")
+    fields_text = json.dumps(payload, ensure_ascii=False)
+    assert "❓" in fields_text
+
+
+# ── build_failure_payload tests ─────────────────────────────────────────────────
+
+
+def test_build_failure_payload(ns: ModuleType) -> None:
+    payload = ns.build_failure_payload("https://github.com/actions/runs/12345")
+    assert "text" in payload
+    assert "❌" in payload["text"]
+    assert "https://github.com/actions/runs/12345" in json.dumps(
+        payload["blocks"], ensure_ascii=False
+    )
+
+
+def test_build_failure_payload_custom_message(ns: ModuleType) -> None:
+    payload = ns.build_failure_payload(
+        "https://example.com/run", "Custom failure message"
+    )
+    assert "Custom failure message" in payload["text"]
+
+
+# ── send_notification tests ─────────────────────────────────────────────────────
+
+
+def test_send_notification_success(ns: ModuleType) -> None:
+    mock_response = MagicMock()
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=False)
+    mock_response.status = 200
+
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        ns.send_notification("https://hooks.slack.com/test", {"text": "hello"})
+
+
+def test_send_notification_url_error(ns: ModuleType) -> None:
+    with (
+        patch("urllib.request.urlopen", side_effect=URLError("connection refused")),
+        pytest.raises(URLError),
+    ):
+        ns.send_notification("https://hooks.slack.com/test", {"text": "hello"})
+
+
+# ── main() tests ────────────────────────────────────────────────────────────────
+
+
+def test_main_no_webhook(ns: ModuleType, capsys: pytest.CaptureFixture[str]) -> None:
+    env: dict[str, str] = {}
+    with patch.dict("os.environ", env, clear=True):
+        result = ns.main(["--report-url", "https://example.com/"])
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "SLACK_WEBHOOK_URL" in captured.out
+
+
+def test_main_success_mode(ns: ModuleType, tmp_path: Path) -> None:
+    artifact_path = tmp_path / "artifact.json"
+    with FIXTURE_PATH.open() as fh:
+        data = json.load(fh)
+    artifact_path.write_text(json.dumps(data))
+
+    mock_response = MagicMock()
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch.dict("os.environ", {"SLACK_WEBHOOK_URL": "https://hooks.slack.com/test"}),
+        patch("urllib.request.urlopen", return_value=mock_response),
+    ):
+        result = ns.main([
+            "--artifact",
+            str(artifact_path),
+            "--report-url",
+            "https://example.com/report/",
+        ])
+    assert result == 0
+
+
+def test_main_failure_mode(ns: ModuleType) -> None:
+    mock_response = MagicMock()
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch.dict("os.environ", {"SLACK_WEBHOOK_URL": "https://hooks.slack.com/test"}),
+        patch("urllib.request.urlopen", return_value=mock_response),
+    ):
+        result = ns.main([
+            "--failure",
+            "--run-url",
+            "https://github.com/actions/runs/99",
+            "--message",
+            "Pipeline failed",
+        ])
+    assert result == 0
+
+
+def test_main_url_error(ns: ModuleType, tmp_path: Path) -> None:
+    artifact_path = tmp_path / "artifact.json"
+    with FIXTURE_PATH.open() as fh:
+        data = json.load(fh)
+    artifact_path.write_text(json.dumps(data))
+
+    with (
+        patch.dict("os.environ", {"SLACK_WEBHOOK_URL": "https://hooks.slack.com/test"}),
+        patch("urllib.request.urlopen", side_effect=URLError("err")),
+    ):
+        result = ns.main([
+            "--artifact",
+            str(artifact_path),
+            "--report-url",
+            "https://example.com/",
+        ])
+    assert result == 1
+
+
+def test_main_success_missing_artifact(ns: ModuleType) -> None:
+    with patch.dict(
+        "os.environ", {"SLACK_WEBHOOK_URL": "https://hooks.slack.com/test"}
+    ):
+        result = ns.main(["--report-url", "https://example.com/"])
+    assert result == 1
+
+
+def test_main_success_artifact_not_found(ns: ModuleType, tmp_path: Path) -> None:
+    missing = tmp_path / "nonexistent.json"
+    with patch.dict(
+        "os.environ", {"SLACK_WEBHOOK_URL": "https://hooks.slack.com/test"}
+    ):
+        result = ns.main([
+            "--artifact",
+            str(missing),
+            "--report-url",
+            "https://example.com/",
+        ])
+    assert result == 1
+
+
+def test_main_success_bad_json(ns: ModuleType, tmp_path: Path) -> None:
+    bad_file = tmp_path / "bad.json"
+    bad_file.write_text("not json {{")
+    with patch.dict(
+        "os.environ", {"SLACK_WEBHOOK_URL": "https://hooks.slack.com/test"}
+    ):
+        result = ns.main([
+            "--artifact",
+            str(bad_file),
+            "--report-url",
+            "https://example.com/",
+        ])
+    assert result == 1
+
+
+def test_main_failure_mode_no_run_url(ns: ModuleType) -> None:
+    mock_response = MagicMock()
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch.dict("os.environ", {"SLACK_WEBHOOK_URL": "https://hooks.slack.com/test"}),
+        patch("urllib.request.urlopen", return_value=mock_response),
+    ):
+        result = ns.main(["--failure"])
+    assert result == 0
+
+
+# ── SAMPLE_PAYLOAD constants ────────────────────────────────────────────────────
+
+
+def test_sample_payloads(ns: ModuleType) -> None:
+    assert isinstance(ns.SAMPLE_SUCCESS_PAYLOAD, dict)
+    assert "text" in ns.SAMPLE_SUCCESS_PAYLOAD
+    assert isinstance(ns.SAMPLE_FAILURE_PAYLOAD, dict)
+    assert "text" in ns.SAMPLE_FAILURE_PAYLOAD

--- a/tests/test_notify_slack.py
+++ b/tests/test_notify_slack.py
@@ -62,6 +62,11 @@ def test_notify_market_regime_empty(ns: ModuleType) -> None:
     assert ns._market_regime([]) == "Unavailable"
 
 
+# Even-length median
+def test_notify_market_regime_even_neutral(ns: ModuleType) -> None:
+    assert ns._market_regime([30.0, 70.0]) == "Neutral"
+
+
 # ── build_success_payload tests ─────────────────────────────────────────────────
 
 
@@ -407,6 +412,62 @@ def test_main_failure_mode_no_run_url(ns: ModuleType) -> None:
         patch("urllib.request.urlopen", return_value=mock_response),
     ):
         result = ns.main(["--failure"])
+    assert result == 0
+
+
+def test_build_success_payload_with_pr_url(
+    ns: ModuleType, fixture_artifact: dict[str, Any]
+) -> None:
+    payload = ns.build_success_payload(
+        fixture_artifact, pr_url="https://github.com/dceoy/aims/pull/99"
+    )
+    fields_text = json.dumps(payload, ensure_ascii=False)
+    assert "View PR" in fields_text
+    assert "Analysis PR created" in payload["text"]
+    assert "https://github.com/dceoy/aims/pull/99" in fields_text
+
+
+def test_build_success_payload_pr_url_overrides_report_url(
+    ns: ModuleType, fixture_artifact: dict[str, Any]
+) -> None:
+    payload = ns.build_success_payload(
+        fixture_artifact,
+        "https://example.com/report/",
+        pr_url="https://github.com/dceoy/aims/pull/99",
+    )
+    fields_text = json.dumps(payload, ensure_ascii=False)
+    assert "View PR" in fields_text
+    assert "https://github.com/dceoy/aims/pull/99" in fields_text
+    assert "https://example.com/report/" not in fields_text
+
+
+def test_build_success_payload_no_urls_omits_actions_block(
+    ns: ModuleType, fixture_artifact: dict[str, Any]
+) -> None:
+    payload = ns.build_success_payload(fixture_artifact)
+    # no actions block since no url provided
+    block_types = [b["type"] for b in payload["blocks"]]
+    assert "actions" not in block_types
+
+
+def test_main_success_with_pr_url(ns: ModuleType, tmp_path: Path) -> None:
+    artifact_path = tmp_path / "artifact.json"
+    with FIXTURE_PATH.open() as fh:
+        data = json.load(fh)
+    artifact_path.write_text(json.dumps(data))
+    mock_response = MagicMock()
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=False)
+    with (
+        patch.dict("os.environ", {"SLACK_WEBHOOK_URL": "https://hooks.slack.com/test"}),
+        patch("urllib.request.urlopen", return_value=mock_response),
+    ):
+        result = ns.main([
+            "--artifact",
+            str(artifact_path),
+            "--pr-url",
+            "https://github.com/dceoy/aims/pull/99",
+        ])
     assert result == 0
 
 


### PR DESCRIPTION
Issue #31 (p4) — Hugo Markdown report generation:
- Add generate_report.py: deterministic generator from analysis JSON artifact
- Produces Hugo-compatible Markdown under content/results/ with TOML front matter,
  market regime, top opportunities, avoid list, key risks, instrument table,
  data freshness, methodology, and financial disclaimer
- Add tests/fixtures/analysis_2024-01-01.json fixture and
  tests/golden/2024-01-01-market-analysis.md golden file
- Add tests/test_generate_report.py with 100% coverage

Issue #32 (p5) — Daily market analysis workflow:
- Add .github/workflows/daily-market-analysis.yml: runs at 01:00 UTC daily
- Supports workflow_dispatch with analysis_date, interval, and dry_run inputs
- Pipeline: validate instruments → fetch data → generate artifact → validate →
  generate Hugo report → build Hugo → commit → notify Slack
- Pushes to main; existing ci.yml deploys to GitHub Pages

Issue #33 (p5) — Slack notification:
- Add notify_slack.py: success and failure notifications via incoming webhook
- Reads SLACK_WEBHOOK_URL from env; exits 0 silently when not set
- Add tests/test_notify_slack.py with 100% coverage
- data/stooq_symbols.txt: default Stooq symbols for daily analysis

Issue #34 (p6) — Documentation and operations:
- Add OPERATIONS.md: data sources, scoring methodology, report generation,
  publication workflow, secrets, permissions, troubleshooting, manual recovery
- Update README.md to reference OPERATIONS.md
- Update .agents/skills/market-analysis/SKILL.md with new script usage

https://claude.ai/code/session_01EobYpkykUuXNwzTxSJPkc7