### PR TITLE
feat: add AGENTS.md for AI coding agents

### DIFF
--- a/.agents/skills/local-qa/scripts/qa.sh
+++ b/.agents/skills/local-qa/scripts/qa.sh
@@ -30,7 +30,7 @@ hugo --gc --minify
 # GitHub Actions
 case "${OSTYPE}" in
   darwin* | linux* )
-    zizmor --fix=safe .github/workflows
+    zizmor --min-severity low --fix=safe .github/workflows
     if [ -n "$(git ls-files '.github/workflows/*.yml' '.github/workflows/*.yaml')" ]; then
       git ls-files -z -- '.github/workflows/*.yml' '.github/workflows/*.yaml' | xargs -0 -t actionlint
       git ls-files -z -- '.github/workflows/*.yml' '.github/workflows/*.yaml' | xargs -0 -t yamllint -d '{"extends": "relaxed", "rules": {"line-length": "disable"}}'

--- a/.agents/skills/local-qa/scripts/qa.sh
+++ b/.agents/skills/local-qa/scripts/qa.sh
@@ -30,7 +30,7 @@ hugo --gc --minify
 # GitHub Actions
 case "${OSTYPE}" in
   darwin* | linux* )
-    zizmor --min-severity low --fix=safe .github/workflows
+    zizmor --fix=safe .github/workflows
     if [ -n "$(git ls-files '.github/workflows/*.yml' '.github/workflows/*.yaml')" ]; then
       git ls-files -z -- '.github/workflows/*.yml' '.github/workflows/*.yaml' | xargs -0 -t actionlint
       git ls-files -z -- '.github/workflows/*.yml' '.github/workflows/*.yaml' | xargs -0 -t yamllint -d '{"extends": "relaxed", "rules": {"line-length": "disable"}}'

--- a/.agents/skills/market-analysis/scripts/generate_report.py
+++ b/.agents/skills/market-analysis/scripts/generate_report.py
@@ -12,7 +12,9 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
-from typing import Any, Final
+from typing import Any, Final, Literal
+
+_Alignment = Literal["left", "right", "center"]
 
 _DEFAULT_OUTPUT_DIR: Final[Path] = Path("content/results")
 
@@ -165,6 +167,53 @@ def _section_instruments_to_avoid(unreliable: list[dict[str, Any]]) -> str:
     return f"{header}\n\n{preamble}\n\n" + "\n".join(lines)
 
 
+def _format_markdown_table(
+    headers: list[str],
+    rows: list[list[str]],
+    alignments: list[_Alignment],
+) -> str:
+    """Format a markdown table with column padding matching Prettier."""
+    widths = [max(len(row[i]) for row in [headers, *rows]) for i in range(len(headers))]
+
+    def _pad_cell(value: str, width: int, align: _Alignment) -> str:
+        if align == "right":
+            inner = value.rjust(width)
+        elif align == "center":
+            inner = value.center(width)
+        else:
+            inner = value.ljust(width)
+        return f" {inner} "
+
+    def _pad_sep(width: int, align: _Alignment) -> str:
+        if align == "right":
+            inner = "-" * (width - 1) + ":" if width > 1 else ":"
+        elif align == "center":
+            inner = ":" + "-" * max(width - 2, 1) + ":"
+        else:
+            inner = "-" * width
+        return f" {inner} "
+
+    lines = [
+        "|"
+        + "|".join(
+            _pad_cell(h, widths[i], alignments[i]) for i, h in enumerate(headers)
+        )
+        + "|",
+        "|"
+        + "|".join(_pad_sep(widths[i], alignments[i]) for i in range(len(headers)))
+        + "|",
+    ]
+    lines.extend(
+        "|"
+        + "|".join(
+            _pad_cell(row[i], widths[i], alignments[i]) for i in range(len(headers))
+        )
+        + "|"
+        for row in rows
+    )
+    return "\n".join(lines)
+
+
 def _section_key_risks(instruments: list[dict[str, Any]]) -> str:
     header = "## Key Risks"
     gate_counts: dict[str, int] = {}
@@ -184,9 +233,23 @@ def _section_key_risks(instruments: list[dict[str, Any]]) -> str:
 
 def _section_instrument_scores(instruments: list[dict[str, Any]]) -> str:
     header = "## Instrument Scores"
-    col_header = "| Rank | Symbol | Score | Reliable | Risk Gates | Explanation |"
-    col_sep = "| ---: | ------ | ----: | :------: | ---------- | ----------- |"
-    rows = [col_header, col_sep]
+    table_headers = [
+        "Rank",
+        "Symbol",
+        "Score",
+        "Reliable",
+        "Risk Gates",
+        "Explanation",
+    ]
+    alignments: list[_Alignment] = [
+        "right",
+        "left",
+        "right",
+        "center",
+        "left",
+        "left",
+    ]
+    rows: list[list[str]] = []
     for inst in instruments:
         rank = inst.get("rank", "")
         symbol = str(inst.get("symbol", ""))
@@ -195,11 +258,16 @@ def _section_instrument_scores(instruments: list[dict[str, Any]]) -> str:
         gates = inst.get("risk_gates") or []
         gates_str = ", ".join(str(g) for g in gates) if gates else "—"
         explanation = str(inst.get("explanation", ""))
-        rows.append(
-            f"| {rank} | {symbol} | {score:.1f} | {reliable} |"
-            f" {gates_str} | {explanation} |"
-        )
-    return f"{header}\n\n" + "\n".join(rows)
+        rows.append([
+            str(rank),
+            symbol,
+            f"{score:.1f}",
+            reliable,
+            gates_str,
+            explanation,
+        ])
+    table = _format_markdown_table(table_headers, rows, alignments)
+    return f"{header}\n\n{table}"
 
 
 def _section_data_freshness(
@@ -210,14 +278,14 @@ def _section_data_freshness(
     parts: list[str] = [f"Data source: **{data_source}**"]
 
     if freshness:
-        table_rows = ["| Symbol | Latest Bar |", "| ------ | ---------- |"]
+        table_headers = ["Symbol", "Latest Bar"]
+        alignments: list[_Alignment] = ["left", "left"]
+        table_rows = [[sym, freshness[sym]] for sym in sorted(freshness)]
         stale_symbols = []
-        for sym in sorted(freshness):
-            val = freshness[sym]
-            table_rows.append(f"| {sym} | {val} |")
+        for sym, val in table_rows:
             if val == "n/a":
                 stale_symbols.append(sym)
-        parts.append("\n".join(table_rows))
+        parts.append(_format_markdown_table(table_headers, table_rows, alignments))
         if stale_symbols:
             stale_joined = ", ".join(sorted(stale_symbols))
             n = len(stale_symbols)

--- a/.agents/skills/pr-feedback-triage/SKILL.md
+++ b/.agents/skills/pr-feedback-triage/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: pr-feedback-triage
+description: Triage pull request review comments into fixes, replies, clarification requests, or open follow-ups while respecting safe execution modes.
+---
+
+# PR Feedback Triage
+
+Triage pull request review feedback, decide what action each thread needs, make focused fixes when allowed, and report or resolve only what is actually handled.
+
+## When to Use
+
+- A PR has review comments, requested changes, unresolved review threads, or bot review findings.
+- The user asks to address, respond to, or resolve PR feedback.
+- The user provides a PR URL/number, a branch with an associated PR, or copied comments.
+
+Do not use this skill for a first-pass code review with no existing feedback; use a code review skill instead.
+
+## Inputs
+
+- Pull request URL or number, or a current branch that has an associated pull request.
+- Repository checkout or platform access sufficient to inspect the PR diff and review feedback.
+- Optional reviewer priorities from the user, such as "only address blocking comments" or "do not reply on the PR platform".
+- Optional operating mode flags: `dry_run`, `no_push`, and `no_reply`.
+
+If no PR or review comments are identifiable, ask for the target PR or the copied comments before proceeding.
+
+## Modes
+
+- `dry_run`: inspect review feedback and report the triage only. Do not edit files, run write-mode formatters, commit, push, post replies, or resolve review threads.
+- `no_push`: local edits and verification are allowed, but do not push commits or otherwise update the remote branch. Report the local diff or local commits that still need to be pushed.
+- `no_reply`: do not post replies, submit reviews, or resolve review threads. Provide suggested replies and resolution actions in the final report instead.
+
+When a mode disables an action, skip that destructive or externally visible action even if normal workflow text would otherwise allow it.
+
+## Preflight
+
+1. Identify the current branch and target PR.
+2. Check tracked local changes with `git diff --name-only` and `git diff --cached --name-only`. Ignore untracked files unless the review feedback explicitly concerns them.
+3. Check unpushed commits before relying on remote review feedback.
+4. If tracked local changes or unpushed commits exist, warn that existing PR comments may not cover the latest local state. In `normal` mode, push only when the user request or repository workflow allows it; otherwise continue with a clearly reported limitation.
+
+## Feedback Collection
+
+Gather the complete feedback set before editing:
+
+- Fetch unresolved review threads, requested-change reviews, PR-level summary comments, and copied comments.
+- Use platform-native APIs/CLI when available. Paginate results; do not inspect only the first page of threads or comments.
+- For bot reviewers that post both summary comments and inline comments, collect both. Summary comments often contain severity, rationale, and fix instructions; inline comments contain the exact file and line context.
+- Preserve each thread/comment identifier needed to reply or resolve later.
+- Compare each comment with the current diff and file contents because review lines can become outdated.
+
+## Deduplication and Ordering
+
+Build one triage record per distinct finding:
+
+- Prefer exact review-thread identity when available.
+- For duplicate bot findings appearing in both summary and inline comments, merge by exact issue title first, then by file path plus line range as a fallback.
+- Prefer inline comments for location and current code context.
+- Prefer summary comments for severity, category, rationale, and detailed agent prompts.
+- Preserve the reviewer’s exact issue title and original wording where practical. Do not rename findings in a way that would make replies hard to map back to comments.
+- Preserve the reviewer’s original ordering unless the user asks for priority reordering. Many review bots already order findings by severity.
+
+Each triage record should track: original title, reviewer, source IDs, location, current applicability, severity/priority if available, disposition, planned action, verification, reply text if any, and resolution decision.
+
+## Resolution Policy
+
+In normal mode, `Resolve conversation` is the default action for any review thread that has been fully handled. A thread is handled when the requested change is implemented and verified, the current code already satisfies the comment, the comment is outdated and no longer applies, or a deliberate deferral/won't-fix response has been posted with a clear reason.
+
+Keep a thread open only when it still needs reviewer, maintainer, or product input, the fix is local-only and not pushed, verification is missing for a material change, or the user explicitly requested `dry_run`, `no_push`, or `no_reply` behavior that prevents resolution.
+
+When resolving a thread, add a concise reply first only if it provides useful context, such as what changed, why no code change was needed, why a finding was intentionally deferred, or why the original comment is now outdated. Do not add noisy replies for self-evident fixes unless project norms require them.
+
+## Flow
+
+```mermaid
+flowchart TD
+  A[Identify PR and branch state] --> B[Collect all review feedback]
+  B --> C[Deduplicate and preserve source IDs]
+  C --> D[Inspect current diff and code]
+  D --> E{Classify each triage record}
+  E -->|Fix| F[Implement minimal change]
+  E -->|Answer| G[Prepare concise reply]
+  E -->|Clarify| H[Leave open with question]
+  E -->|Already addressed or Outdated| I[Prepare evidence]
+  E -->|Defer or Won't fix| J[Document reason]
+  F --> K[Verify]
+  G --> L{Mode}
+  H --> L
+  I --> L
+  J --> L
+  K --> L
+  L -->|dry_run| M[Report triage only]
+  L -->|no_push| N[Report local diff or commits]
+  L -->|no_reply| O[Report suggested replies/actions]
+  L -->|normal| P[Commit/push if changed, then batch reply and resolve handled threads]
+  M --> Q[Final summary]
+  N --> Q
+  O --> Q
+  P --> Q
+```
+
+## Compact Workflow
+
+1. **Collect all relevant feedback**
+   - Identify the PR and gather unresolved review threads, requested-change reviews, PR-level summaries, inline comments, and copied comments.
+   - Paginate all platform calls and keep comment/thread IDs for later replies and resolution.
+   - For bot reviews, collect both summary and inline comments, then merge duplicates rather than fixing the same finding twice.
+
+2. **Classify each triage record**
+   - **Fix**: Valid requested change; make the smallest focused edit when not in `dry_run`.
+   - **Answer**: No code change needed; prepare a concise explanation.
+   - **Clarify**: Ambiguous, conflicting, or missing context; leave open with a question.
+   - **Already addressed**: Current code already satisfies it; prepare evidence.
+   - **Outdated**: Commented code or issue no longer exists; prepare evidence.
+   - **Defer / Won't fix**: Valid concern intentionally not changed now; document a specific reason.
+
+3. **Act according to the classification and mode**
+   - Keep edits scoped to the review feedback.
+   - Follow reviewer-provided fix instructions literally when they are still applicable; deviate only when the current code proves the instruction is stale or unsafe.
+   - In `dry_run`, stop at triage, proposed fixes, suggested replies, and verification plan.
+   - In `no_push`, local edits are allowed, but do not push or resolve threads for local-only fixes.
+   - In `no_reply`, do not post replies or resolve threads; report suggested replies/actions instead.
+   - In normal mode, batch replies where practical, then resolve every handled thread by default after the fix, explanation, or deferral reason is available on the PR.
+
+4. **Verify before claiming completion**
+   - For fixes, run appropriate checks or explain why they could not run.
+   - Re-inspect the updated diff and comment context to confirm the concern is resolved.
+   - Do not mark a thread resolved if it still needs reviewer, maintainer, or product input.
+
+5. **Finish**
+   - Normal mode: commit/push changes when appropriate, post useful replies or a summary, and resolve all handled threads by default.
+   - Safe modes: report the local state and the exact replies/resolution actions a human could take.
+
+## Reply Guidance
+
+- Keep inline replies short and tied to the original title or concern.
+- For fixed findings, mention the concrete change or commit if useful.
+- For already-addressed or outdated findings, cite the current code path or behavior that makes the finding no longer applicable.
+- For deferred or won't-fix findings, provide the reason and any follow-up issue or owner if known.
+- If a reply or resolve operation fails, continue with the remaining threads and report the failure in the final summary.
+
+## Final Summary Checklist
+
+- Mode used: `normal`, `dry_run`, `no_push`, or `no_reply`
+- Counts by disposition: fixed, answered, clarified/left open, already addressed, outdated, deferred/won't-fix
+- Threads resolved, intentionally left open, or resolution actions skipped by mode
+- Verification run or planned
+- Commits pushed, local diff/commits, or "none"
+- Remaining open items and who needs to respond

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,17 @@ jobs:
     uses: dceoy/gh-actions-for-devops/.github/workflows/python-package-test.yml@main  # zizmor: ignore[unpinned-uses]
     with:
       package-path: .
+  github-codeql-analysis:
+    if: >
+      github.event_name == 'push'
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    uses: dceoy/gh-actions-for-devops/.github/workflows/github-codeql-analysis.yml@main  # zizmor: ignore[unpinned-uses]
+    with:
+      language: >
+        ["python"]
   hugo-deploy-to-gh-pages:
     if: >
       github.event_name == 'push'

--- a/.github/workflows/daily-market-analysis.yml
+++ b/.github/workflows/daily-market-analysis.yml
@@ -137,6 +137,7 @@ jobs:
           BRANCH="generated/analysis-${DATE}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          gh auth setup-git
           git fetch origin "$BRANCH" 2>/dev/null || true
           git checkout -B "$BRANCH"
           git add data/analysis/ content/results/

--- a/.github/workflows/daily-market-analysis.yml
+++ b/.github/workflows/daily-market-analysis.yml
@@ -38,6 +38,8 @@ jobs:
       DRY_RUN: ${{ inputs.dry_run || 'false' }}
     steps:
       - uses: actions/checkout@v4  # zizmor: ignore[unpinned-uses]
+        with:
+          persist-credentials: false
       - uses: astral-sh/setup-uv@v5  # zizmor: ignore[unpinned-uses]
         with:
           python-version: "3.x"

--- a/.github/workflows/daily-market-analysis.yml
+++ b/.github/workflows/daily-market-analysis.yml
@@ -74,14 +74,16 @@ jobs:
           fi
       - name: Fetch market data
         if: steps.symbols.outputs.symbols != ''
+        env:
+          DATE: ${{ steps.date.outputs.date }}
+          SYMBOLS: ${{ steps.symbols.outputs.symbols }}
         run: |
-          DATE="${{ steps.date.outputs.date }}"
           START=$(python3 -c "
           from datetime import datetime, timedelta
           d = datetime.strptime('${DATE}', '%Y-%m-%d')
           print((d - timedelta(days=365)).strftime('%Y-%m-%d'))
           ")
-          IFS=',' read -ra SYMS <<< "${{ steps.symbols.outputs.symbols }}"
+          IFS=',' read -ra SYMS <<< "${SYMBOLS}"
           for SYM in "${SYMS[@]}"; do
             uv run python .agents/skills/market-analysis/scripts/market_analysis.py \
               fetch --symbol "$SYM" --start "$START" --end "$DATE" \
@@ -90,23 +92,30 @@ jobs:
           done
       - name: Generate analysis artifact
         if: steps.symbols.outputs.symbols != ''
+        env:
+          DATE: ${{ steps.date.outputs.date }}
+          SYMBOLS: ${{ steps.symbols.outputs.symbols }}
         run: |
           uv run python .agents/skills/market-analysis/scripts/market_analysis.py \
             generate \
-            --symbols "${{ steps.symbols.outputs.symbols }}" \
+            --symbols "${SYMBOLS}" \
             --interval "$INTERVAL" \
-            --analysis-date "${{ steps.date.outputs.date }}" \
+            --analysis-date "${DATE}" \
             --output data/analysis/
       - name: Validate artifact
         if: steps.symbols.outputs.symbols != ''
+        env:
+          DATE: ${{ steps.date.outputs.date }}
         run: |
           uv run python .agents/skills/market-analysis/scripts/validate_analysis.py \
-            --input "data/analysis/${{ steps.date.outputs.date }}.json"
+            --input "data/analysis/${DATE}.json"
       - name: Generate Hugo report
         if: steps.symbols.outputs.symbols != ''
+        env:
+          DATE: ${{ steps.date.outputs.date }}
         run: |
           uv run python .agents/skills/market-analysis/scripts/generate_report.py \
-            --input "data/analysis/${{ steps.date.outputs.date }}.json" \
+            --input "data/analysis/${DATE}.json" \
             --output content/results/
       - uses: actions/setup-go@v5  # zizmor: ignore[unpinned-uses]
         with:
@@ -123,8 +132,9 @@ jobs:
         if: steps.symbols.outputs.symbols != '' && env.DRY_RUN != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DATE: ${{ steps.date.outputs.date }}
         run: |
-          BRANCH="generated/analysis-${{ steps.date.outputs.date }}"
+          BRANCH="generated/analysis-${DATE}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git fetch origin "$BRANCH" 2>/dev/null || true
@@ -134,7 +144,7 @@ jobs:
             echo "No changes to commit."
             echo "pr_url=" >> "$GITHUB_OUTPUT"
           else
-            git commit -m "feat(analysis): daily market analysis ${{ steps.date.outputs.date }}"
+            git commit -m "feat(analysis): daily market analysis ${DATE}"
             git push --force-with-lease -u origin "$BRANCH"
             PR_NUMBER="$(gh pr list --head "$BRANCH" --json number --jq '.[0].number // empty')"
             if [ -n "$PR_NUMBER" ]; then
@@ -143,8 +153,8 @@ jobs:
               echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
             else
               PR_URL=$(gh pr create \
-                --title "feat(analysis): daily market analysis ${{ steps.date.outputs.date }}" \
-                --body "Automated daily market analysis for ${{ steps.date.outputs.date }}." \
+                --title "feat(analysis): daily market analysis ${DATE}" \
+                --body "Automated daily market analysis for ${DATE}." \
                 --base main \
                 --head "$BRANCH")
               echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
@@ -154,10 +164,12 @@ jobs:
         if: steps.symbols.outputs.symbols != '' && env.DRY_RUN != 'true'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          DATE: ${{ steps.date.outputs.date }}
+          PR_URL: ${{ steps.pr.outputs.pr_url }}
         run: |
           uv run python .agents/skills/market-analysis/scripts/notify_slack.py \
-            --artifact "data/analysis/${{ steps.date.outputs.date }}.json" \
-            --pr-url "${{ steps.pr.outputs.pr_url }}"
+            --artifact "data/analysis/${DATE}.json" \
+            --pr-url "${PR_URL}"
       - name: Notify Slack (failure)
         if: failure()
         env:

--- a/.github/workflows/update-cfd-instruments.yml
+++ b/.github/workflows/update-cfd-instruments.yml
@@ -109,6 +109,7 @@ jobs:
           BRANCH="chore/refresh-cfd-instruments-$(date -u +%Y%m%d)"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          gh auth setup-git
 
           # Fetch remote branch state so --force-with-lease works on reruns
           git fetch origin "$BRANCH" 2>/dev/null || true

--- a/.github/workflows/update-cfd-instruments.yml
+++ b/.github/workflows/update-cfd-instruments.yml
@@ -14,6 +14,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4  # zizmor: ignore[unpinned-uses]
+        with:
+          persist-credentials: false
       - uses: astral-sh/setup-uv@v5  # zizmor: ignore[unpinned-uses]
         with:
           python-version: "3.x"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+This repository combines Python automation scripts with a Hugo static site. Core scripts live under `.agents/skills/`, especially `market-analysis/scripts/` and `update-cfd-instruments/scripts/`. Tests and fixtures are in `tests/`, with golden report output in `tests/golden/`. Data files and JSON schemas are in `data/` and `data/schema/`. Hugo content, archetypes, and configuration live in `content/`, `archetypes/`, and `config/_default/`; the generated site is written to the ignored `site/` directory.
+
+## Build, Test, and Development Commands
+
+- `uv sync --group dev`: install Python development tools from `uv.lock`.
+- `uv run pytest`: run the Python test suite with branch coverage.
+- `uv run ruff format .`: format Python files.
+- `uv run ruff check --fix .`: lint and apply safe Ruff fixes.
+- `uv run pyright .`: run strict type checks for skill scripts.
+- `hugo --gc --minify`: build the static site.
+- `hugo server --buildDrafts`: preview the site locally, including draft posts.
+- `.agents/skills/local-qa/scripts/qa.sh`: run the full local QA workflow used by contributors.
+
+## Coding Style & Naming Conventions
+
+Python targets 3.11 through 3.13. Ruff enforces 88-character lines, Google-style docstrings, import sorting, and strict lint rules. Prefer typed functions and `pathlib` over string path manipulation. Test files use `test_*.py`, and test names should describe behavior. Keep generated Hugo reports named like `YYYY-MM-DD-market-analysis.md` under `content/results/`.
+
+## Testing Guidelines
+
+Pytest is configured in `pyproject.toml` and requires 100% branch coverage for the script directories under `.agents/skills/`. Add or update fixtures in `tests/fixtures/` and golden output in `tests/golden/` when changing report generation or parser behavior. Validate CFD data with:
+
+```bash
+uv run python .agents/skills/update-cfd-instruments/scripts/validate_cfd_instruments.py --input data/cfd_instruments.csv --schema data/schema/cfd_instruments.schema.json
+```
+
+## Commit & Pull Request Guidelines
+
+Recent history uses concise Conventional Commit-style subjects such as `feat: ...`, `fix: ...`, and scoped variants like `feat(data): ...`. Keep commits focused and include issue or PR references when relevant. Pull requests should explain the change, list validation commands run, link related issues, and include screenshots or generated report paths when the Hugo output changes.
+
+## Security & Configuration Tips
+
+Do not commit secrets or local environment files. Operational details, scheduled workflows, Slack notifications, and required repository secrets are documented in `OPERATIONS.md`. GitHub Actions live in `.github/workflows/`; run the full QA script after workflow edits because it applies `zizmor`, `actionlint`, `yamllint`, and `checkov`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -30,6 +30,7 @@ AIMS fetches daily OHLCV (open/high/low/close/volume) price history from [Stooq]
 Examples: `^SPX` (S&P 500), `^DJI` (Dow Jones), `^NDX` (NASDAQ 100), `^NKX` (Nikkei 225), `^DAX` (DAX).
 
 **Limitations:**
+
 - Daily, weekly, and monthly bars only — no intraday data.
 - Symbol availability and history depth vary; some symbols return no data.
 - No authentication required, but subject to undocumented rate limits.
@@ -66,18 +67,18 @@ AIMS scores and ranks instruments cross-sectionally using ten features computed 
 
 ### Features
 
-| Feature | Window | Direction |
-| ------- | ------ | --------- |
-| Return | 1 day | Higher is better |
-| Return | 5 days | Higher is better |
-| Return | 20 days | Higher is better |
-| Return | 60 days | Higher is better |
-| Distance from MA | 20-day | Higher is better |
-| Distance from MA | 50-day | Higher is better |
-| Realized volatility | 20-day annualised | Lower is better |
-| Maximum drawdown | 60 days | Lower is better |
-| RSI | 14-day | Higher is better |
-| Z-score | 20-day | Higher is better |
+| Feature             | Window            | Direction        |
+| ------------------- | ----------------- | ---------------- |
+| Return              | 1 day             | Higher is better |
+| Return              | 5 days            | Higher is better |
+| Return              | 20 days           | Higher is better |
+| Return              | 60 days           | Higher is better |
+| Distance from MA    | 20-day            | Higher is better |
+| Distance from MA    | 50-day            | Higher is better |
+| Realized volatility | 20-day annualised | Lower is better  |
+| Maximum drawdown    | 60 days           | Lower is better  |
+| RSI                 | 14-day            | Higher is better |
+| Z-score             | 20-day            | Higher is better |
 
 ### Cross-sectional ranking
 
@@ -87,23 +88,23 @@ Each feature value is converted to a cross-sectional percentile rank across all 
 
 Instruments that fail quality checks are included in output but marked `is_reliable: false` and ranked below reliable instruments. They appear in the "Instruments to Avoid" section of the report.
 
-| Gate | Trigger |
-| ---- | ------- |
-| `stale_data` | Latest bar older than `stale_days` calendar days (default: 5) |
-| `insufficient_history` | Fewer than `min_history` bars (default: 60) |
-| `missing_bars` | Gap > 7 calendar days between consecutive bars |
-| `malformed_input` | Non-positive prices, high < low, or price outside [low, high] |
-| `high_volatility` | 20-day annualised volatility > 100% |
+| Gate                   | Trigger                                                       |
+| ---------------------- | ------------------------------------------------------------- |
+| `stale_data`           | Latest bar older than `stale_days` calendar days (default: 5) |
+| `insufficient_history` | Fewer than `min_history` bars (default: 60)                   |
+| `missing_bars`         | Gap > 7 calendar days between consecutive bars                |
+| `malformed_input`      | Non-positive prices, high < low, or price outside [low, high] |
+| `high_volatility`      | 20-day annualised volatility > 100%                           |
 
 ### Market regime
 
 The market regime label is derived from the median composite score of reliable instruments:
 
-| Label | Median score |
-| ----- | ------------ |
-| Bullish | ≥ 65 |
-| Neutral | 40 – 64 |
-| Bearish | ≤ 40 |
+| Label       | Median score            |
+| ----------- | ----------------------- |
+| Bullish     | ≥ 65                    |
+| Neutral     | 40 – 64                 |
+| Bearish     | ≤ 40                    |
 | Unavailable | No reliable instruments |
 
 ### Scoring version
@@ -178,11 +179,11 @@ Pipeline order:
 
 The workflow supports `workflow_dispatch` with three optional inputs:
 
-| Input | Default | Description |
-| ----- | ------- | ----------- |
-| `analysis_date` | Today UTC | Override the analysis date (YYYY-MM-DD) |
-| `interval` | `d` | Price bar interval: `d` (daily), `w` (weekly), `m` (monthly) |
-| `dry_run` | `false` | When `true`, skips PR creation and Slack success notification |
+| Input           | Default   | Description                                                   |
+| --------------- | --------- | ------------------------------------------------------------- |
+| `analysis_date` | Today UTC | Override the analysis date (YYYY-MM-DD)                       |
+| `interval`      | `d`       | Price bar interval: `d` (daily), `w` (weekly), `m` (monthly)  |
+| `dry_run`       | `false`   | When `true`, skips PR creation and Slack success notification |
 
 ### Deployment gate
 
@@ -192,10 +193,10 @@ GitHub Pages deployment is handled by `ci.yml` (`hugo-deploy-to-gh-pages` job), 
 
 ## 6. GitHub Actions secrets
 
-| Secret | Required | Description |
-| ------ | -------- | ----------- |
-| `SLACK_WEBHOOK_URL` | Optional | Slack incoming webhook URL for success and failure notifications. If not set, the notification steps exit silently (exit code 0). |
-| `GITHUB_TOKEN` | Built-in | Used automatically by `gh` and `git push` in the `update-cfd-instruments` and `daily-market-analysis` workflows. No manual configuration needed. |
+| Secret              | Required | Description                                                                                                                                      |
+| ------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `SLACK_WEBHOOK_URL` | Optional | Slack incoming webhook URL for success and failure notifications. If not set, the notification steps exit silently (exit code 0).                |
+| `GITHUB_TOKEN`      | Built-in | Used automatically by `gh` and `git push` in the `update-cfd-instruments` and `daily-market-analysis` workflows. No manual configuration needed. |
 
 **How to add `SLACK_WEBHOOK_URL`:** Go to the repository → Settings → Secrets and variables → Actions → New repository secret. Name: `SLACK_WEBHOOK_URL`. Value: the `https://hooks.slack.com/services/…` URL from your Slack app's Incoming Webhooks configuration.
 
@@ -207,11 +208,11 @@ GitHub Pages deployment is handled by `ci.yml` (`hugo-deploy-to-gh-pages` job), 
 
 The `daily-market-analysis.yml` workflow uses:
 
-| Permission | Scope | Reason |
-| ---------- | ----- | ------ |
-| `contents: write` | `analyze` job | Create and push to analysis branch; open PR |
-| `pull-requests: write` | `analyze` job | Create analysis pull requests |
-| `contents: read` | Workflow-level default | Checkout |
+| Permission             | Scope                  | Reason                                      |
+| ---------------------- | ---------------------- | ------------------------------------------- |
+| `contents: write`      | `analyze` job          | Create and push to analysis branch; open PR |
+| `pull-requests: write` | `analyze` job          | Create analysis pull requests               |
+| `contents: read`       | Workflow-level default | Checkout                                    |
 
 The `ci.yml` workflow adds:
 | Permission | Scope | Reason |

--- a/tests/golden/2024-01-01-market-analysis.md
+++ b/tests/golden/2024-01-01-market-analysis.md
@@ -32,11 +32,11 @@ These instruments have quality or risk issues and are excluded from ranking:
 
 ## Instrument Scores
 
-| Rank | Symbol | Score | Reliable | Risk Gates | Explanation |
-| ---: | ------ | ----: | :------: | ---------- | ----------- |
-| 1 | ^SPX | 72.5 | Yes | — | 20d up +5.3%; above MA20 by 2.1%; RSI14=62 |
-| 2 | ^DJI | 58.3 | Yes | — | 20d up +2.1%; above MA20 by 0.8%; RSI14=55 |
-| 3 | ^NDX | 31.7 | No | insufficient_history | Suppressed: insufficient_history |
+| Rank | Symbol | Score | Reliable | Risk Gates           | Explanation                                |
+| ---: | ------ | ----: | :------: | -------------------- | ------------------------------------------ |
+|    1 | ^SPX   |  72.5 |   Yes    | —                    | 20d up +5.3%; above MA20 by 2.1%; RSI14=62 |
+|    2 | ^DJI   |  58.3 |   Yes    | —                    | 20d up +2.1%; above MA20 by 0.8%; RSI14=55 |
+|    3 | ^NDX   |  31.7 |    No    | insufficient_history | Suppressed: insufficient_history           |
 
 ## Data Freshness
 
@@ -44,9 +44,9 @@ Data source: **stooq**
 
 | Symbol | Latest Bar |
 | ------ | ---------- |
-| ^DJI | 2023-12-29 |
-| ^NDX | n/a |
-| ^SPX | 2024-01-01 |
+| ^DJI   | 2023-12-29 |
+| ^NDX   | n/a        |
+| ^SPX   | 2024-01-01 |
 
 > **Warning:** 1 instrument(s) have no data: ^NDX.
 


### PR DESCRIPTION
Closes #24

## Summary

- Add root-level `AGENTS.md` documenting repository structure, skills layout, validation commands, generated artifacts, and contributor conventions for AI coding agents; symlink `CLAUDE.md` to the same content
- Add `_format_markdown_table` to `generate_report.py` so Instrument Scores and Data Freshness tables use Prettier-compatible column padding, keeping generated reports stable after `local-qa` runs Prettier on markdown files
- Update the golden test fixture to match Prettier-formatted table output
- Add `pr-feedback-triage` agent skill and refresh `OPERATIONS.md` contributor docs
- Harden local QA and CI workflows: set `persist-credentials: false` on checkout steps, fix actionlint violations, configure git auth before push in automation workflows, and add CodeQL analysis for Python

## Test plan

- [x] `uv run pytest` (262 tests, 100% coverage)
- [x] Verified generated report output is unchanged after running Prettier
- [x] `local-qa` / pre-push hook passes