### PR TITLE
feat(okf): introduce OKF knowledge layer and deterministic OKF→Hugo adapter

### DIFF
--- a/.agents/skills/aims-okf-author/SKILL.md
+++ b/.agents/skills/aims-okf-author/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: aims-okf-author
+description: Create or update canonical OKF concept documents from repository evidence without inventing numeric market facts.
+disable-model-invocation: false
+---
+
+# AIMS OKF authoring
+
+Author only `okf/` files first. Use `data/analysis/*.json` for numeric facts and cite generated reports only as publication outputs, not canonical facts. Regenerate `content/knowledge/` with the adapter before finishing.
+
+## AIMS paths and commands
+
+- Canonical OKF source: `okf/`
+- Generated Hugo shadow content: `content/knowledge/`
+- Daily report output: `content/results/`
+- Numeric analysis artifacts: `data/analysis/*.json`
+- Generate: `uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge --clean`
+- Check: `uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge --check`
+- Build: `hugo --gc --minify`
+
+## Guardrails
+
+- Do not let LLM-authored OKF prose become the source of truth for scores, ranks, dates, prices, risk gates, or data availability.
+- Do not hand-edit `content/knowledge/`; regenerate it from `okf/`.
+- Keep custom code small and deterministic.

--- a/.agents/skills/aims-okf-author/SKILL.md
+++ b/.agents/skills/aims-okf-author/SKILL.md
@@ -23,3 +23,8 @@ Author only `okf/` files first. Use `data/analysis/*.json` for numeric facts and
 - Do not let LLM-authored OKF prose become the source of truth for scores, ranks, dates, prices, risk gates, or data availability.
 - Do not hand-edit `content/knowledge/`; regenerate it from `okf/`.
 - Keep custom code small and deterministic.
+
+## OKF primary references
+
+- Google Cloud announcement: https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing
+- OKF v0.1 draft specification: https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md

--- a/.agents/skills/aims-okf-curator/SKILL.md
+++ b/.agents/skills/aims-okf-curator/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: aims-okf-curator
+description: Maintain OKF indexes, logs, tags, cross-links, duplicate consolidation, and stale concept cleanup.
+disable-model-invocation: false
+---
+
+# AIMS OKF curation
+
+Keep tags lowercase kebab-case. Ensure `okf/index.md` links durable concepts and `okf/logs/log.md` records meaningful curation changes. Run the adapter with `--check` to catch broken links and drift.
+
+## AIMS paths and commands
+
+- Canonical OKF source: `okf/`
+- Generated Hugo shadow content: `content/knowledge/`
+- Daily report output: `content/results/`
+- Numeric analysis artifacts: `data/analysis/*.json`
+- Generate: `uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge --clean`
+- Check: `uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge --check`
+- Build: `hugo --gc --minify`
+
+## Guardrails
+
+- Do not let LLM-authored OKF prose become the source of truth for scores, ranks, dates, prices, risk gates, or data availability.
+- Do not hand-edit `content/knowledge/`; regenerate it from `okf/`.
+- Keep custom code small and deterministic.

--- a/.agents/skills/aims-okf-curator/SKILL.md
+++ b/.agents/skills/aims-okf-curator/SKILL.md
@@ -23,3 +23,8 @@ Keep tags lowercase kebab-case. Ensure `okf/index.md` links durable concepts and
 - Do not let LLM-authored OKF prose become the source of truth for scores, ranks, dates, prices, risk gates, or data availability.
 - Do not hand-edit `content/knowledge/`; regenerate it from `okf/`.
 - Keep custom code small and deterministic.
+
+## OKF primary references
+
+- Google Cloud announcement: https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing
+- OKF v0.1 draft specification: https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md

--- a/.agents/skills/aims-okf-pr-review/SKILL.md
+++ b/.agents/skills/aims-okf-pr-review/SKILL.md
@@ -23,3 +23,8 @@ Check that `okf/` is canonical, `content/knowledge/` is generated, generated con
 - Do not let LLM-authored OKF prose become the source of truth for scores, ranks, dates, prices, risk gates, or data availability.
 - Do not hand-edit `content/knowledge/`; regenerate it from `okf/`.
 - Keep custom code small and deterministic.
+
+## OKF primary references
+
+- Google Cloud announcement: https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing
+- OKF v0.1 draft specification: https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md

--- a/.agents/skills/aims-okf-pr-review/SKILL.md
+++ b/.agents/skills/aims-okf-pr-review/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: aims-okf-pr-review
+description: Review changes touching OKF, generated knowledge content, adapter code, skills, docs, or CI.
+disable-model-invocation: false
+---
+
+# AIMS OKF PR review
+
+Check that `okf/` is canonical, `content/knowledge/` is generated, generated content is up to date, and no vector database, external RAG service, custom CMS, or server runtime was introduced.
+
+## AIMS paths and commands
+
+- Canonical OKF source: `okf/`
+- Generated Hugo shadow content: `content/knowledge/`
+- Daily report output: `content/results/`
+- Numeric analysis artifacts: `data/analysis/*.json`
+- Generate: `uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge --clean`
+- Check: `uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge --check`
+- Build: `hugo --gc --minify`
+
+## Guardrails
+
+- Do not let LLM-authored OKF prose become the source of truth for scores, ranks, dates, prices, risk gates, or data availability.
+- Do not hand-edit `content/knowledge/`; regenerate it from `okf/`.
+- Keep custom code small and deterministic.

--- a/.agents/skills/aims-okf-site/SKILL.md
+++ b/.agents/skills/aims-okf-site/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: aims-okf-site
+description: Generate Hugo shadow content from OKF and troubleshoot Hugo publication.
+disable-model-invocation: false
+---
+
+# AIMS OKF site generation
+
+Run `uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge --clean`, then `hugo --gc --minify`. Keep `content/results/` and `content/knowledge/` separate in URLs and navigation.
+
+## AIMS paths and commands
+
+- Canonical OKF source: `okf/`
+- Generated Hugo shadow content: `content/knowledge/`
+- Daily report output: `content/results/`
+- Numeric analysis artifacts: `data/analysis/*.json`
+- Generate: `uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge --clean`
+- Check: `uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge --check`
+- Build: `hugo --gc --minify`
+
+## Guardrails
+
+- Do not let LLM-authored OKF prose become the source of truth for scores, ranks, dates, prices, risk gates, or data availability.
+- Do not hand-edit `content/knowledge/`; regenerate it from `okf/`.
+- Keep custom code small and deterministic.

--- a/.agents/skills/aims-okf-site/SKILL.md
+++ b/.agents/skills/aims-okf-site/SKILL.md
@@ -23,3 +23,8 @@ Run `uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge -
 - Do not let LLM-authored OKF prose become the source of truth for scores, ranks, dates, prices, risk gates, or data availability.
 - Do not hand-edit `content/knowledge/`; regenerate it from `okf/`.
 - Keep custom code small and deterministic.
+
+## OKF primary references
+
+- Google Cloud announcement: https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing
+- OKF v0.1 draft specification: https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md

--- a/.agents/skills/local-qa/scripts/qa.sh
+++ b/.agents/skills/local-qa/scripts/qa.sh
@@ -21,6 +21,11 @@ if [ -f data/cfd_instruments.csv ]; then
     --schema data/schema/cfd_instruments.schema.json
 fi
 
+# OKF knowledge shadow content
+if [ -d okf ]; then
+  uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge --check
+fi
+
 # Markdown
 npx -y prettier --write './**/*.md'
 

--- a/.agents/skills/local-qa/scripts/qa.sh
+++ b/.agents/skills/local-qa/scripts/qa.sh
@@ -21,13 +21,13 @@ if [ -f data/cfd_instruments.csv ]; then
     --schema data/schema/cfd_instruments.schema.json
 fi
 
+# Markdown
+npx -y prettier --write './**/*.md'
+
 # OKF knowledge shadow content
 if [ -d okf ]; then
   uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge --check
 fi
-
-# Markdown
-npx -y prettier --write './**/*.md'
 
 # Hugo
 hugo --gc --minify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
     with:
       language: >
         ["python"]
-  okf-validate:
+  okf-hugo-build:
     if: >
       github.event_name == 'push'
       || github.event_name == 'pull_request'
@@ -64,11 +64,22 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6  # zizmor: ignore[unpinned-uses]
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10   # v6.0.3
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@v7  # zizmor: ignore[unpinned-uses]
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39   # v8.2.0
+        with:
+          python-version: "3.x"
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: stable
+      - name: Install Hugo
+        uses: peaceiris/actions-hugo@2752ce1d29631191ea3f27c23495fa06139a5b78 # v3.2.1
+        with:
+          hugo-version: latest
+          extended: true
       - run: uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge --check
+      - run: hugo --gc --minify
   hugo-deploy-to-gh-pages:
     if: >
       github.event_name == 'push'
@@ -76,7 +87,7 @@ jobs:
       - github-actions-lint-and-scan
       - python-lint-and-scan
       - python-test
-      - okf-validate
+      - okf-hugo-build
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,7 @@ jobs:
     uses: dceoy/gh-actions-for-devops/.github/workflows/hugo-deploy-to-gh-pages.yml@main   # zizmor: ignore[unpinned-uses]
     with:
       site-path: .
+      go-version: stable
       base-url: https://dceoy.github.io/aims/
       destination-dir: site
   dependabot-auto-merge:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
   github-codeql-analysis:
     if: >
       github.event_name == 'push'
+      || github.event_name == 'pull_request'
     permissions:
       contents: read
       security-events: write
@@ -79,6 +80,7 @@ jobs:
       - github-actions-lint-and-scan
       - python-lint-and-scan
       - python-test
+      - github-codeql-analysis
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39   # v8.2.0
-        with:
-          python-version: "3.x"
+      - run: uv sync --all-groups
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,19 @@ jobs:
     with:
       language: >
         ["python"]
+  okf-validate:
+    if: >
+      github.event_name == 'push'
+      || github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6  # zizmor: ignore[unpinned-uses]
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@v7  # zizmor: ignore[unpinned-uses]
+      - run: uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge --check
   hugo-deploy-to-gh-pages:
     if: >
       github.event_name == 'push'
@@ -63,6 +76,7 @@ jobs:
       - github-actions-lint-and-scan
       - python-lint-and-scan
       - python-test
+      - okf-validate
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
       - python-lint-and-scan
       - python-test
       - github-codeql-analysis
+      - okf-hugo-build
     permissions:
       contents: write
       pull-requests: write

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+content/knowledge/**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,8 @@ Do not commit secrets or local environment files. Operational details, scheduled
 
 ## OKF Knowledge Layer
 
+OKF v0.1 Draft primary references: [specification](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) and [Google Cloud announcement](https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing).
+
 - Treat `okf/` as the canonical source for durable AIMS knowledge.
 - Treat `content/knowledge/` as generated Hugo shadow content; do not hand-edit it.
 - Treat OKF v0.1 `index.md` and `log.md` as reserved files, not concept documents; do not add concept front matter to those files.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,8 @@ This repository combines Python automation scripts with a Hugo static site. Core
 - `uv run pytest`: run the Python test suite with branch coverage.
 - `uv run ruff format .`: format Python files.
 - `uv run ruff check --fix .`: lint and apply safe Ruff fixes.
-- `uv run pyright .`: run strict type checks for skill scripts.
-- `hugo --gc --minify`: build the static site.
+- `uv run pyright .`: run strict type checks for skill scripts and `tools/`.
+- `hugo --gc --minify`: build the static site (requires Go for Hugo Modules).
 - `hugo server --buildDrafts`: preview the site locally, including draft posts.
 - `.agents/skills/local-qa/scripts/qa.sh`: run the full local QA workflow used by contributors.
 
@@ -44,6 +44,13 @@ OKF v0.1 Draft primary references: [specification](https://github.com/GoogleClou
 - Treat OKF v0.1 `index.md` and `log.md` as reserved files, not concept documents; do not add concept front matter to those files.
 - Keep `data/analysis/*.json` authoritative for numeric market facts, scores, ranks, dates, risk gates, and data availability.
 - Keep `content/results/` as the public daily analysis report output.
-- Use `uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge --clean` after OKF edits.
-- Use `uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge --check` to validate OKF metadata, internal links, and generated-content drift.
+- After OKF edits, regenerate and validate shadow content, then build Hugo:
+
+  ```bash
+  uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge --clean
+  uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge --check
+  hugo --gc --minify
+  ```
+
+- Do not hand-edit `content/knowledge/`; fix drift by regenerating from `okf/`.
 - Do not introduce vector databases, embeddings pipelines, external RAG services, custom CMS layers, or server-side runtimes for the OKF layer.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,3 +34,13 @@ Recent history uses concise Conventional Commit-style subjects such as `feat: ..
 ## Security & Configuration Tips
 
 Do not commit secrets or local environment files. Operational details, scheduled workflows, Slack notifications, and required repository secrets are documented in `OPERATIONS.md`. GitHub Actions live in `.github/workflows/`; run the full QA script after workflow edits because it applies `zizmor`, `actionlint`, `yamllint`, and `checkov`.
+
+## OKF Knowledge Layer
+
+- Treat `okf/` as the canonical source for durable AIMS knowledge.
+- Treat `content/knowledge/` as generated Hugo shadow content; do not hand-edit it.
+- Keep `data/analysis/*.json` authoritative for numeric market facts, scores, ranks, dates, risk gates, and data availability.
+- Keep `content/results/` as the public daily analysis report output.
+- Use `uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge --clean` after OKF edits.
+- Use `uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge --check` to validate OKF metadata, internal links, and generated-content drift.
+- Do not introduce vector databases, embeddings pipelines, external RAG services, custom CMS layers, or server-side runtimes for the OKF layer.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ Do not commit secrets or local environment files. Operational details, scheduled
 
 - Treat `okf/` as the canonical source for durable AIMS knowledge.
 - Treat `content/knowledge/` as generated Hugo shadow content; do not hand-edit it.
+- Treat OKF v0.1 `index.md` and `log.md` as reserved files, not concept documents; do not add concept front matter to those files.
 - Keep `data/analysis/*.json` authoritative for numeric market facts, scores, ranks, dates, risk gates, and data availability.
 - Keep `content/results/` as the public daily analysis report output.
 - Use `uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge --clean` after OKF edits.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ AI Market Strategist
 ## Static analysis site
 
 Analysis results are saved as Hugo content under `content/results/` and rendered to the ignored `site/` directory.
-The site uses the Congo Hugo theme via Hugo Modules.
+The site uses the Congo Hugo theme via Hugo Modules, so local Hugo builds require a Go toolchain in addition to Hugo Extended.
 
 Create a new result:
 
@@ -43,11 +43,14 @@ AIMS uses an OKF-first knowledge layer for durable repository knowledge. AIMS ta
 - `content/knowledge/` is generated Hugo shadow content derived from `okf/` and must not be hand-edited.
 - Repository-local Agent Skills under `.agents/skills/` guide OKF authoring, curation, Hugo generation, and PR review.
 
-Generate or validate the Hugo shadow content with:
+After editing `okf/`, regenerate and validate the Hugo shadow content, then build the site:
 
 ```bash
 uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge --clean
 uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge --check
+hugo --gc --minify
 ```
+
+Do not hand-edit `content/knowledge/`. If Markdown formatting or other tooling changes the generated files, fix drift by regenerating from `okf/` with the adapter rather than editing the shadow content directly.
 
 The adapter deterministically maps OKF reserved `index.md` files to Hugo `_index.md` files, accepts OKF v0.1 reserved files without concept front matter, and moves non-reserved OKF front matter `type` into `params.okf_type` so Hugo can use a stable `type: knowledge` presentation type.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ See [OPERATIONS.md](OPERATIONS.md) for data sources, scoring methodology, requir
 
 ## OKF knowledge layer
 
-AIMS uses an OKF-first knowledge layer for durable repository knowledge:
+AIMS uses an OKF-first knowledge layer for durable repository knowledge. AIMS targets OKF v0.1 Draft as described in the [OKF v0.1 draft specification](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) and the [Google Cloud OKF announcement](https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing):
 
 - `okf/` is the canonical source for stable concepts about architecture, data sources, scoring methodology, operations, and Agent Skills.
 - `data/analysis/*.json` remains authoritative for numeric market facts, scores, ranks, dates, risk gates, and data availability.

--- a/README.md
+++ b/README.md
@@ -32,3 +32,22 @@ hugo server --buildDrafts
 Daily market analysis runs automatically via `.github/workflows/daily-market-analysis.yml`. It fetches market data, scores instruments, generates JSON artifacts and Hugo Markdown reports, builds the site, and creates a pull request with the results for review and merging.
 
 See [OPERATIONS.md](OPERATIONS.md) for data sources, scoring methodology, required secrets, and operational runbooks.
+
+## OKF knowledge layer
+
+AIMS uses an OKF-first knowledge layer for durable repository knowledge:
+
+- `okf/` is the canonical source for stable concepts about architecture, data sources, scoring methodology, operations, and Agent Skills.
+- `data/analysis/*.json` remains authoritative for numeric market facts, scores, ranks, dates, risk gates, and data availability.
+- `content/results/` remains the public daily market-analysis report output.
+- `content/knowledge/` is generated Hugo shadow content derived from `okf/` and must not be hand-edited.
+- Repository-local Agent Skills under `.agents/skills/` guide OKF authoring, curation, Hugo generation, and PR review.
+
+Generate or validate the Hugo shadow content with:
+
+```bash
+uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge --clean
+uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge --check
+```
+
+The adapter deterministically maps OKF `index.md` files to Hugo `_index.md` files and moves OKF front matter `type` into `params.okf_type` so Hugo can use a stable `type: knowledge` presentation type.

--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge --clea
 uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge --check
 ```
 
-The adapter deterministically maps OKF `index.md` files to Hugo `_index.md` files and moves OKF front matter `type` into `params.okf_type` so Hugo can use a stable `type: knowledge` presentation type.
+The adapter deterministically maps OKF reserved `index.md` files to Hugo `_index.md` files, accepts OKF v0.1 reserved files without concept front matter, and moves non-reserved OKF front matter `type` into `params.okf_type` so Hugo can use a stable `type: knowledge` presentation type.

--- a/config/_default/menus.en.toml
+++ b/config/_default/menus.en.toml
@@ -2,3 +2,8 @@
   name = "Results"
   pageRef = "results"
   weight = 10
+
+[[main]]
+  name = "Knowledge"
+  pageRef = "knowledge"
+  weight = 20

--- a/content/knowledge/_index.md
+++ b/content/knowledge/_index.md
@@ -16,15 +16,15 @@ The `okf/` tree is the canonical repository-native source for durable AIMS archi
 
 ## Concepts
 
-- [Agent Skills](/knowledge/concepts/agent-skills/)
-- [AIMS Architecture](/knowledge/concepts/architecture/)
-- [Data Sources](/knowledge/concepts/data-sources/)
-- [Instrument Master](/knowledge/concepts/instrument-master/)
-- [Operational Recovery](/knowledge/concepts/operational-recovery/)
-- [Publication Workflow](/knowledge/concepts/publication-workflow/)
-- [Report Generation](/knowledge/concepts/report-generation/)
-- [Scoring Methodology](/knowledge/concepts/scoring-methodology/)
+- [Agent Skills](concepts/agent-skills/)
+- [AIMS Architecture](concepts/architecture/)
+- [Data Sources](concepts/data-sources/)
+- [Instrument Master](concepts/instrument-master/)
+- [Operational Recovery](concepts/operational-recovery/)
+- [Publication Workflow](concepts/publication-workflow/)
+- [Report Generation](concepts/report-generation/)
+- [Scoring Methodology](concepts/scoring-methodology/)
 
 ## Log
 
-- [Knowledge log](/knowledge/logs/log/)
+- [Knowledge log](logs/log/)

--- a/content/knowledge/_index.md
+++ b/content/knowledge/_index.md
@@ -1,7 +1,8 @@
 ---
 description: Generated from index.md.
-okf_version: '0.1'
 params:
+  okf_extra:
+    okf_version: '0.1'
   okf_reserved: index
 resource:
   path: index.md

--- a/content/knowledge/_index.md
+++ b/content/knowledge/_index.md
@@ -1,0 +1,34 @@
+---
+description: Canonical OKF source for durable AIMS market-analysis knowledge.
+id: okf/index
+params:
+  okf_type: index
+resource:
+  path: okf/index.md
+  source: repository
+tags:
+  - okf
+  - knowledge
+timestamp: 2026-06-16T00:00:00Z
+title: AIMS Knowledge Base
+type: knowledge
+---
+
+# AIMS Knowledge Base
+
+The `okf/` tree is the canonical repository-native knowledge source for durable AIMS architecture, operations, and market-analysis methodology. Hugo pages under `content/knowledge/` are generated shadow content and must not be hand-edited.
+
+## Concepts
+
+- [Agent Skills](./concepts/agent-skills.md)
+- [AIMS Architecture](./concepts/architecture.md)
+- [Data Sources](./concepts/data-sources.md)
+- [Instrument Master](./concepts/instrument-master.md)
+- [Operational Recovery](./concepts/operational-recovery.md)
+- [Publication Workflow](./concepts/publication-workflow.md)
+- [Report Generation](./concepts/report-generation.md)
+- [Scoring Methodology](./concepts/scoring-methodology.md)
+
+## Logs
+
+- [Knowledge log](./logs/log.md)

--- a/content/knowledge/_index.md
+++ b/content/knowledge/_index.md
@@ -1,34 +1,29 @@
 ---
-description: Canonical OKF source for durable AIMS market-analysis knowledge.
-id: okf/index
+description: Generated from index.md.
+okf_version: '0.1'
 params:
-  okf_type: index
+  okf_reserved: index
 resource:
-  path: okf/index.md
-  source: repository
-tags:
-  - okf
-  - knowledge
-timestamp: 2026-06-16T00:00:00Z
+  path: index.md
 title: AIMS Knowledge Base
 type: knowledge
 ---
 
 # AIMS Knowledge Base
 
-The `okf/` tree is the canonical repository-native knowledge source for durable AIMS architecture, operations, and market-analysis methodology. Hugo pages under `content/knowledge/` are generated shadow content and must not be hand-edited.
+The `okf/` tree is the canonical repository-native source for durable AIMS architecture, operations, and methodology knowledge. Hugo pages under `content/knowledge/` are generated shadow content and must not be hand-edited.
 
 ## Concepts
 
-- [Agent Skills](./concepts/agent-skills.md)
-- [AIMS Architecture](./concepts/architecture.md)
-- [Data Sources](./concepts/data-sources.md)
-- [Instrument Master](./concepts/instrument-master.md)
-- [Operational Recovery](./concepts/operational-recovery.md)
-- [Publication Workflow](./concepts/publication-workflow.md)
-- [Report Generation](./concepts/report-generation.md)
-- [Scoring Methodology](./concepts/scoring-methodology.md)
+- [Agent Skills](/knowledge/concepts/agent-skills/)
+- [AIMS Architecture](/knowledge/concepts/architecture/)
+- [Data Sources](/knowledge/concepts/data-sources/)
+- [Instrument Master](/knowledge/concepts/instrument-master/)
+- [Operational Recovery](/knowledge/concepts/operational-recovery/)
+- [Publication Workflow](/knowledge/concepts/publication-workflow/)
+- [Report Generation](/knowledge/concepts/report-generation/)
+- [Scoring Methodology](/knowledge/concepts/scoring-methodology/)
 
-## Logs
+## Log
 
-- [Knowledge log](./logs/log.md)
+- [Knowledge log](/knowledge/logs/log/)

--- a/content/knowledge/concepts/agent-skills.md
+++ b/content/knowledge/concepts/agent-skills.md
@@ -1,16 +1,18 @@
 ---
-description: Repository-local Agent Skills that guide AIMS automation, OKF curation, site generation, and PR review.
+description: Repository-local Agent Skills that guide AIMS automation, OKF curation,
+  site generation, and PR review.
 id: okf/concepts/agent-skills
 params:
   okf_type: concept
 resource:
   path: okf/concepts/agent-skills.md
   source: repository
+status: seeded
 tags:
-  - agents
-  - skills
-  - okf
-timestamp: 2026-06-16T00:00:00Z
+- agents
+- skills
+- okf
+timestamp: 2026-06-16 00:00:00+00:00
 title: Agent Skills
 type: knowledge
 ---
@@ -19,15 +21,24 @@ type: knowledge
 
 Repository-local Agent Skills that guide AIMS automation, OKF curation, site generation, and PR review.
 
+## Repository facts
+
+Repository-local Agent Skills describe repeatable workflows for market analysis, CFD instrument updates, local QA, PR feedback triage, and OKF maintenance. The OKF author, curator, site, and PR-review skills point agents at canonical `okf/` edits and generated `content/knowledge/` validation.
+
+Agent workflows must keep generated knowledge separate from canonical OKF and must not invent numeric market facts.
+
 ## Source-of-truth boundary
 
-AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in `data/analysis/*.json` and generated daily reports in `content/results/`. This OKF concept captures durable repository knowledge only and must not invent or override generated numeric facts.
-
-## AIMS notes
-
-This concept is seeded from repository documentation, operations guidance, tests, workflows, and issue dceoy/aims#57. Update it through the OKF authoring and curation workflow when durable architecture or operational knowledge changes.
+AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in generated artifacts and validated reports. This OKF concept captures durable repository knowledge only.
 
 ## Related concepts
 
-- [Related: architecture](./architecture.md)
-- [Related: operational-recovery](./operational-recovery.md)
+- [Architecture](/knowledge/concepts/architecture/)
+- [Operational Recovery](/knowledge/concepts/operational-recovery/)
+
+# Citations
+
+- `.agents/skills/local-qa/SKILL.md`
+- `.agents/skills/market-analysis/SKILL.md`
+- `.agents/skills/update-cfd-instruments/SKILL.md`
+- `.agents/skills/aims-okf-author/SKILL.md`

--- a/content/knowledge/concepts/agent-skills.md
+++ b/content/knowledge/concepts/agent-skills.md
@@ -34,8 +34,8 @@ AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data avai
 
 ## Related concepts
 
-- [Architecture](/knowledge/concepts/architecture/)
-- [Operational Recovery](/knowledge/concepts/operational-recovery/)
+- [Architecture](../architecture/)
+- [Operational Recovery](../operational-recovery/)
 
 # Citations
 

--- a/content/knowledge/concepts/agent-skills.md
+++ b/content/knowledge/concepts/agent-skills.md
@@ -13,7 +13,7 @@ tags:
 - agents
 - skills
 - okf
-timestamp: 2026-06-16T00:00:00Z
+timestamp: '2026-06-16T00:00:00Z'
 title: Agent Skills
 type: knowledge
 ---

--- a/content/knowledge/concepts/agent-skills.md
+++ b/content/knowledge/concepts/agent-skills.md
@@ -1,0 +1,33 @@
+---
+description: Repository-local Agent Skills that guide AIMS automation, OKF curation, site generation, and PR review.
+id: okf/concepts/agent-skills
+params:
+  okf_type: concept
+resource:
+  path: okf/concepts/agent-skills.md
+  source: repository
+tags:
+  - agents
+  - skills
+  - okf
+timestamp: 2026-06-16T00:00:00Z
+title: Agent Skills
+type: knowledge
+---
+
+# Agent Skills
+
+Repository-local Agent Skills that guide AIMS automation, OKF curation, site generation, and PR review.
+
+## Source-of-truth boundary
+
+AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in `data/analysis/*.json` and generated daily reports in `content/results/`. This OKF concept captures durable repository knowledge only and must not invent or override generated numeric facts.
+
+## AIMS notes
+
+This concept is seeded from repository documentation, operations guidance, tests, workflows, and issue dceoy/aims#57. Update it through the OKF authoring and curation workflow when durable architecture or operational knowledge changes.
+
+## Related concepts
+
+- [Related: architecture](./architecture.md)
+- [Related: operational-recovery](./operational-recovery.md)

--- a/content/knowledge/concepts/agent-skills.md
+++ b/content/knowledge/concepts/agent-skills.md
@@ -1,18 +1,19 @@
 ---
 description: Repository-local Agent Skills that guide AIMS automation, OKF curation,
   site generation, and PR review.
-id: okf/concepts/agent-skills
 params:
+  okf_extra:
+    id: okf/concepts/agent-skills
+    status: seeded
   okf_type: concept
 resource:
   path: okf/concepts/agent-skills.md
   source: repository
-status: seeded
 tags:
 - agents
 - skills
 - okf
-timestamp: 2026-06-16 00:00:00+00:00
+timestamp: 2026-06-16T00:00:00Z
 title: Agent Skills
 type: knowledge
 ---

--- a/content/knowledge/concepts/architecture.md
+++ b/content/knowledge/concepts/architecture.md
@@ -13,7 +13,7 @@ tags:
 - architecture
 - okf
 - hugo
-timestamp: 2026-06-16T00:00:00Z
+timestamp: '2026-06-16T00:00:00Z'
 title: AIMS Architecture
 type: knowledge
 ---

--- a/content/knowledge/concepts/architecture.md
+++ b/content/knowledge/concepts/architecture.md
@@ -34,9 +34,9 @@ AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data avai
 
 ## Related concepts
 
-- [Data Sources](/knowledge/concepts/data-sources/)
-- [Report Generation](/knowledge/concepts/report-generation/)
-- [Publication Workflow](/knowledge/concepts/publication-workflow/)
+- [Data Sources](../data-sources/)
+- [Report Generation](../report-generation/)
+- [Publication Workflow](../publication-workflow/)
 
 # Citations
 

--- a/content/knowledge/concepts/architecture.md
+++ b/content/knowledge/concepts/architecture.md
@@ -1,34 +1,43 @@
 ---
-description: Repository-level architecture for the AIMS analysis pipeline, static site, OKF source, and generated knowledge pages.
+description: Repository-level architecture for the AIMS analysis pipeline, Hugo site,
+  OKF source, and generated knowledge pages.
 id: okf/concepts/architecture
 params:
   okf_type: concept
 resource:
   path: okf/concepts/architecture.md
   source: repository
+status: seeded
 tags:
-  - architecture
-  - okf
-  - hugo
-timestamp: 2026-06-16T00:00:00Z
+- architecture
+- okf
+- hugo
+timestamp: 2026-06-16 00:00:00+00:00
 title: AIMS Architecture
 type: knowledge
 ---
 
 # AIMS Architecture
 
-Repository-level architecture for the AIMS analysis pipeline, static site, OKF source, and generated knowledge pages.
+Repository-level architecture for the AIMS analysis pipeline, Hugo site, OKF source, and generated knowledge pages.
+
+## Repository facts
+
+AIMS combines Python automation with a Hugo static site. Python scripts live under `.agents/skills/`, tests live in `tests/`, schemas live under `data/schema/`, and Hugo source content lives under `content/`. Generated static output is written to the ignored `site/` directory.
+
+The OKF layer adds `okf/` as the durable knowledge source while preserving existing source-of-truth boundaries: daily analysis JSON remains under `data/analysis/`, public reports remain under `content/results/`, and `content/knowledge/` is regenerated from OKF.
 
 ## Source-of-truth boundary
 
-AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in `data/analysis/*.json` and generated daily reports in `content/results/`. This OKF concept captures durable repository knowledge only and must not invent or override generated numeric facts.
-
-## AIMS notes
-
-This concept is seeded from repository documentation, operations guidance, tests, workflows, and issue dceoy/aims#57. Update it through the OKF authoring and curation workflow when durable architecture or operational knowledge changes.
+AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in generated artifacts and validated reports. This OKF concept captures durable repository knowledge only.
 
 ## Related concepts
 
-- [Related: data-sources](./data-sources.md)
-- [Related: report-generation](./report-generation.md)
-- [Related: publication-workflow](./publication-workflow.md)
+- [Data Sources](/knowledge/concepts/data-sources/)
+- [Report Generation](/knowledge/concepts/report-generation/)
+- [Publication Workflow](/knowledge/concepts/publication-workflow/)
+
+# Citations
+
+- `AGENTS.md`
+- `README.md`

--- a/content/knowledge/concepts/architecture.md
+++ b/content/knowledge/concepts/architecture.md
@@ -1,18 +1,19 @@
 ---
 description: Repository-level architecture for the AIMS analysis pipeline, Hugo site,
   OKF source, and generated knowledge pages.
-id: okf/concepts/architecture
 params:
+  okf_extra:
+    id: okf/concepts/architecture
+    status: seeded
   okf_type: concept
 resource:
   path: okf/concepts/architecture.md
   source: repository
-status: seeded
 tags:
 - architecture
 - okf
 - hugo
-timestamp: 2026-06-16 00:00:00+00:00
+timestamp: 2026-06-16T00:00:00Z
 title: AIMS Architecture
 type: knowledge
 ---

--- a/content/knowledge/concepts/architecture.md
+++ b/content/knowledge/concepts/architecture.md
@@ -1,0 +1,34 @@
+---
+description: Repository-level architecture for the AIMS analysis pipeline, static site, OKF source, and generated knowledge pages.
+id: okf/concepts/architecture
+params:
+  okf_type: concept
+resource:
+  path: okf/concepts/architecture.md
+  source: repository
+tags:
+  - architecture
+  - okf
+  - hugo
+timestamp: 2026-06-16T00:00:00Z
+title: AIMS Architecture
+type: knowledge
+---
+
+# AIMS Architecture
+
+Repository-level architecture for the AIMS analysis pipeline, static site, OKF source, and generated knowledge pages.
+
+## Source-of-truth boundary
+
+AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in `data/analysis/*.json` and generated daily reports in `content/results/`. This OKF concept captures durable repository knowledge only and must not invent or override generated numeric facts.
+
+## AIMS notes
+
+This concept is seeded from repository documentation, operations guidance, tests, workflows, and issue dceoy/aims#57. Update it through the OKF authoring and curation workflow when durable architecture or operational knowledge changes.
+
+## Related concepts
+
+- [Related: data-sources](./data-sources.md)
+- [Related: report-generation](./report-generation.md)
+- [Related: publication-workflow](./publication-workflow.md)

--- a/content/knowledge/concepts/data-sources.md
+++ b/content/knowledge/concepts/data-sources.md
@@ -1,15 +1,17 @@
 ---
-description: Authoritative market and instrument data sources used by AIMS and the boundaries for durable knowledge updates.
+description: Authoritative market and instrument data sources used by AIMS and the
+  boundaries for durable knowledge updates.
 id: okf/concepts/data-sources
 params:
   okf_type: concept
 resource:
   path: okf/concepts/data-sources.md
   source: repository
+status: seeded
 tags:
-  - data-sources
-  - market-analysis
-timestamp: 2026-06-16T00:00:00Z
+- data-sources
+- market-analysis
+timestamp: 2026-06-16 00:00:00+00:00
 title: Data Sources
 type: knowledge
 ---
@@ -18,15 +20,23 @@ type: knowledge
 
 Authoritative market and instrument data sources used by AIMS and the boundaries for durable knowledge updates.
 
+## Repository facts
+
+AIMS fetches daily OHLCV history from Stooq using its free CSV download API. Configured Stooq symbols are maintained in `data/stooq_symbols.txt`.
+
+The CFD instrument master is a separate data source maintained in `data/cfd_instruments.csv`. It is refreshed by the weekly updater workflow and validated before the daily market analysis workflow runs.
+
 ## Source-of-truth boundary
 
-AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in `data/analysis/*.json` and generated daily reports in `content/results/`. This OKF concept captures durable repository knowledge only and must not invent or override generated numeric facts.
-
-## AIMS notes
-
-This concept is seeded from repository documentation, operations guidance, tests, workflows, and issue dceoy/aims#57. Update it through the OKF authoring and curation workflow when durable architecture or operational knowledge changes.
+AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in generated artifacts and validated reports. This OKF concept captures durable repository knowledge only.
 
 ## Related concepts
 
-- [Related: instrument-master](./instrument-master.md)
-- [Related: scoring-methodology](./scoring-methodology.md)
+- [Instrument Master](/knowledge/concepts/instrument-master/)
+- [Scoring Methodology](/knowledge/concepts/scoring-methodology/)
+
+# Citations
+
+- `OPERATIONS.md`
+- `.github/workflows/daily-market-analysis.yml`
+- `.github/workflows/update-cfd-instruments.yml`

--- a/content/knowledge/concepts/data-sources.md
+++ b/content/knowledge/concepts/data-sources.md
@@ -1,0 +1,32 @@
+---
+description: Authoritative market and instrument data sources used by AIMS and the boundaries for durable knowledge updates.
+id: okf/concepts/data-sources
+params:
+  okf_type: concept
+resource:
+  path: okf/concepts/data-sources.md
+  source: repository
+tags:
+  - data-sources
+  - market-analysis
+timestamp: 2026-06-16T00:00:00Z
+title: Data Sources
+type: knowledge
+---
+
+# Data Sources
+
+Authoritative market and instrument data sources used by AIMS and the boundaries for durable knowledge updates.
+
+## Source-of-truth boundary
+
+AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in `data/analysis/*.json` and generated daily reports in `content/results/`. This OKF concept captures durable repository knowledge only and must not invent or override generated numeric facts.
+
+## AIMS notes
+
+This concept is seeded from repository documentation, operations guidance, tests, workflows, and issue dceoy/aims#57. Update it through the OKF authoring and curation workflow when durable architecture or operational knowledge changes.
+
+## Related concepts
+
+- [Related: instrument-master](./instrument-master.md)
+- [Related: scoring-methodology](./scoring-methodology.md)

--- a/content/knowledge/concepts/data-sources.md
+++ b/content/knowledge/concepts/data-sources.md
@@ -33,8 +33,8 @@ AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data avai
 
 ## Related concepts
 
-- [Instrument Master](/knowledge/concepts/instrument-master/)
-- [Scoring Methodology](/knowledge/concepts/scoring-methodology/)
+- [Instrument Master](../instrument-master/)
+- [Scoring Methodology](../scoring-methodology/)
 
 # Citations
 

--- a/content/knowledge/concepts/data-sources.md
+++ b/content/knowledge/concepts/data-sources.md
@@ -1,17 +1,18 @@
 ---
 description: Authoritative market and instrument data sources used by AIMS and the
   boundaries for durable knowledge updates.
-id: okf/concepts/data-sources
 params:
+  okf_extra:
+    id: okf/concepts/data-sources
+    status: seeded
   okf_type: concept
 resource:
   path: okf/concepts/data-sources.md
   source: repository
-status: seeded
 tags:
 - data-sources
 - market-analysis
-timestamp: 2026-06-16 00:00:00+00:00
+timestamp: 2026-06-16T00:00:00Z
 title: Data Sources
 type: knowledge
 ---

--- a/content/knowledge/concepts/data-sources.md
+++ b/content/knowledge/concepts/data-sources.md
@@ -12,7 +12,7 @@ resource:
 tags:
 - data-sources
 - market-analysis
-timestamp: 2026-06-16T00:00:00Z
+timestamp: '2026-06-16T00:00:00Z'
 title: Data Sources
 type: knowledge
 ---

--- a/content/knowledge/concepts/instrument-master.md
+++ b/content/knowledge/concepts/instrument-master.md
@@ -1,18 +1,19 @@
 ---
 description: Canonical CFD instrument reference data and validation responsibilities
   in AIMS.
-id: okf/concepts/instrument-master
 params:
+  okf_extra:
+    id: okf/concepts/instrument-master
+    status: seeded
   okf_type: concept
 resource:
   path: okf/concepts/instrument-master.md
   source: repository
-status: seeded
 tags:
 - cfd
 - data
 - instrument-master
-timestamp: 2026-06-16 00:00:00+00:00
+timestamp: 2026-06-16T00:00:00Z
 title: Instrument Master
 type: knowledge
 ---

--- a/content/knowledge/concepts/instrument-master.md
+++ b/content/knowledge/concepts/instrument-master.md
@@ -1,16 +1,18 @@
 ---
-description: Canonical CFD instrument reference data and validation responsibilities in AIMS.
+description: Canonical CFD instrument reference data and validation responsibilities
+  in AIMS.
 id: okf/concepts/instrument-master
 params:
   okf_type: concept
 resource:
   path: okf/concepts/instrument-master.md
   source: repository
+status: seeded
 tags:
-  - cfd
-  - data
-  - instrument-master
-timestamp: 2026-06-16T00:00:00Z
+- cfd
+- data
+- instrument-master
+timestamp: 2026-06-16 00:00:00+00:00
 title: Instrument Master
 type: knowledge
 ---
@@ -19,15 +21,23 @@ type: knowledge
 
 Canonical CFD instrument reference data and validation responsibilities in AIMS.
 
+## Repository facts
+
+The CFD instrument master is stored in `data/cfd_instruments.csv` and sourced from GMO Click Securities and Rakuten Securities CFD lineup pages. Broker ticker symbols are maintained separately from Stooq symbols, with mappings in `data/mappings/cfd_ticker_mappings.csv`.
+
+The master CSV is validated against `data/schema/cfd_instruments.schema.json` after updates and before daily analysis.
+
 ## Source-of-truth boundary
 
-AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in `data/analysis/*.json` and generated daily reports in `content/results/`. This OKF concept captures durable repository knowledge only and must not invent or override generated numeric facts.
-
-## AIMS notes
-
-This concept is seeded from repository documentation, operations guidance, tests, workflows, and issue dceoy/aims#57. Update it through the OKF authoring and curation workflow when durable architecture or operational knowledge changes.
+AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in generated artifacts and validated reports. This OKF concept captures durable repository knowledge only.
 
 ## Related concepts
 
-- [Related: data-sources](./data-sources.md)
-- [Related: scoring-methodology](./scoring-methodology.md)
+- [Data Sources](/knowledge/concepts/data-sources/)
+- [Scoring Methodology](/knowledge/concepts/scoring-methodology/)
+
+# Citations
+
+- `OPERATIONS.md`
+- `data/schema/cfd_instruments.schema.json`
+- `.agents/skills/update-cfd-instruments/SKILL.md`

--- a/content/knowledge/concepts/instrument-master.md
+++ b/content/knowledge/concepts/instrument-master.md
@@ -34,8 +34,8 @@ AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data avai
 
 ## Related concepts
 
-- [Data Sources](/knowledge/concepts/data-sources/)
-- [Scoring Methodology](/knowledge/concepts/scoring-methodology/)
+- [Data Sources](../data-sources/)
+- [Scoring Methodology](../scoring-methodology/)
 
 # Citations
 

--- a/content/knowledge/concepts/instrument-master.md
+++ b/content/knowledge/concepts/instrument-master.md
@@ -13,7 +13,7 @@ tags:
 - cfd
 - data
 - instrument-master
-timestamp: 2026-06-16T00:00:00Z
+timestamp: '2026-06-16T00:00:00Z'
 title: Instrument Master
 type: knowledge
 ---

--- a/content/knowledge/concepts/instrument-master.md
+++ b/content/knowledge/concepts/instrument-master.md
@@ -1,0 +1,33 @@
+---
+description: Canonical CFD instrument reference data and validation responsibilities in AIMS.
+id: okf/concepts/instrument-master
+params:
+  okf_type: concept
+resource:
+  path: okf/concepts/instrument-master.md
+  source: repository
+tags:
+  - cfd
+  - data
+  - instrument-master
+timestamp: 2026-06-16T00:00:00Z
+title: Instrument Master
+type: knowledge
+---
+
+# Instrument Master
+
+Canonical CFD instrument reference data and validation responsibilities in AIMS.
+
+## Source-of-truth boundary
+
+AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in `data/analysis/*.json` and generated daily reports in `content/results/`. This OKF concept captures durable repository knowledge only and must not invent or override generated numeric facts.
+
+## AIMS notes
+
+This concept is seeded from repository documentation, operations guidance, tests, workflows, and issue dceoy/aims#57. Update it through the OKF authoring and curation workflow when durable architecture or operational knowledge changes.
+
+## Related concepts
+
+- [Related: data-sources](./data-sources.md)
+- [Related: scoring-methodology](./scoring-methodology.md)

--- a/content/knowledge/concepts/operational-recovery.md
+++ b/content/knowledge/concepts/operational-recovery.md
@@ -33,8 +33,8 @@ AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data avai
 
 ## Related concepts
 
-- [Publication Workflow](/knowledge/concepts/publication-workflow/)
-- [Agent Skills](/knowledge/concepts/agent-skills/)
+- [Publication Workflow](../publication-workflow/)
+- [Agent Skills](../agent-skills/)
 
 # Citations
 

--- a/content/knowledge/concepts/operational-recovery.md
+++ b/content/knowledge/concepts/operational-recovery.md
@@ -1,15 +1,17 @@
 ---
-description: Runbook-oriented knowledge for restoring AIMS analysis, validation, and publication workflows.
+description: Runbook-oriented knowledge for restoring AIMS analysis, validation, and
+  publication workflows.
 id: okf/concepts/operational-recovery
 params:
   okf_type: concept
 resource:
   path: okf/concepts/operational-recovery.md
   source: repository
+status: seeded
 tags:
-  - operations
-  - recovery
-timestamp: 2026-06-16T00:00:00Z
+- operations
+- recovery
+timestamp: 2026-06-16 00:00:00+00:00
 title: Operational Recovery
 type: knowledge
 ---
@@ -18,15 +20,22 @@ type: knowledge
 
 Runbook-oriented knowledge for restoring AIMS analysis, validation, and publication workflows.
 
+## Repository facts
+
+Operational recovery starts from the failing workflow step: Stooq fetch warnings are non-fatal per symbol, artifact validation failures should be fixed in the generated JSON or generator inputs, and site build failures should be reproduced locally with Hugo.
+
+Manual recovery uses the documented scripts and validations rather than editing generated outputs by hand.
+
 ## Source-of-truth boundary
 
-AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in `data/analysis/*.json` and generated daily reports in `content/results/`. This OKF concept captures durable repository knowledge only and must not invent or override generated numeric facts.
-
-## AIMS notes
-
-This concept is seeded from repository documentation, operations guidance, tests, workflows, and issue dceoy/aims#57. Update it through the OKF authoring and curation workflow when durable architecture or operational knowledge changes.
+AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in generated artifacts and validated reports. This OKF concept captures durable repository knowledge only.
 
 ## Related concepts
 
-- [Related: publication-workflow](./publication-workflow.md)
-- [Related: agent-skills](./agent-skills.md)
+- [Publication Workflow](/knowledge/concepts/publication-workflow/)
+- [Agent Skills](/knowledge/concepts/agent-skills/)
+
+# Citations
+
+- `OPERATIONS.md`
+- `.agents/skills/local-qa/SKILL.md`

--- a/content/knowledge/concepts/operational-recovery.md
+++ b/content/knowledge/concepts/operational-recovery.md
@@ -1,17 +1,18 @@
 ---
 description: Runbook-oriented knowledge for restoring AIMS analysis, validation, and
   publication workflows.
-id: okf/concepts/operational-recovery
 params:
+  okf_extra:
+    id: okf/concepts/operational-recovery
+    status: seeded
   okf_type: concept
 resource:
   path: okf/concepts/operational-recovery.md
   source: repository
-status: seeded
 tags:
 - operations
 - recovery
-timestamp: 2026-06-16 00:00:00+00:00
+timestamp: 2026-06-16T00:00:00Z
 title: Operational Recovery
 type: knowledge
 ---

--- a/content/knowledge/concepts/operational-recovery.md
+++ b/content/knowledge/concepts/operational-recovery.md
@@ -1,0 +1,32 @@
+---
+description: Runbook-oriented knowledge for restoring AIMS analysis, validation, and publication workflows.
+id: okf/concepts/operational-recovery
+params:
+  okf_type: concept
+resource:
+  path: okf/concepts/operational-recovery.md
+  source: repository
+tags:
+  - operations
+  - recovery
+timestamp: 2026-06-16T00:00:00Z
+title: Operational Recovery
+type: knowledge
+---
+
+# Operational Recovery
+
+Runbook-oriented knowledge for restoring AIMS analysis, validation, and publication workflows.
+
+## Source-of-truth boundary
+
+AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in `data/analysis/*.json` and generated daily reports in `content/results/`. This OKF concept captures durable repository knowledge only and must not invent or override generated numeric facts.
+
+## AIMS notes
+
+This concept is seeded from repository documentation, operations guidance, tests, workflows, and issue dceoy/aims#57. Update it through the OKF authoring and curation workflow when durable architecture or operational knowledge changes.
+
+## Related concepts
+
+- [Related: publication-workflow](./publication-workflow.md)
+- [Related: agent-skills](./agent-skills.md)

--- a/content/knowledge/concepts/operational-recovery.md
+++ b/content/knowledge/concepts/operational-recovery.md
@@ -12,7 +12,7 @@ resource:
 tags:
 - operations
 - recovery
-timestamp: 2026-06-16T00:00:00Z
+timestamp: '2026-06-16T00:00:00Z'
 title: Operational Recovery
 type: knowledge
 ---

--- a/content/knowledge/concepts/publication-workflow.md
+++ b/content/knowledge/concepts/publication-workflow.md
@@ -34,8 +34,8 @@ AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data avai
 
 ## Related concepts
 
-- [Architecture](/knowledge/concepts/architecture/)
-- [Operational Recovery](/knowledge/concepts/operational-recovery/)
+- [Architecture](../architecture/)
+- [Operational Recovery](../operational-recovery/)
 
 # Citations
 

--- a/content/knowledge/concepts/publication-workflow.md
+++ b/content/knowledge/concepts/publication-workflow.md
@@ -1,16 +1,18 @@
 ---
-description: How CI/CD, pull requests, and GitHub Pages publish AIMS reports and generated OKF shadow content.
+description: How CI/CD, pull requests, and GitHub Pages publish AIMS reports and generated
+  OKF shadow content.
 id: okf/concepts/publication-workflow
 params:
   okf_type: concept
 resource:
   path: okf/concepts/publication-workflow.md
   source: repository
+status: seeded
 tags:
-  - ci
-  - hugo
-  - publication
-timestamp: 2026-06-16T00:00:00Z
+- ci
+- hugo
+- publication
+timestamp: 2026-06-16 00:00:00+00:00
 title: Publication Workflow
 type: knowledge
 ---
@@ -19,15 +21,23 @@ type: knowledge
 
 How CI/CD, pull requests, and GitHub Pages publish AIMS reports and generated OKF shadow content.
 
+## Repository facts
+
+The daily analysis workflow validates the CFD master, generates JSON artifacts, validates the artifact, generates a Hugo report, builds the Hugo site for validation, and opens a pull request for review.
+
+The CI workflow deploys the Hugo site to GitHub Pages after linting, type checking, and tests pass. The OKF validation job checks generated knowledge content drift before deployment.
+
 ## Source-of-truth boundary
 
-AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in `data/analysis/*.json` and generated daily reports in `content/results/`. This OKF concept captures durable repository knowledge only and must not invent or override generated numeric facts.
-
-## AIMS notes
-
-This concept is seeded from repository documentation, operations guidance, tests, workflows, and issue dceoy/aims#57. Update it through the OKF authoring and curation workflow when durable architecture or operational knowledge changes.
+AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in generated artifacts and validated reports. This OKF concept captures durable repository knowledge only.
 
 ## Related concepts
 
-- [Related: architecture](./architecture.md)
-- [Related: operational-recovery](./operational-recovery.md)
+- [Architecture](/knowledge/concepts/architecture/)
+- [Operational Recovery](/knowledge/concepts/operational-recovery/)
+
+# Citations
+
+- `OPERATIONS.md`
+- `.github/workflows/daily-market-analysis.yml`
+- `.github/workflows/ci.yml`

--- a/content/knowledge/concepts/publication-workflow.md
+++ b/content/knowledge/concepts/publication-workflow.md
@@ -1,0 +1,33 @@
+---
+description: How CI/CD, pull requests, and GitHub Pages publish AIMS reports and generated OKF shadow content.
+id: okf/concepts/publication-workflow
+params:
+  okf_type: concept
+resource:
+  path: okf/concepts/publication-workflow.md
+  source: repository
+tags:
+  - ci
+  - hugo
+  - publication
+timestamp: 2026-06-16T00:00:00Z
+title: Publication Workflow
+type: knowledge
+---
+
+# Publication Workflow
+
+How CI/CD, pull requests, and GitHub Pages publish AIMS reports and generated OKF shadow content.
+
+## Source-of-truth boundary
+
+AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in `data/analysis/*.json` and generated daily reports in `content/results/`. This OKF concept captures durable repository knowledge only and must not invent or override generated numeric facts.
+
+## AIMS notes
+
+This concept is seeded from repository documentation, operations guidance, tests, workflows, and issue dceoy/aims#57. Update it through the OKF authoring and curation workflow when durable architecture or operational knowledge changes.
+
+## Related concepts
+
+- [Related: architecture](./architecture.md)
+- [Related: operational-recovery](./operational-recovery.md)

--- a/content/knowledge/concepts/publication-workflow.md
+++ b/content/knowledge/concepts/publication-workflow.md
@@ -1,18 +1,19 @@
 ---
 description: How CI/CD, pull requests, and GitHub Pages publish AIMS reports and generated
   OKF shadow content.
-id: okf/concepts/publication-workflow
 params:
+  okf_extra:
+    id: okf/concepts/publication-workflow
+    status: seeded
   okf_type: concept
 resource:
   path: okf/concepts/publication-workflow.md
   source: repository
-status: seeded
 tags:
 - ci
 - hugo
 - publication
-timestamp: 2026-06-16 00:00:00+00:00
+timestamp: 2026-06-16T00:00:00Z
 title: Publication Workflow
 type: knowledge
 ---

--- a/content/knowledge/concepts/publication-workflow.md
+++ b/content/knowledge/concepts/publication-workflow.md
@@ -13,7 +13,7 @@ tags:
 - ci
 - hugo
 - publication
-timestamp: 2026-06-16T00:00:00Z
+timestamp: '2026-06-16T00:00:00Z'
 title: Publication Workflow
 type: knowledge
 ---

--- a/content/knowledge/concepts/report-generation.md
+++ b/content/knowledge/concepts/report-generation.md
@@ -1,18 +1,19 @@
 ---
 description: How deterministic JSON analysis artifacts become public Hugo market analysis
   reports.
-id: okf/concepts/report-generation
 params:
+  okf_extra:
+    id: okf/concepts/report-generation
+    status: seeded
   okf_type: concept
 resource:
   path: okf/concepts/report-generation.md
   source: repository
-status: seeded
 tags:
 - reports
 - hugo
 - market-analysis
-timestamp: 2026-06-16 00:00:00+00:00
+timestamp: 2026-06-16T00:00:00Z
 title: Report Generation
 type: knowledge
 ---

--- a/content/knowledge/concepts/report-generation.md
+++ b/content/knowledge/concepts/report-generation.md
@@ -34,8 +34,8 @@ AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data avai
 
 ## Related concepts
 
-- [Architecture](/knowledge/concepts/architecture/)
-- [Publication Workflow](/knowledge/concepts/publication-workflow/)
+- [Architecture](../architecture/)
+- [Publication Workflow](../publication-workflow/)
 
 # Citations
 

--- a/content/knowledge/concepts/report-generation.md
+++ b/content/knowledge/concepts/report-generation.md
@@ -1,16 +1,18 @@
 ---
-description: How deterministic JSON analysis artifacts become public Hugo market analysis reports.
+description: How deterministic JSON analysis artifacts become public Hugo market analysis
+  reports.
 id: okf/concepts/report-generation
 params:
   okf_type: concept
 resource:
   path: okf/concepts/report-generation.md
   source: repository
+status: seeded
 tags:
-  - reports
-  - hugo
-  - market-analysis
-timestamp: 2026-06-16T00:00:00Z
+- reports
+- hugo
+- market-analysis
+timestamp: 2026-06-16 00:00:00+00:00
 title: Report Generation
 type: knowledge
 ---
@@ -19,15 +21,23 @@ type: knowledge
 
 How deterministic JSON analysis artifacts become public Hugo market analysis reports.
 
+## Repository facts
+
+The report generator reads `data/analysis/YYYY-MM-DD.json` and writes Hugo Markdown reports to `content/results/YYYY-MM-DD-market-analysis.md`. The generator is deterministic: identical JSON input produces identical Markdown output and the report timestamp comes from the artifact.
+
+OKF-generated `content/knowledge/` pages are separate from `content/results/` reports and do not replace daily report generation.
+
 ## Source-of-truth boundary
 
-AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in `data/analysis/*.json` and generated daily reports in `content/results/`. This OKF concept captures durable repository knowledge only and must not invent or override generated numeric facts.
-
-## AIMS notes
-
-This concept is seeded from repository documentation, operations guidance, tests, workflows, and issue dceoy/aims#57. Update it through the OKF authoring and curation workflow when durable architecture or operational knowledge changes.
+AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in generated artifacts and validated reports. This OKF concept captures durable repository knowledge only.
 
 ## Related concepts
 
-- [Related: architecture](./architecture.md)
-- [Related: publication-workflow](./publication-workflow.md)
+- [Architecture](/knowledge/concepts/architecture/)
+- [Publication Workflow](/knowledge/concepts/publication-workflow/)
+
+# Citations
+
+- `OPERATIONS.md`
+- `README.md`
+- `tests/golden/2024-01-01-market-analysis.md`

--- a/content/knowledge/concepts/report-generation.md
+++ b/content/knowledge/concepts/report-generation.md
@@ -1,0 +1,33 @@
+---
+description: How deterministic JSON analysis artifacts become public Hugo market analysis reports.
+id: okf/concepts/report-generation
+params:
+  okf_type: concept
+resource:
+  path: okf/concepts/report-generation.md
+  source: repository
+tags:
+  - reports
+  - hugo
+  - market-analysis
+timestamp: 2026-06-16T00:00:00Z
+title: Report Generation
+type: knowledge
+---
+
+# Report Generation
+
+How deterministic JSON analysis artifacts become public Hugo market analysis reports.
+
+## Source-of-truth boundary
+
+AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in `data/analysis/*.json` and generated daily reports in `content/results/`. This OKF concept captures durable repository knowledge only and must not invent or override generated numeric facts.
+
+## AIMS notes
+
+This concept is seeded from repository documentation, operations guidance, tests, workflows, and issue dceoy/aims#57. Update it through the OKF authoring and curation workflow when durable architecture or operational knowledge changes.
+
+## Related concepts
+
+- [Related: architecture](./architecture.md)
+- [Related: publication-workflow](./publication-workflow.md)

--- a/content/knowledge/concepts/report-generation.md
+++ b/content/knowledge/concepts/report-generation.md
@@ -13,7 +13,7 @@ tags:
 - reports
 - hugo
 - market-analysis
-timestamp: 2026-06-16T00:00:00Z
+timestamp: '2026-06-16T00:00:00Z'
 title: Report Generation
 type: knowledge
 ---

--- a/content/knowledge/concepts/scoring-methodology.md
+++ b/content/knowledge/concepts/scoring-methodology.md
@@ -12,7 +12,7 @@ resource:
 tags:
 - scoring
 - market-analysis
-timestamp: 2026-06-16T00:00:00Z
+timestamp: '2026-06-16T00:00:00Z'
 title: Scoring Methodology
 type: knowledge
 ---

--- a/content/knowledge/concepts/scoring-methodology.md
+++ b/content/knowledge/concepts/scoring-methodology.md
@@ -1,15 +1,17 @@
 ---
-description: How AIMS treats analysis artifacts, score semantics, ranking outputs, and risk gates as generated numeric facts.
+description: How AIMS treats analysis artifacts, score semantics, ranking outputs,
+  and risk gates as generated numeric facts.
 id: okf/concepts/scoring-methodology
 params:
   okf_type: concept
 resource:
   path: okf/concepts/scoring-methodology.md
   source: repository
+status: seeded
 tags:
-  - scoring
-  - market-analysis
-timestamp: 2026-06-16T00:00:00Z
+- scoring
+- market-analysis
+timestamp: 2026-06-16 00:00:00+00:00
 title: Scoring Methodology
 type: knowledge
 ---
@@ -18,15 +20,23 @@ type: knowledge
 
 How AIMS treats analysis artifacts, score semantics, ranking outputs, and risk gates as generated numeric facts.
 
+## Repository facts
+
+AIMS computes cross-sectional rankings from daily OHLCV-derived features and produces a composite score from percentile ranks. Risk gates mark unreliable instruments, which remain in output but are ranked below reliable instruments.
+
+OKF concepts may summarize durable methodology, but numeric market facts, scores, ranks, dates, risk gates, and availability remain authoritative only in generated analysis artifacts and validated report outputs.
+
 ## Source-of-truth boundary
 
-AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in `data/analysis/*.json` and generated daily reports in `content/results/`. This OKF concept captures durable repository knowledge only and must not invent or override generated numeric facts.
-
-## AIMS notes
-
-This concept is seeded from repository documentation, operations guidance, tests, workflows, and issue dceoy/aims#57. Update it through the OKF authoring and curation workflow when durable architecture or operational knowledge changes.
+AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in generated artifacts and validated reports. This OKF concept captures durable repository knowledge only.
 
 ## Related concepts
 
-- [Related: data-sources](./data-sources.md)
-- [Related: report-generation](./report-generation.md)
+- [Data Sources](/knowledge/concepts/data-sources/)
+- [Report Generation](/knowledge/concepts/report-generation/)
+
+# Citations
+
+- `OPERATIONS.md`
+- `data/schema/analysis.schema.json`
+- `AGENTS.md`

--- a/content/knowledge/concepts/scoring-methodology.md
+++ b/content/knowledge/concepts/scoring-methodology.md
@@ -1,17 +1,18 @@
 ---
 description: How AIMS treats analysis artifacts, score semantics, ranking outputs,
   and risk gates as generated numeric facts.
-id: okf/concepts/scoring-methodology
 params:
+  okf_extra:
+    id: okf/concepts/scoring-methodology
+    status: seeded
   okf_type: concept
 resource:
   path: okf/concepts/scoring-methodology.md
   source: repository
-status: seeded
 tags:
 - scoring
 - market-analysis
-timestamp: 2026-06-16 00:00:00+00:00
+timestamp: 2026-06-16T00:00:00Z
 title: Scoring Methodology
 type: knowledge
 ---

--- a/content/knowledge/concepts/scoring-methodology.md
+++ b/content/knowledge/concepts/scoring-methodology.md
@@ -1,0 +1,32 @@
+---
+description: How AIMS treats analysis artifacts, score semantics, ranking outputs, and risk gates as generated numeric facts.
+id: okf/concepts/scoring-methodology
+params:
+  okf_type: concept
+resource:
+  path: okf/concepts/scoring-methodology.md
+  source: repository
+tags:
+  - scoring
+  - market-analysis
+timestamp: 2026-06-16T00:00:00Z
+title: Scoring Methodology
+type: knowledge
+---
+
+# Scoring Methodology
+
+How AIMS treats analysis artifacts, score semantics, ranking outputs, and risk gates as generated numeric facts.
+
+## Source-of-truth boundary
+
+AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in `data/analysis/*.json` and generated daily reports in `content/results/`. This OKF concept captures durable repository knowledge only and must not invent or override generated numeric facts.
+
+## AIMS notes
+
+This concept is seeded from repository documentation, operations guidance, tests, workflows, and issue dceoy/aims#57. Update it through the OKF authoring and curation workflow when durable architecture or operational knowledge changes.
+
+## Related concepts
+
+- [Related: data-sources](./data-sources.md)
+- [Related: report-generation](./report-generation.md)

--- a/content/knowledge/concepts/scoring-methodology.md
+++ b/content/knowledge/concepts/scoring-methodology.md
@@ -33,8 +33,8 @@ AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data avai
 
 ## Related concepts
 
-- [Data Sources](/knowledge/concepts/data-sources/)
-- [Report Generation](/knowledge/concepts/report-generation/)
+- [Data Sources](../data-sources/)
+- [Report Generation](../report-generation/)
 
 # Citations
 

--- a/content/knowledge/logs/log.md
+++ b/content/knowledge/logs/log.md
@@ -1,23 +1,16 @@
 ---
-description: Append-only curation log for durable AIMS OKF knowledge changes.
-id: okf/logs/log
+description: Generated from logs/log.md.
 params:
-  okf_type: log
+  okf_reserved: log
 resource:
-  path: okf/logs/log.md
-  source: repository
-tags:
-  - okf
-  - log
-timestamp: 2026-06-16T00:00:00Z
+  path: logs/log.md
 title: AIMS OKF Log
 type: knowledge
 ---
-
 # AIMS OKF Log
 
 ## 2026-06-16
 
-- Established `okf/` as the canonical knowledge source for durable AIMS concepts.
-- Added generated `content/knowledge/` shadow content as Hugo publication output.
+- Established `okf/` as the canonical OKF v0.1 knowledge source for durable AIMS concepts.
+- Added generated `content/knowledge/` shadow content as Hugo publication output, not a canonical authoring location.
 - Seeded initial concepts for architecture, data sources, instrument master data, scoring methodology, report generation, publication, recovery, and Agent Skills.

--- a/content/knowledge/logs/log.md
+++ b/content/knowledge/logs/log.md
@@ -1,0 +1,23 @@
+---
+description: Append-only curation log for durable AIMS OKF knowledge changes.
+id: okf/logs/log
+params:
+  okf_type: log
+resource:
+  path: okf/logs/log.md
+  source: repository
+tags:
+  - okf
+  - log
+timestamp: 2026-06-16T00:00:00Z
+title: AIMS OKF Log
+type: knowledge
+---
+
+# AIMS OKF Log
+
+## 2026-06-16
+
+- Established `okf/` as the canonical knowledge source for durable AIMS concepts.
+- Added generated `content/knowledge/` shadow content as Hugo publication output.
+- Seeded initial concepts for architecture, data sources, instrument master data, scoring methodology, report generation, publication, recovery, and Agent Skills.

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/dceoy/aims
 
-go 1.26.3
+go 1.22.0
 
 require github.com/jpanther/congo/v2 v2.14.0 // indirect

--- a/okf/concepts/agent-skills.md
+++ b/okf/concepts/agent-skills.md
@@ -3,29 +3,36 @@ id: okf/concepts/agent-skills
 title: Agent Skills
 description: Repository-local Agent Skills that guide AIMS automation, OKF curation, site generation, and PR review.
 type: concept
-tags:
-  - agents
-  - skills
-  - okf
+tags: [agents, skills, okf]
 timestamp: 2026-06-16T00:00:00Z
 resource:
   path: okf/concepts/agent-skills.md
   source: repository
+status: seeded
 ---
 
 # Agent Skills
 
 Repository-local Agent Skills that guide AIMS automation, OKF curation, site generation, and PR review.
 
+## Repository facts
+
+Repository-local Agent Skills describe repeatable workflows for market analysis, CFD instrument updates, local QA, PR feedback triage, and OKF maintenance. The OKF author, curator, site, and PR-review skills point agents at canonical `okf/` edits and generated `content/knowledge/` validation.
+
+Agent workflows must keep generated knowledge separate from canonical OKF and must not invent numeric market facts.
+
 ## Source-of-truth boundary
 
-AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in `data/analysis/*.json` and generated daily reports in `content/results/`. This OKF concept captures durable repository knowledge only and must not invent or override generated numeric facts.
-
-## AIMS notes
-
-This concept is seeded from repository documentation, operations guidance, tests, workflows, and issue dceoy/aims#57. Update it through the OKF authoring and curation workflow when durable architecture or operational knowledge changes.
+AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in generated artifacts and validated reports. This OKF concept captures durable repository knowledge only.
 
 ## Related concepts
 
-- [Related: architecture](./architecture.md)
-- [Related: operational-recovery](./operational-recovery.md)
+- [Architecture](/concepts/architecture.md)
+- [Operational Recovery](/concepts/operational-recovery.md)
+
+# Citations
+
+- `.agents/skills/local-qa/SKILL.md`
+- `.agents/skills/market-analysis/SKILL.md`
+- `.agents/skills/update-cfd-instruments/SKILL.md`
+- `.agents/skills/aims-okf-author/SKILL.md`

--- a/okf/concepts/agent-skills.md
+++ b/okf/concepts/agent-skills.md
@@ -1,0 +1,31 @@
+---
+id: okf/concepts/agent-skills
+title: Agent Skills
+description: Repository-local Agent Skills that guide AIMS automation, OKF curation, site generation, and PR review.
+type: concept
+tags:
+  - agents
+  - skills
+  - okf
+timestamp: 2026-06-16T00:00:00Z
+resource:
+  path: okf/concepts/agent-skills.md
+  source: repository
+---
+
+# Agent Skills
+
+Repository-local Agent Skills that guide AIMS automation, OKF curation, site generation, and PR review.
+
+## Source-of-truth boundary
+
+AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in `data/analysis/*.json` and generated daily reports in `content/results/`. This OKF concept captures durable repository knowledge only and must not invent or override generated numeric facts.
+
+## AIMS notes
+
+This concept is seeded from repository documentation, operations guidance, tests, workflows, and issue dceoy/aims#57. Update it through the OKF authoring and curation workflow when durable architecture or operational knowledge changes.
+
+## Related concepts
+
+- [Related: architecture](./architecture.md)
+- [Related: operational-recovery](./operational-recovery.md)

--- a/okf/concepts/architecture.md
+++ b/okf/concepts/architecture.md
@@ -1,0 +1,32 @@
+---
+id: okf/concepts/architecture
+title: AIMS Architecture
+description: Repository-level architecture for the AIMS analysis pipeline, static site, OKF source, and generated knowledge pages.
+type: concept
+tags:
+  - architecture
+  - okf
+  - hugo
+timestamp: 2026-06-16T00:00:00Z
+resource:
+  path: okf/concepts/architecture.md
+  source: repository
+---
+
+# AIMS Architecture
+
+Repository-level architecture for the AIMS analysis pipeline, static site, OKF source, and generated knowledge pages.
+
+## Source-of-truth boundary
+
+AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in `data/analysis/*.json` and generated daily reports in `content/results/`. This OKF concept captures durable repository knowledge only and must not invent or override generated numeric facts.
+
+## AIMS notes
+
+This concept is seeded from repository documentation, operations guidance, tests, workflows, and issue dceoy/aims#57. Update it through the OKF authoring and curation workflow when durable architecture or operational knowledge changes.
+
+## Related concepts
+
+- [Related: data-sources](./data-sources.md)
+- [Related: report-generation](./report-generation.md)
+- [Related: publication-workflow](./publication-workflow.md)

--- a/okf/concepts/architecture.md
+++ b/okf/concepts/architecture.md
@@ -1,32 +1,37 @@
 ---
 id: okf/concepts/architecture
 title: AIMS Architecture
-description: Repository-level architecture for the AIMS analysis pipeline, static site, OKF source, and generated knowledge pages.
+description: Repository-level architecture for the AIMS analysis pipeline, Hugo site, OKF source, and generated knowledge pages.
 type: concept
-tags:
-  - architecture
-  - okf
-  - hugo
+tags: [architecture, okf, hugo]
 timestamp: 2026-06-16T00:00:00Z
 resource:
   path: okf/concepts/architecture.md
   source: repository
+status: seeded
 ---
 
 # AIMS Architecture
 
-Repository-level architecture for the AIMS analysis pipeline, static site, OKF source, and generated knowledge pages.
+Repository-level architecture for the AIMS analysis pipeline, Hugo site, OKF source, and generated knowledge pages.
+
+## Repository facts
+
+AIMS combines Python automation with a Hugo static site. Python scripts live under `.agents/skills/`, tests live in `tests/`, schemas live under `data/schema/`, and Hugo source content lives under `content/`. Generated static output is written to the ignored `site/` directory.
+
+The OKF layer adds `okf/` as the durable knowledge source while preserving existing source-of-truth boundaries: daily analysis JSON remains under `data/analysis/`, public reports remain under `content/results/`, and `content/knowledge/` is regenerated from OKF.
 
 ## Source-of-truth boundary
 
-AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in `data/analysis/*.json` and generated daily reports in `content/results/`. This OKF concept captures durable repository knowledge only and must not invent or override generated numeric facts.
-
-## AIMS notes
-
-This concept is seeded from repository documentation, operations guidance, tests, workflows, and issue dceoy/aims#57. Update it through the OKF authoring and curation workflow when durable architecture or operational knowledge changes.
+AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in generated artifacts and validated reports. This OKF concept captures durable repository knowledge only.
 
 ## Related concepts
 
-- [Related: data-sources](./data-sources.md)
-- [Related: report-generation](./report-generation.md)
-- [Related: publication-workflow](./publication-workflow.md)
+- [Data Sources](/concepts/data-sources.md)
+- [Report Generation](/concepts/report-generation.md)
+- [Publication Workflow](/concepts/publication-workflow.md)
+
+# Citations
+
+- `AGENTS.md`
+- `README.md`

--- a/okf/concepts/data-sources.md
+++ b/okf/concepts/data-sources.md
@@ -1,0 +1,30 @@
+---
+id: okf/concepts/data-sources
+title: Data Sources
+description: Authoritative market and instrument data sources used by AIMS and the boundaries for durable knowledge updates.
+type: concept
+tags:
+  - data-sources
+  - market-analysis
+timestamp: 2026-06-16T00:00:00Z
+resource:
+  path: okf/concepts/data-sources.md
+  source: repository
+---
+
+# Data Sources
+
+Authoritative market and instrument data sources used by AIMS and the boundaries for durable knowledge updates.
+
+## Source-of-truth boundary
+
+AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in `data/analysis/*.json` and generated daily reports in `content/results/`. This OKF concept captures durable repository knowledge only and must not invent or override generated numeric facts.
+
+## AIMS notes
+
+This concept is seeded from repository documentation, operations guidance, tests, workflows, and issue dceoy/aims#57. Update it through the OKF authoring and curation workflow when durable architecture or operational knowledge changes.
+
+## Related concepts
+
+- [Related: instrument-master](./instrument-master.md)
+- [Related: scoring-methodology](./scoring-methodology.md)

--- a/okf/concepts/data-sources.md
+++ b/okf/concepts/data-sources.md
@@ -3,28 +3,35 @@ id: okf/concepts/data-sources
 title: Data Sources
 description: Authoritative market and instrument data sources used by AIMS and the boundaries for durable knowledge updates.
 type: concept
-tags:
-  - data-sources
-  - market-analysis
+tags: [data-sources, market-analysis]
 timestamp: 2026-06-16T00:00:00Z
 resource:
   path: okf/concepts/data-sources.md
   source: repository
+status: seeded
 ---
 
 # Data Sources
 
 Authoritative market and instrument data sources used by AIMS and the boundaries for durable knowledge updates.
 
+## Repository facts
+
+AIMS fetches daily OHLCV history from Stooq using its free CSV download API. Configured Stooq symbols are maintained in `data/stooq_symbols.txt`.
+
+The CFD instrument master is a separate data source maintained in `data/cfd_instruments.csv`. It is refreshed by the weekly updater workflow and validated before the daily market analysis workflow runs.
+
 ## Source-of-truth boundary
 
-AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in `data/analysis/*.json` and generated daily reports in `content/results/`. This OKF concept captures durable repository knowledge only and must not invent or override generated numeric facts.
-
-## AIMS notes
-
-This concept is seeded from repository documentation, operations guidance, tests, workflows, and issue dceoy/aims#57. Update it through the OKF authoring and curation workflow when durable architecture or operational knowledge changes.
+AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in generated artifacts and validated reports. This OKF concept captures durable repository knowledge only.
 
 ## Related concepts
 
-- [Related: instrument-master](./instrument-master.md)
-- [Related: scoring-methodology](./scoring-methodology.md)
+- [Instrument Master](/concepts/instrument-master.md)
+- [Scoring Methodology](/concepts/scoring-methodology.md)
+
+# Citations
+
+- `OPERATIONS.md`
+- `.github/workflows/daily-market-analysis.yml`
+- `.github/workflows/update-cfd-instruments.yml`

--- a/okf/concepts/instrument-master.md
+++ b/okf/concepts/instrument-master.md
@@ -1,0 +1,31 @@
+---
+id: okf/concepts/instrument-master
+title: Instrument Master
+description: Canonical CFD instrument reference data and validation responsibilities in AIMS.
+type: concept
+tags:
+  - cfd
+  - data
+  - instrument-master
+timestamp: 2026-06-16T00:00:00Z
+resource:
+  path: okf/concepts/instrument-master.md
+  source: repository
+---
+
+# Instrument Master
+
+Canonical CFD instrument reference data and validation responsibilities in AIMS.
+
+## Source-of-truth boundary
+
+AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in `data/analysis/*.json` and generated daily reports in `content/results/`. This OKF concept captures durable repository knowledge only and must not invent or override generated numeric facts.
+
+## AIMS notes
+
+This concept is seeded from repository documentation, operations guidance, tests, workflows, and issue dceoy/aims#57. Update it through the OKF authoring and curation workflow when durable architecture or operational knowledge changes.
+
+## Related concepts
+
+- [Related: data-sources](./data-sources.md)
+- [Related: scoring-methodology](./scoring-methodology.md)

--- a/okf/concepts/instrument-master.md
+++ b/okf/concepts/instrument-master.md
@@ -3,29 +3,35 @@ id: okf/concepts/instrument-master
 title: Instrument Master
 description: Canonical CFD instrument reference data and validation responsibilities in AIMS.
 type: concept
-tags:
-  - cfd
-  - data
-  - instrument-master
+tags: [cfd, data, instrument-master]
 timestamp: 2026-06-16T00:00:00Z
 resource:
   path: okf/concepts/instrument-master.md
   source: repository
+status: seeded
 ---
 
 # Instrument Master
 
 Canonical CFD instrument reference data and validation responsibilities in AIMS.
 
+## Repository facts
+
+The CFD instrument master is stored in `data/cfd_instruments.csv` and sourced from GMO Click Securities and Rakuten Securities CFD lineup pages. Broker ticker symbols are maintained separately from Stooq symbols, with mappings in `data/mappings/cfd_ticker_mappings.csv`.
+
+The master CSV is validated against `data/schema/cfd_instruments.schema.json` after updates and before daily analysis.
+
 ## Source-of-truth boundary
 
-AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in `data/analysis/*.json` and generated daily reports in `content/results/`. This OKF concept captures durable repository knowledge only and must not invent or override generated numeric facts.
-
-## AIMS notes
-
-This concept is seeded from repository documentation, operations guidance, tests, workflows, and issue dceoy/aims#57. Update it through the OKF authoring and curation workflow when durable architecture or operational knowledge changes.
+AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in generated artifacts and validated reports. This OKF concept captures durable repository knowledge only.
 
 ## Related concepts
 
-- [Related: data-sources](./data-sources.md)
-- [Related: scoring-methodology](./scoring-methodology.md)
+- [Data Sources](/concepts/data-sources.md)
+- [Scoring Methodology](/concepts/scoring-methodology.md)
+
+# Citations
+
+- `OPERATIONS.md`
+- `data/schema/cfd_instruments.schema.json`
+- `.agents/skills/update-cfd-instruments/SKILL.md`

--- a/okf/concepts/operational-recovery.md
+++ b/okf/concepts/operational-recovery.md
@@ -3,28 +3,34 @@ id: okf/concepts/operational-recovery
 title: Operational Recovery
 description: Runbook-oriented knowledge for restoring AIMS analysis, validation, and publication workflows.
 type: concept
-tags:
-  - operations
-  - recovery
+tags: [operations, recovery]
 timestamp: 2026-06-16T00:00:00Z
 resource:
   path: okf/concepts/operational-recovery.md
   source: repository
+status: seeded
 ---
 
 # Operational Recovery
 
 Runbook-oriented knowledge for restoring AIMS analysis, validation, and publication workflows.
 
+## Repository facts
+
+Operational recovery starts from the failing workflow step: Stooq fetch warnings are non-fatal per symbol, artifact validation failures should be fixed in the generated JSON or generator inputs, and site build failures should be reproduced locally with Hugo.
+
+Manual recovery uses the documented scripts and validations rather than editing generated outputs by hand.
+
 ## Source-of-truth boundary
 
-AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in `data/analysis/*.json` and generated daily reports in `content/results/`. This OKF concept captures durable repository knowledge only and must not invent or override generated numeric facts.
-
-## AIMS notes
-
-This concept is seeded from repository documentation, operations guidance, tests, workflows, and issue dceoy/aims#57. Update it through the OKF authoring and curation workflow when durable architecture or operational knowledge changes.
+AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in generated artifacts and validated reports. This OKF concept captures durable repository knowledge only.
 
 ## Related concepts
 
-- [Related: publication-workflow](./publication-workflow.md)
-- [Related: agent-skills](./agent-skills.md)
+- [Publication Workflow](/concepts/publication-workflow.md)
+- [Agent Skills](/concepts/agent-skills.md)
+
+# Citations
+
+- `OPERATIONS.md`
+- `.agents/skills/local-qa/SKILL.md`

--- a/okf/concepts/operational-recovery.md
+++ b/okf/concepts/operational-recovery.md
@@ -1,0 +1,30 @@
+---
+id: okf/concepts/operational-recovery
+title: Operational Recovery
+description: Runbook-oriented knowledge for restoring AIMS analysis, validation, and publication workflows.
+type: concept
+tags:
+  - operations
+  - recovery
+timestamp: 2026-06-16T00:00:00Z
+resource:
+  path: okf/concepts/operational-recovery.md
+  source: repository
+---
+
+# Operational Recovery
+
+Runbook-oriented knowledge for restoring AIMS analysis, validation, and publication workflows.
+
+## Source-of-truth boundary
+
+AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in `data/analysis/*.json` and generated daily reports in `content/results/`. This OKF concept captures durable repository knowledge only and must not invent or override generated numeric facts.
+
+## AIMS notes
+
+This concept is seeded from repository documentation, operations guidance, tests, workflows, and issue dceoy/aims#57. Update it through the OKF authoring and curation workflow when durable architecture or operational knowledge changes.
+
+## Related concepts
+
+- [Related: publication-workflow](./publication-workflow.md)
+- [Related: agent-skills](./agent-skills.md)

--- a/okf/concepts/publication-workflow.md
+++ b/okf/concepts/publication-workflow.md
@@ -3,29 +3,35 @@ id: okf/concepts/publication-workflow
 title: Publication Workflow
 description: How CI/CD, pull requests, and GitHub Pages publish AIMS reports and generated OKF shadow content.
 type: concept
-tags:
-  - ci
-  - hugo
-  - publication
+tags: [ci, hugo, publication]
 timestamp: 2026-06-16T00:00:00Z
 resource:
   path: okf/concepts/publication-workflow.md
   source: repository
+status: seeded
 ---
 
 # Publication Workflow
 
 How CI/CD, pull requests, and GitHub Pages publish AIMS reports and generated OKF shadow content.
 
+## Repository facts
+
+The daily analysis workflow validates the CFD master, generates JSON artifacts, validates the artifact, generates a Hugo report, builds the Hugo site for validation, and opens a pull request for review.
+
+The CI workflow deploys the Hugo site to GitHub Pages after linting, type checking, and tests pass. The OKF validation job checks generated knowledge content drift before deployment.
+
 ## Source-of-truth boundary
 
-AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in `data/analysis/*.json` and generated daily reports in `content/results/`. This OKF concept captures durable repository knowledge only and must not invent or override generated numeric facts.
-
-## AIMS notes
-
-This concept is seeded from repository documentation, operations guidance, tests, workflows, and issue dceoy/aims#57. Update it through the OKF authoring and curation workflow when durable architecture or operational knowledge changes.
+AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in generated artifacts and validated reports. This OKF concept captures durable repository knowledge only.
 
 ## Related concepts
 
-- [Related: architecture](./architecture.md)
-- [Related: operational-recovery](./operational-recovery.md)
+- [Architecture](/concepts/architecture.md)
+- [Operational Recovery](/concepts/operational-recovery.md)
+
+# Citations
+
+- `OPERATIONS.md`
+- `.github/workflows/daily-market-analysis.yml`
+- `.github/workflows/ci.yml`

--- a/okf/concepts/publication-workflow.md
+++ b/okf/concepts/publication-workflow.md
@@ -1,0 +1,31 @@
+---
+id: okf/concepts/publication-workflow
+title: Publication Workflow
+description: How CI/CD, pull requests, and GitHub Pages publish AIMS reports and generated OKF shadow content.
+type: concept
+tags:
+  - ci
+  - hugo
+  - publication
+timestamp: 2026-06-16T00:00:00Z
+resource:
+  path: okf/concepts/publication-workflow.md
+  source: repository
+---
+
+# Publication Workflow
+
+How CI/CD, pull requests, and GitHub Pages publish AIMS reports and generated OKF shadow content.
+
+## Source-of-truth boundary
+
+AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in `data/analysis/*.json` and generated daily reports in `content/results/`. This OKF concept captures durable repository knowledge only and must not invent or override generated numeric facts.
+
+## AIMS notes
+
+This concept is seeded from repository documentation, operations guidance, tests, workflows, and issue dceoy/aims#57. Update it through the OKF authoring and curation workflow when durable architecture or operational knowledge changes.
+
+## Related concepts
+
+- [Related: architecture](./architecture.md)
+- [Related: operational-recovery](./operational-recovery.md)

--- a/okf/concepts/report-generation.md
+++ b/okf/concepts/report-generation.md
@@ -3,29 +3,35 @@ id: okf/concepts/report-generation
 title: Report Generation
 description: How deterministic JSON analysis artifacts become public Hugo market analysis reports.
 type: concept
-tags:
-  - reports
-  - hugo
-  - market-analysis
+tags: [reports, hugo, market-analysis]
 timestamp: 2026-06-16T00:00:00Z
 resource:
   path: okf/concepts/report-generation.md
   source: repository
+status: seeded
 ---
 
 # Report Generation
 
 How deterministic JSON analysis artifacts become public Hugo market analysis reports.
 
+## Repository facts
+
+The report generator reads `data/analysis/YYYY-MM-DD.json` and writes Hugo Markdown reports to `content/results/YYYY-MM-DD-market-analysis.md`. The generator is deterministic: identical JSON input produces identical Markdown output and the report timestamp comes from the artifact.
+
+OKF-generated `content/knowledge/` pages are separate from `content/results/` reports and do not replace daily report generation.
+
 ## Source-of-truth boundary
 
-AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in `data/analysis/*.json` and generated daily reports in `content/results/`. This OKF concept captures durable repository knowledge only and must not invent or override generated numeric facts.
-
-## AIMS notes
-
-This concept is seeded from repository documentation, operations guidance, tests, workflows, and issue dceoy/aims#57. Update it through the OKF authoring and curation workflow when durable architecture or operational knowledge changes.
+AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in generated artifacts and validated reports. This OKF concept captures durable repository knowledge only.
 
 ## Related concepts
 
-- [Related: architecture](./architecture.md)
-- [Related: publication-workflow](./publication-workflow.md)
+- [Architecture](/concepts/architecture.md)
+- [Publication Workflow](/concepts/publication-workflow.md)
+
+# Citations
+
+- `OPERATIONS.md`
+- `README.md`
+- `tests/golden/2024-01-01-market-analysis.md`

--- a/okf/concepts/report-generation.md
+++ b/okf/concepts/report-generation.md
@@ -1,0 +1,31 @@
+---
+id: okf/concepts/report-generation
+title: Report Generation
+description: How deterministic JSON analysis artifacts become public Hugo market analysis reports.
+type: concept
+tags:
+  - reports
+  - hugo
+  - market-analysis
+timestamp: 2026-06-16T00:00:00Z
+resource:
+  path: okf/concepts/report-generation.md
+  source: repository
+---
+
+# Report Generation
+
+How deterministic JSON analysis artifacts become public Hugo market analysis reports.
+
+## Source-of-truth boundary
+
+AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in `data/analysis/*.json` and generated daily reports in `content/results/`. This OKF concept captures durable repository knowledge only and must not invent or override generated numeric facts.
+
+## AIMS notes
+
+This concept is seeded from repository documentation, operations guidance, tests, workflows, and issue dceoy/aims#57. Update it through the OKF authoring and curation workflow when durable architecture or operational knowledge changes.
+
+## Related concepts
+
+- [Related: architecture](./architecture.md)
+- [Related: publication-workflow](./publication-workflow.md)

--- a/okf/concepts/scoring-methodology.md
+++ b/okf/concepts/scoring-methodology.md
@@ -3,28 +3,35 @@ id: okf/concepts/scoring-methodology
 title: Scoring Methodology
 description: How AIMS treats analysis artifacts, score semantics, ranking outputs, and risk gates as generated numeric facts.
 type: concept
-tags:
-  - scoring
-  - market-analysis
+tags: [scoring, market-analysis]
 timestamp: 2026-06-16T00:00:00Z
 resource:
   path: okf/concepts/scoring-methodology.md
   source: repository
+status: seeded
 ---
 
 # Scoring Methodology
 
 How AIMS treats analysis artifacts, score semantics, ranking outputs, and risk gates as generated numeric facts.
 
+## Repository facts
+
+AIMS computes cross-sectional rankings from daily OHLCV-derived features and produces a composite score from percentile ranks. Risk gates mark unreliable instruments, which remain in output but are ranked below reliable instruments.
+
+OKF concepts may summarize durable methodology, but numeric market facts, scores, ranks, dates, risk gates, and availability remain authoritative only in generated analysis artifacts and validated report outputs.
+
 ## Source-of-truth boundary
 
-AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in `data/analysis/*.json` and generated daily reports in `content/results/`. This OKF concept captures durable repository knowledge only and must not invent or override generated numeric facts.
-
-## AIMS notes
-
-This concept is seeded from repository documentation, operations guidance, tests, workflows, and issue dceoy/aims#57. Update it through the OKF authoring and curation workflow when durable architecture or operational knowledge changes.
+AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in generated artifacts and validated reports. This OKF concept captures durable repository knowledge only.
 
 ## Related concepts
 
-- [Related: data-sources](./data-sources.md)
-- [Related: report-generation](./report-generation.md)
+- [Data Sources](/concepts/data-sources.md)
+- [Report Generation](/concepts/report-generation.md)
+
+# Citations
+
+- `OPERATIONS.md`
+- `data/schema/analysis.schema.json`
+- `AGENTS.md`

--- a/okf/concepts/scoring-methodology.md
+++ b/okf/concepts/scoring-methodology.md
@@ -1,0 +1,30 @@
+---
+id: okf/concepts/scoring-methodology
+title: Scoring Methodology
+description: How AIMS treats analysis artifacts, score semantics, ranking outputs, and risk gates as generated numeric facts.
+type: concept
+tags:
+  - scoring
+  - market-analysis
+timestamp: 2026-06-16T00:00:00Z
+resource:
+  path: okf/concepts/scoring-methodology.md
+  source: repository
+---
+
+# Scoring Methodology
+
+How AIMS treats analysis artifacts, score semantics, ranking outputs, and risk gates as generated numeric facts.
+
+## Source-of-truth boundary
+
+AIMS keeps numeric market facts, scores, ranks, dates, risk gates, and data availability in `data/analysis/*.json` and generated daily reports in `content/results/`. This OKF concept captures durable repository knowledge only and must not invent or override generated numeric facts.
+
+## AIMS notes
+
+This concept is seeded from repository documentation, operations guidance, tests, workflows, and issue dceoy/aims#57. Update it through the OKF authoring and curation workflow when durable architecture or operational knowledge changes.
+
+## Related concepts
+
+- [Related: data-sources](./data-sources.md)
+- [Related: report-generation](./report-generation.md)

--- a/okf/index.md
+++ b/okf/index.md
@@ -1,0 +1,32 @@
+---
+id: okf/index
+title: AIMS Knowledge Base
+description: Canonical OKF source for durable AIMS market-analysis knowledge.
+type: index
+tags:
+  - okf
+  - knowledge
+timestamp: 2026-06-16T00:00:00Z
+resource:
+  path: okf/index.md
+  source: repository
+---
+
+# AIMS Knowledge Base
+
+The `okf/` tree is the canonical repository-native knowledge source for durable AIMS architecture, operations, and market-analysis methodology. Hugo pages under `content/knowledge/` are generated shadow content and must not be hand-edited.
+
+## Concepts
+
+- [Agent Skills](./concepts/agent-skills.md)
+- [AIMS Architecture](./concepts/architecture.md)
+- [Data Sources](./concepts/data-sources.md)
+- [Instrument Master](./concepts/instrument-master.md)
+- [Operational Recovery](./concepts/operational-recovery.md)
+- [Publication Workflow](./concepts/publication-workflow.md)
+- [Report Generation](./concepts/report-generation.md)
+- [Scoring Methodology](./concepts/scoring-methodology.md)
+
+## Logs
+
+- [Knowledge log](./logs/log.md)

--- a/okf/index.md
+++ b/okf/index.md
@@ -1,32 +1,22 @@
 ---
-id: okf/index
-title: AIMS Knowledge Base
-description: Canonical OKF source for durable AIMS market-analysis knowledge.
-type: index
-tags:
-  - okf
-  - knowledge
-timestamp: 2026-06-16T00:00:00Z
-resource:
-  path: okf/index.md
-  source: repository
+okf_version: "0.1"
 ---
 
 # AIMS Knowledge Base
 
-The `okf/` tree is the canonical repository-native knowledge source for durable AIMS architecture, operations, and market-analysis methodology. Hugo pages under `content/knowledge/` are generated shadow content and must not be hand-edited.
+The `okf/` tree is the canonical repository-native source for durable AIMS architecture, operations, and methodology knowledge. Hugo pages under `content/knowledge/` are generated shadow content and must not be hand-edited.
 
 ## Concepts
 
-- [Agent Skills](./concepts/agent-skills.md)
-- [AIMS Architecture](./concepts/architecture.md)
-- [Data Sources](./concepts/data-sources.md)
-- [Instrument Master](./concepts/instrument-master.md)
-- [Operational Recovery](./concepts/operational-recovery.md)
-- [Publication Workflow](./concepts/publication-workflow.md)
-- [Report Generation](./concepts/report-generation.md)
-- [Scoring Methodology](./concepts/scoring-methodology.md)
+- [Agent Skills](/concepts/agent-skills.md)
+- [AIMS Architecture](/concepts/architecture.md)
+- [Data Sources](/concepts/data-sources.md)
+- [Instrument Master](/concepts/instrument-master.md)
+- [Operational Recovery](/concepts/operational-recovery.md)
+- [Publication Workflow](/concepts/publication-workflow.md)
+- [Report Generation](/concepts/report-generation.md)
+- [Scoring Methodology](/concepts/scoring-methodology.md)
 
-## Logs
+## Log
 
-- [Knowledge log](./logs/log.md)
+- [Knowledge log](/logs/log.md)

--- a/okf/logs/log.md
+++ b/okf/logs/log.md
@@ -1,21 +1,7 @@
----
-id: okf/logs/log
-title: AIMS OKF Log
-description: Append-only curation log for durable AIMS OKF knowledge changes.
-type: log
-tags:
-  - okf
-  - log
-timestamp: 2026-06-16T00:00:00Z
-resource:
-  path: okf/logs/log.md
-  source: repository
----
-
 # AIMS OKF Log
 
 ## 2026-06-16
 
-- Established `okf/` as the canonical knowledge source for durable AIMS concepts.
-- Added generated `content/knowledge/` shadow content as Hugo publication output.
+- Established `okf/` as the canonical OKF v0.1 knowledge source for durable AIMS concepts.
+- Added generated `content/knowledge/` shadow content as Hugo publication output, not a canonical authoring location.
 - Seeded initial concepts for architecture, data sources, instrument master data, scoring methodology, report generation, publication, recovery, and Agent Skills.

--- a/okf/logs/log.md
+++ b/okf/logs/log.md
@@ -1,0 +1,21 @@
+---
+id: okf/logs/log
+title: AIMS OKF Log
+description: Append-only curation log for durable AIMS OKF knowledge changes.
+type: log
+tags:
+  - okf
+  - log
+timestamp: 2026-06-16T00:00:00Z
+resource:
+  path: okf/logs/log.md
+  source: repository
+---
+
+# AIMS OKF Log
+
+## 2026-06-16
+
+- Established `okf/` as the canonical knowledge source for durable AIMS concepts.
+- Added generated `content/knowledge/` shadow content as Hugo publication output.
+- Seeded initial concepts for architecture, data sources, instrument master data, scoring methodology, report generation, publication, recovery, and Agent Skills.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,9 @@ license = "AGPL-3.0-or-later"
 license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">= 3.11, < 3.14"
-dependencies = []
+dependencies = [
+    "pyyaml>=6.0.0",
+]
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Environment :: Console",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,16 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
+"tools/*.py" = [
+  "D100",
+  "D101",
+  "D103",
+  "DOC201",
+  "DOC501",
+  "PERF401",
+  "T201",
+]
+"tools/__init__.py" = ["D104"]
 ".agents/skills/market-analysis/scripts/*.py" = [
   "C901",     # Scoring/feature functions have inherent complexity
   "D100",     # Module docstrings are in the module-level string

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,6 +199,7 @@ max-public-methods = 40
 include = [
   ".agents/skills/update-cfd-instruments/scripts",
   ".agents/skills/market-analysis/scripts",
+  "tools",
 ]
 exclude = ["build", ".venv", ".claude", "tests"]
 venvPath = "."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ ignore = [
   "DOC201",
   "DOC501",
   "PERF401",
+  "S506",
   "T201",
 ]
 "tools/__init__.py" = ["D104"]

--- a/tests/test_okf_hugo_adapter.py
+++ b/tests/test_okf_hugo_adapter.py
@@ -1,0 +1,74 @@
+from pathlib import Path
+
+from tools import okf_hugo_adapter
+
+
+def test_adapter_generates_hugo_metadata_and_index(tmp_path: Path) -> None:
+    src = tmp_path / "okf"
+    dst = tmp_path / "content" / "knowledge"
+    src.mkdir()
+    (src / "index.md").write_text(
+        "---\n"
+        "title: Knowledge\n"
+        "description: Test index\n"
+        "type: index\n"
+        "tags:\n"
+        "  - okf\n"
+        "timestamp: 2026-06-16T00:00:00Z\n"
+        "---\n"
+        "# Knowledge\n"
+    )
+
+    logs = src / "logs"
+    logs.mkdir()
+    (logs / "log.md").write_text(
+        "---\n"
+        "title: Log\n"
+        "description: Test log\n"
+        "type: log\n"
+        "tags:\n"
+        "  - okf\n"
+        "timestamp: 2026-06-16T00:00:00Z\n"
+        "---\n"
+        "# Log\n"
+    )
+
+    assert okf_hugo_adapter.main(["--src", str(src), "--dst", str(dst)]) == 0
+
+    generated = dst / "_index.md"
+    text = generated.read_text()
+    assert "type: knowledge" in text
+    assert "  okf_type: index" in text
+    assert "# Knowledge" in text
+    assert okf_hugo_adapter.main(["--src", str(src), "--dst", str(dst), "--check"]) == 0
+
+
+def test_check_reports_broken_links_and_drift(tmp_path: Path) -> None:
+    src = tmp_path / "okf"
+    concepts = src / "concepts"
+    dst = tmp_path / "content" / "knowledge"
+    concepts.mkdir(parents=True)
+    (src / "index.md").write_text(
+        "---\n"
+        "title: Knowledge\n"
+        "description: Test index\n"
+        "type: index\n"
+        "tags:\n"
+        "  - okf\n"
+        "timestamp: 2026-06-16T00:00:00Z\n"
+        "---\n"
+        "# Knowledge\n"
+    )
+    (concepts / "broken.md").write_text(
+        "---\n"
+        "title: Broken\n"
+        "description: Broken concept\n"
+        "type: concept\n"
+        "tags:\n"
+        "  - bad-tag\n"
+        "timestamp: 2026-06-16T00:00:00Z\n"
+        "---\n"
+        "[Missing](./missing.md)\n"
+    )
+
+    assert okf_hugo_adapter.main(["--src", str(src), "--dst", str(dst), "--check"]) == 1

--- a/tests/test_okf_hugo_adapter.py
+++ b/tests/test_okf_hugo_adapter.py
@@ -135,6 +135,28 @@ def test_bundle_absolute_links_are_validated(
     assert "broken link '/concepts/missing.md'" in capsys.readouterr().err
 
 
+def test_internal_links_rewrite_to_hugo_urls(tmp_path: Path) -> None:
+    src = tmp_path / "okf"
+    dst = tmp_path / "content" / "knowledge"
+    src.mkdir()
+    (src / "index.md").write_text("# Knowledge\n", encoding="utf-8")
+    (src / "areas").mkdir()
+    (src / "areas" / "index.md").write_text("# Area Index\n", encoding="utf-8")
+    write_concept(src / "concepts" / "bar.md", "# Bar\n")
+    write_concept(
+        src / "concepts" / "foo.md",
+        "# Foo\n[Bar](./bar.md)\n[Area](/areas/index.md)\n",
+    )
+
+    assert okf_hugo_adapter.main(["--src", str(src), "--dst", str(dst)]) == 0
+
+    generated = (dst / "concepts" / "foo.md").read_text(encoding="utf-8")
+    assert "[Bar](/knowledge/concepts/bar/)" in generated
+    assert "[Area](/knowledge/areas/)" in generated
+    assert "./bar.md" not in generated
+    assert "/knowledge/areas/index/" not in generated
+
+
 def test_check_detects_generated_drift(tmp_path: Path) -> None:
     src = tmp_path / "okf"
     dst = tmp_path / "content" / "knowledge"

--- a/tests/test_okf_hugo_adapter.py
+++ b/tests/test_okf_hugo_adapter.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -171,6 +172,29 @@ def test_knowledge_index_links_are_relative(tmp_path: Path) -> None:
     generated = (dst / "_index.md").read_text(encoding="utf-8")
     assert "[Concept](concepts/concept/)" in generated
     assert "/knowledge/" not in generated
+
+
+def test_okf_yaml_loader_does_not_mutate_safe_loader() -> None:
+    parsed = yaml.safe_load("value: 2026-06-16T00:00:00Z")
+    assert isinstance(parsed, dict)
+    assert isinstance(parsed["value"], datetime)
+
+
+def test_internal_links_preserve_label_when_it_matches_target(tmp_path: Path) -> None:
+    src = tmp_path / "okf"
+    dst = tmp_path / "content" / "knowledge"
+    src.mkdir()
+    (src / "index.md").write_text("# Knowledge\n", encoding="utf-8")
+    write_concept(src / "concepts" / "bar.md", "# Bar\n")
+    write_concept(
+        src / "concepts" / "foo.md",
+        "# Foo\n[./bar.md](./bar.md)\n",
+    )
+
+    assert okf_hugo_adapter.main(["--src", str(src), "--dst", str(dst)]) == 0
+
+    generated = (dst / "concepts" / "foo.md").read_text(encoding="utf-8")
+    assert "[./bar.md](../bar/)" in generated
 
 
 def test_check_detects_generated_drift(tmp_path: Path) -> None:

--- a/tests/test_okf_hugo_adapter.py
+++ b/tests/test_okf_hugo_adapter.py
@@ -1,74 +1,115 @@
 from pathlib import Path
 
+import pytest
+
 from tools import okf_hugo_adapter
 
 
-def test_adapter_generates_hugo_metadata_and_index(tmp_path: Path) -> None:
+def write_concept(path: Path, body: str = "# Concept\n") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "---\n"
+        "title: Concept\n"
+        "description: Test concept\n"
+        "type: concept\n"
+        "tags: [sales]\n"
+        "timestamp: 2026-06-16T00:00:00Z\n"
+        "unknown_key:\n"
+        "  nested: preserved\n"
+        "---\n"
+        f"{body}",
+        encoding="utf-8",
+    )
+
+
+def test_adapter_accepts_reserved_files_without_frontmatter(tmp_path: Path) -> None:
     src = tmp_path / "okf"
     dst = tmp_path / "content" / "knowledge"
     src.mkdir()
     (src / "index.md").write_text(
-        "---\n"
-        "title: Knowledge\n"
-        "description: Test index\n"
-        "type: index\n"
-        "tags:\n"
-        "  - okf\n"
-        "timestamp: 2026-06-16T00:00:00Z\n"
-        "---\n"
-        "# Knowledge\n"
+        "# Knowledge\n\n- [Concept](/concepts/concept.md)\n", encoding="utf-8"
     )
-
     logs = src / "logs"
     logs.mkdir()
     (logs / "log.md").write_text(
-        "---\n"
-        "title: Log\n"
-        "description: Test log\n"
-        "type: log\n"
-        "tags:\n"
-        "  - okf\n"
-        "timestamp: 2026-06-16T00:00:00Z\n"
-        "---\n"
-        "# Log\n"
+        "# Log\n\n## 2026-06-16\n\n- Created.\n", encoding="utf-8"
     )
+    write_concept(src / "concepts" / "concept.md")
 
     assert okf_hugo_adapter.main(["--src", str(src), "--dst", str(dst)]) == 0
 
     generated = dst / "_index.md"
-    text = generated.read_text()
+    text = generated.read_text(encoding="utf-8")
     assert "type: knowledge" in text
-    assert "  okf_type: index" in text
+    assert "okf_reserved: index" in text
     assert "# Knowledge" in text
     assert okf_hugo_adapter.main(["--src", str(src), "--dst", str(dst), "--check"]) == 0
 
 
-def test_check_reports_broken_links_and_drift(tmp_path: Path) -> None:
+def test_adapter_accepts_root_index_with_okf_version_and_preserves_unknown_fields(
+    tmp_path: Path,
+) -> None:
     src = tmp_path / "okf"
-    concepts = src / "concepts"
     dst = tmp_path / "content" / "knowledge"
+    src.mkdir()
+    (src / "index.md").write_text(
+        '---\nokf_version: "0.1"\n---\n# Knowledge\n', encoding="utf-8"
+    )
+    write_concept(src / "concepts" / "concept.md")
+
+    assert okf_hugo_adapter.main(["--src", str(src), "--dst", str(dst)]) == 0
+
+    generated = (dst / "concepts" / "concept.md").read_text(encoding="utf-8")
+    assert "  okf_type: concept" in generated
+    assert "unknown_key:" in generated
+    assert "  nested: preserved" in generated
+    assert "tags:" in generated
+    assert "- sales" in generated
+    assert okf_hugo_adapter.main(["--src", str(src), "--dst", str(dst), "--check"]) == 0
+
+
+def test_check_labels_okf_and_aims_errors(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    src = tmp_path / "okf"
+    dst = tmp_path / "content" / "knowledge"
+    concepts = src / "concepts"
     concepts.mkdir(parents=True)
     (src / "index.md").write_text(
-        "---\n"
-        "title: Knowledge\n"
-        "description: Test index\n"
-        "type: index\n"
-        "tags:\n"
-        "  - okf\n"
-        "timestamp: 2026-06-16T00:00:00Z\n"
-        "---\n"
-        "# Knowledge\n"
+        "---\ntitle: Not allowed\n---\n# Knowledge\n", encoding="utf-8"
     )
     (concepts / "broken.md").write_text(
         "---\n"
         "title: Broken\n"
         "description: Broken concept\n"
-        "type: concept\n"
-        "tags:\n"
-        "  - bad-tag\n"
+        "type: ''\n"
+        "tags: [bad_tag]\n"
         "timestamp: 2026-06-16T00:00:00Z\n"
         "---\n"
-        "[Missing](./missing.md)\n"
+        "[Missing](./missing.md)\n",
+        encoding="utf-8",
     )
 
     assert okf_hugo_adapter.main(["--src", str(src), "--dst", str(dst), "--check"]) == 1
+    captured = capsys.readouterr().err
+    assert "OKF conformance error:" in captured
+    assert "AIMS policy error:" in captured
+
+
+def test_bundle_absolute_links_are_validated(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    src = tmp_path / "okf"
+    dst = tmp_path / "content" / "knowledge"
+    src.mkdir()
+    (src / "index.md").write_text("# Knowledge\n", encoding="utf-8")
+    write_concept(src / "concepts" / "foo.md", "# Foo\n[Foo](/concepts/foo.md)\n")
+
+    assert okf_hugo_adapter.main(["--src", str(src), "--dst", str(dst)]) == 0
+    assert okf_hugo_adapter.main(["--src", str(src), "--dst", str(dst), "--check"]) == 0
+
+    write_concept(
+        src / "concepts" / "foo.md", "# Foo\n[Broken](/concepts/missing.md)\n"
+    )
+    assert okf_hugo_adapter.main(["--src", str(src), "--dst", str(dst), "--check"]) == 1
+    assert "broken link '/concepts/missing.md'" in capsys.readouterr().err

--- a/tests/test_okf_hugo_adapter.py
+++ b/tests/test_okf_hugo_adapter.py
@@ -216,3 +216,42 @@ def test_check_detects_generated_drift(tmp_path: Path) -> None:
         )
         == first
     )
+
+
+def test_parent_directory_links_rewrite_to_hugo_urls(tmp_path: Path) -> None:
+    src = tmp_path / "okf"
+    dst = tmp_path / "content" / "knowledge"
+    src.mkdir()
+    (src / "index.md").write_text("# Knowledge\n", encoding="utf-8")
+    logs = src / "logs"
+    logs.mkdir()
+    (logs / "log.md").write_text("# Log\n", encoding="utf-8")
+    write_concept(
+        src / "concepts" / "foo.md",
+        "# Foo\n[Index](../index.md)\n[Log](../logs/log.md)\n",
+    )
+
+    assert okf_hugo_adapter.main(["--src", str(src), "--dst", str(dst)]) == 0
+
+    generated = (dst / "concepts" / "foo.md").read_text(encoding="utf-8")
+    assert "[Index](../../)" in generated
+    assert "[Log](../../logs/log/)" in generated
+    assert "../index.md" not in generated
+    assert "../logs/log.md" not in generated
+    assert okf_hugo_adapter.main(["--src", str(src), "--dst", str(dst), "--check"]) == 0
+
+
+def test_check_rejects_internal_links_that_escape_okf_bundle(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    src = tmp_path / "okf"
+    dst = tmp_path / "content" / "knowledge"
+    outside = tmp_path / "outside.md"
+    outside.write_text("# Outside\n", encoding="utf-8")
+    src.mkdir()
+    (src / "index.md").write_text("# Knowledge\n", encoding="utf-8")
+    write_concept(src / "concepts" / "foo.md", "# Foo\n[Outside](../../outside.md)\n")
+
+    assert okf_hugo_adapter.main(["--src", str(src), "--dst", str(dst), "--check"]) == 1
+    captured = capsys.readouterr().err
+    assert "unsafe internal link '../../outside.md' escapes OKF bundle" in captured

--- a/tests/test_okf_hugo_adapter.py
+++ b/tests/test_okf_hugo_adapter.py
@@ -151,10 +151,26 @@ def test_internal_links_rewrite_to_hugo_urls(tmp_path: Path) -> None:
     assert okf_hugo_adapter.main(["--src", str(src), "--dst", str(dst)]) == 0
 
     generated = (dst / "concepts" / "foo.md").read_text(encoding="utf-8")
-    assert "[Bar](/knowledge/concepts/bar/)" in generated
-    assert "[Area](/knowledge/areas/)" in generated
+    assert "[Bar](../bar/)" in generated
+    assert "[Area](../../areas/)" in generated
     assert "./bar.md" not in generated
-    assert "/knowledge/areas/index/" not in generated
+    assert "/knowledge/" not in generated
+
+
+def test_knowledge_index_links_are_relative(tmp_path: Path) -> None:
+    src = tmp_path / "okf"
+    dst = tmp_path / "content" / "knowledge"
+    src.mkdir()
+    (src / "index.md").write_text(
+        "# Knowledge\n\n- [Concept](/concepts/concept.md)\n", encoding="utf-8"
+    )
+    write_concept(src / "concepts" / "concept.md")
+
+    assert okf_hugo_adapter.main(["--src", str(src), "--dst", str(dst)]) == 0
+
+    generated = (dst / "_index.md").read_text(encoding="utf-8")
+    assert "[Concept](concepts/concept/)" in generated
+    assert "/knowledge/" not in generated
 
 
 def test_check_detects_generated_drift(tmp_path: Path) -> None:
@@ -172,7 +188,7 @@ def test_check_detects_generated_drift(tmp_path: Path) -> None:
     assert okf_hugo_adapter.main(["--src", str(src), "--dst", str(dst), "--check"]) == 1
     assert (
         okf_hugo_adapter.render_document(
-            okf_hugo_adapter.load_documents(src, dst)[0][0], src
+            okf_hugo_adapter.load_documents(src, dst)[0][0], src, dst
         )
         == first
     )

--- a/tests/test_okf_hugo_adapter.py
+++ b/tests/test_okf_hugo_adapter.py
@@ -1,6 +1,8 @@
 from pathlib import Path
+from typing import Any
 
 import pytest
+import yaml
 
 from tools import okf_hugo_adapter
 
@@ -9,17 +11,32 @@ def write_concept(path: Path, body: str = "# Concept\n") -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
         "---\n"
+        "id: okf/concepts/concept\n"
         "title: Concept\n"
         "description: Test concept\n"
         "type: concept\n"
         "tags: [sales]\n"
         "timestamp: 2026-06-16T00:00:00Z\n"
+        "status: seeded\n"
+        "url: /unsafe\n"
+        "slug: unsafe-slug\n"
+        "layout: unsafe-layout\n"
+        "draft: true\n"
+        "weight: 99\n"
         "unknown_key:\n"
         "  nested: preserved\n"
         "---\n"
         f"{body}",
         encoding="utf-8",
     )
+
+
+def generated_metadata(path: Path) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    front_matter = text.split("---\n", 2)[1]
+    metadata = yaml.safe_load(front_matter)
+    assert isinstance(metadata, dict)
+    return metadata
 
 
 def test_adapter_accepts_reserved_files_without_frontmatter(tmp_path: Path) -> None:
@@ -38,15 +55,15 @@ def test_adapter_accepts_reserved_files_without_frontmatter(tmp_path: Path) -> N
 
     assert okf_hugo_adapter.main(["--src", str(src), "--dst", str(dst)]) == 0
 
-    generated = dst / "_index.md"
-    text = generated.read_text(encoding="utf-8")
-    assert "type: knowledge" in text
-    assert "okf_reserved: index" in text
+    metadata = generated_metadata(dst / "_index.md")
+    text = (dst / "_index.md").read_text(encoding="utf-8")
+    assert metadata["type"] == "knowledge"
+    assert metadata["params"]["okf_reserved"] == "index"
     assert "# Knowledge" in text
     assert okf_hugo_adapter.main(["--src", str(src), "--dst", str(dst), "--check"]) == 0
 
 
-def test_adapter_accepts_root_index_with_okf_version_and_preserves_unknown_fields(
+def test_hugo_metadata_isolates_unknown_and_sensitive_okf_fields(
     tmp_path: Path,
 ) -> None:
     src = tmp_path / "okf"
@@ -59,12 +76,15 @@ def test_adapter_accepts_root_index_with_okf_version_and_preserves_unknown_field
 
     assert okf_hugo_adapter.main(["--src", str(src), "--dst", str(dst)]) == 0
 
-    generated = (dst / "concepts" / "concept.md").read_text(encoding="utf-8")
-    assert "  okf_type: concept" in generated
-    assert "unknown_key:" in generated
-    assert "  nested: preserved" in generated
-    assert "tags:" in generated
-    assert "- sales" in generated
+    metadata = generated_metadata(dst / "concepts" / "concept.md")
+    assert metadata["type"] == "knowledge"
+    assert metadata["params"]["okf_type"] == "concept"
+    assert metadata["tags"] == ["sales"]
+    assert metadata["timestamp"] == "2026-06-16T00:00:00Z"
+    for key in ["id", "status", "url", "slug", "layout", "draft", "weight"]:
+        assert key not in metadata
+        assert key in metadata["params"]["okf_extra"]
+    assert metadata["params"]["okf_extra"]["unknown_key"] == {"nested": "preserved"}
     assert okf_hugo_adapter.main(["--src", str(src), "--dst", str(dst), "--check"]) == 0
 
 
@@ -113,3 +133,24 @@ def test_bundle_absolute_links_are_validated(
     )
     assert okf_hugo_adapter.main(["--src", str(src), "--dst", str(dst), "--check"]) == 1
     assert "broken link '/concepts/missing.md'" in capsys.readouterr().err
+
+
+def test_check_detects_generated_drift(tmp_path: Path) -> None:
+    src = tmp_path / "okf"
+    dst = tmp_path / "content" / "knowledge"
+    src.mkdir()
+    (src / "index.md").write_text("# Knowledge\n", encoding="utf-8")
+    write_concept(src / "concepts" / "concept.md")
+
+    assert okf_hugo_adapter.main(["--src", str(src), "--dst", str(dst)]) == 0
+    first = (dst / "concepts" / "concept.md").read_text(encoding="utf-8")
+    assert okf_hugo_adapter.main(["--src", str(src), "--dst", str(dst), "--check"]) == 0
+
+    (dst / "concepts" / "concept.md").write_text(f"{first}\n", encoding="utf-8")
+    assert okf_hugo_adapter.main(["--src", str(src), "--dst", str(dst), "--check"]) == 1
+    assert (
+        okf_hugo_adapter.render_document(
+            okf_hugo_adapter.load_documents(src, dst)[0][0], src
+        )
+        == first
+    )

--- a/tools/okf_hugo_adapter.py
+++ b/tools/okf_hugo_adapter.py
@@ -11,10 +11,14 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 FRONT_MATTER = re.compile(r"\A---\n(?P<meta>.*?)\n---\n(?P<body>.*)\Z", re.DOTALL)
 LINK = re.compile(r"(?<!!)\[[^\]]+\]\((?P<target>[^)]+)\)")
 TAG = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
-REQUIRED_CONCEPT_FIELDS = ("title", "description", "type", "tags", "timestamp")
+RECOMMENDED_CONCEPT_FIELDS = ("title", "description", "tags", "timestamp")
+ROOT_INDEX_ALLOWED_FIELDS = {"okf_version"}
+RESERVED_NAMES = {"index.md", "log.md"}
 
 
 @dataclass(frozen=True)
@@ -25,72 +29,33 @@ class OkfDocument:
     destination: Path
     metadata: dict[str, Any]
     body: str
+    reserved: bool
+    has_front_matter: bool
 
 
-def parse_front_matter(path: Path) -> tuple[dict[str, Any], str]:
-    """Parse the YAML-like front matter used by repository OKF files."""
+def split_front_matter(path: Path) -> tuple[dict[str, Any], str, bool]:
+    """Split optional YAML front matter from an OKF Markdown file."""
     text = path.read_text(encoding="utf-8")
     match = FRONT_MATTER.match(text)
     if match is None:
-        msg = f"{path}: missing YAML front matter"
-        raise ValueError(msg)
-    return parse_simple_yaml(match.group("meta"), path), match.group("body")
+        return {}, text, False
+    metadata = yaml.safe_load(match.group("meta"))
+    if metadata is None:
+        metadata = {}
+    if not isinstance(metadata, dict):
+        msg = f"OKF conformance error: {path}: front matter must be a YAML mapping"
+        raise TypeError(msg)
+    return metadata, match.group("body"), True
 
 
-def parse_simple_yaml(text: str, path: Path) -> dict[str, Any]:
-    """Parse the small YAML subset used by OKF metadata."""
-    result: dict[str, Any] = {}
-    lines = text.splitlines()
-    index = 0
-    while index < len(lines):
-        line = lines[index]
-        if not line.strip():
-            index += 1
-            continue
-        if line.startswith(" ") or ":" not in line:
-            msg = f"{path}: invalid front matter line: {line}"
-            raise ValueError(msg)
-        key, raw_value = line.split(":", 1)
-        key = key.strip()
-        value = raw_value.strip()
-        if value:
-            result[key] = value
-            index += 1
-            continue
-        index += 1
-        items: list[str] = []
-        mapping: dict[str, str] = {}
-        while index < len(lines) and lines[index].startswith("  "):
-            child = lines[index][2:]
-            if child.startswith("- "):
-                items.append(child[2:].strip())
-            elif ":" in child:
-                child_key, child_value = child.split(":", 1)
-                mapping[child_key.strip()] = child_value.strip()
-            else:
-                msg = f"{path}: invalid nested front matter line: {lines[index]}"
-                raise ValueError(msg)
-            index += 1
-        result[key] = items or mapping
-    return result
-
-
-def dump_simple_yaml(metadata: dict[str, Any]) -> str:
+def dump_yaml(metadata: dict[str, Any]) -> str:
     """Serialize metadata deterministically for Hugo front matter."""
-    lines: list[str] = []
-    for key in sorted(metadata):
-        value = metadata[key]
-        if isinstance(value, dict):
-            lines.append(f"{key}:")
-            for child_key in sorted(value):
-                lines.append(f"  {child_key}: {value[child_key]}")
-        elif isinstance(value, list):
-            lines.append(f"{key}:")
-            for item in value:
-                lines.append(f"  - {item}")
-        else:
-            lines.append(f"{key}: {value}")
-    return "\n".join(lines) + "\n"
+    return yaml.safe_dump(
+        metadata,
+        allow_unicode=True,
+        default_flow_style=False,
+        sort_keys=True,
+    )
 
 
 def destination_for(source: Path, src_root: Path, dst_root: Path) -> Path:
@@ -106,100 +71,243 @@ def iter_markdown(root: Path) -> list[Path]:
     return sorted(path for path in root.rglob("*.md") if path.is_file())
 
 
-def load_documents(src_root: Path, dst_root: Path) -> list[OkfDocument]:
-    """Load OKF documents from source root."""
+def is_reserved(path: Path) -> bool:
+    """Return whether an OKF Markdown path is reserved by OKF v0.1."""
+    return path.name in RESERVED_NAMES
+
+
+def load_documents(
+    src_root: Path, dst_root: Path
+) -> tuple[list[OkfDocument], list[str]]:
+    """Load OKF documents from source root and capture parse errors."""
     documents: list[OkfDocument] = []
+    errors: list[str] = []
     for source in iter_markdown(src_root):
-        metadata, body = parse_front_matter(source)
+        try:
+            metadata, body, has_front_matter = split_front_matter(source)
+        except yaml.YAMLError as exc:
+            errors.append(
+                "OKF conformance error: "
+                f"{source}: YAML front matter does not parse: {exc}"
+            )
+            continue
+        except (TypeError, ValueError) as exc:
+            errors.append(str(exc))
+            continue
         documents.append(
             OkfDocument(
                 source=source,
                 destination=destination_for(source, src_root, dst_root),
                 metadata=metadata,
                 body=body,
+                reserved=is_reserved(source),
+                has_front_matter=has_front_matter,
             )
         )
-    return documents
+    return documents, errors
 
 
-def hugo_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
+def heading_title(body: str, fallback: str) -> str:
+    """Extract a title from the first Markdown H1 or use a fallback."""
+    for line in body.splitlines():
+        if line.startswith("# "):
+            return line.removeprefix("# ").strip()
+    return fallback
+
+
+def hugo_metadata(document: OkfDocument, src_root: Path) -> dict[str, Any]:
     """Map OKF metadata to Hugo-safe metadata."""
-    converted = dict(metadata)
+    converted = dict(document.metadata)
     okf_type = converted.pop("type", None)
-    params = dict(converted.pop("params", {}))
+    params = dict(converted.pop("params", {}) or {})
     if okf_type is not None:
         params["okf_type"] = okf_type
+    if document.reserved:
+        params["okf_reserved"] = document.source.name.removesuffix(".md")
     converted["params"] = params
     converted["type"] = "knowledge"
+    converted.setdefault(
+        "title", heading_title(document.body, document.source.stem.title())
+    )
+    converted.setdefault(
+        "description", f"Generated from {document.source.relative_to(src_root)}."
+    )
+    converted.setdefault(
+        "resource", {"path": str(document.source.relative_to(src_root))}
+    )
     return converted
 
 
-def render_document(document: OkfDocument) -> str:
+def hugo_body(body: str) -> str:
+    """Rewrite OKF bundle-absolute Markdown links for Hugo knowledge URLs."""
+
+    def replace(match: re.Match[str]) -> str:
+        target = match.group("target")
+        if (
+            not target.startswith("/")
+            or "://" in target
+            or target.startswith("mailto:")
+        ):
+            return match.group(0)
+        target_path, separator, suffix = target.partition("#")
+        path = target_path.removesuffix(".md")
+        rewritten = f"/knowledge{path}/"
+        if separator:
+            rewritten = f"{rewritten}#{suffix}"
+        return match.group(0).replace(target, rewritten)
+
+    return LINK.sub(replace, body)
+
+
+def render_document(document: OkfDocument, src_root: Path) -> str:
     """Render a Hugo Markdown document from an OKF document."""
-    return (
-        f"---\n{dump_simple_yaml(hugo_metadata(document.metadata))}---\n{document.body}"
-    )
+    front_matter = dump_yaml(hugo_metadata(document, src_root))
+    return f"---\n{front_matter}---\n{hugo_body(document.body)}"
 
 
-def write_documents(documents: list[OkfDocument], dst_root: Path, clean: bool) -> None:
+def write_documents(
+    documents: list[OkfDocument], src_root: Path, dst_root: Path, clean: bool
+) -> None:
     """Write generated Hugo content to disk."""
     if clean and dst_root.exists():
         shutil.rmtree(dst_root)
     for document in documents:
         document.destination.parent.mkdir(parents=True, exist_ok=True)
-        document.destination.write_text(render_document(document), encoding="utf-8")
+        document.destination.write_text(
+            render_document(document, src_root), encoding="utf-8"
+        )
 
 
 def validate_documents(
-    documents: list[OkfDocument], src_root: Path, dst_root: Path
+    documents: list[OkfDocument],
+    parse_errors: list[str],
+    src_root: Path,
+    dst_root: Path,
 ) -> list[str]:
-    """Validate OKF metadata, links, and generated-content drift."""
-    errors: list[str] = []
+    """Validate OKF conformance and AIMS repository policy."""
+    errors = list(parse_errors)
     sources = {document.source.resolve() for document in documents}
     for document in documents:
-        errors.extend(validate_metadata(document))
-        errors.extend(validate_links(document, sources))
-        expected = render_document(document)
+        errors.extend(validate_reserved_or_concept(document, src_root))
+        errors.extend(validate_aims_policy(document, sources, src_root))
+        expected = render_document(document, src_root)
         if not document.destination.exists():
-            errors.append(f"{document.destination}: generated file is missing")
+            errors.append(
+                f"AIMS policy error: {document.destination}: generated file is missing"
+            )
         elif document.destination.read_text(encoding="utf-8") != expected:
-            errors.append(f"{document.destination}: generated file is out of date")
+            errors.append(
+                "AIMS policy error: "
+                f"{document.destination}: generated file is out of date"
+            )
     if not (src_root / "index.md").exists():
-        errors.append(f"{src_root / 'index.md'}: required OKF index is missing")
-    if not (src_root / "logs" / "log.md").exists():
-        errors.append(f"{src_root / 'logs' / 'log.md'}: required OKF log is missing")
+        errors.append(
+            f"OKF conformance error: {src_root / 'index.md'}: bundle index is missing"
+        )
     for generated in iter_markdown(dst_root) if dst_root.exists() else []:
         if generated not in {document.destination for document in documents}:
-            errors.append(f"{generated}: stale generated file")
+            errors.append(f"AIMS policy error: {generated}: stale generated file")
     return errors
 
 
-def validate_metadata(document: OkfDocument) -> list[str]:
-    """Validate required OKF metadata fields."""
+def validate_reserved_or_concept(document: OkfDocument, src_root: Path) -> list[str]:
+    """Validate OKF v0.1 reserved-file and concept-document rules."""
     errors: list[str] = []
-    for field in REQUIRED_CONCEPT_FIELDS:
-        if document.source.match("*/concepts/*.md") and field not in document.metadata:
-            errors.append(f"{document.source}: missing required field '{field}'")
-    tags = document.metadata.get("tags")
-    if not isinstance(tags, list) or not tags:
-        errors.append(f"{document.source}: tags must be a non-empty list")
-    else:
-        for tag in tags:
-            if not TAG.fullmatch(str(tag)):
-                errors.append(f"{document.source}: invalid tag '{tag}'")
+    if document.reserved:
+        errors.extend(validate_reserved(document, src_root))
+        return errors
+    if not document.has_front_matter:
+        errors.append(
+            "OKF conformance error: "
+            f"{document.source}: concept requires YAML front matter"
+        )
+    elif not str(document.metadata.get("type", "")).strip():
+        errors.append(
+            "OKF conformance error: "
+            f"{document.source}: concept requires non-empty 'type'"
+        )
     return errors
 
 
-def validate_links(document: OkfDocument, sources: set[Path]) -> list[str]:
-    """Validate resolvable relative Markdown links inside OKF bodies."""
+def validate_reserved(document: OkfDocument, src_root: Path) -> list[str]:
+    """Validate OKF v0.1 reserved Markdown files."""
+    errors: list[str] = []
+    if document.source.name == "log.md" and document.has_front_matter:
+        errors.append(
+            "OKF conformance error: "
+            f"{document.source}: reserved log.md must not have concept front matter"
+        )
+    if document.source.name != "index.md" or not document.has_front_matter:
+        return errors
+    allowed_fields = (
+        ROOT_INDEX_ALLOWED_FIELDS if document.source == src_root / "index.md" else set()
+    )
+    unknown = sorted(set(document.metadata) - allowed_fields)
+    if unknown:
+        errors.append(
+            "OKF conformance error: "
+            f"{document.source}: reserved index.md allows only "
+            f"{sorted(allowed_fields)} front matter fields; found {unknown}"
+        )
+    return errors
+
+
+def validate_aims_policy(
+    document: OkfDocument, sources: set[Path], src_root: Path
+) -> list[str]:
+    """Validate AIMS metadata, tag, and link policies."""
+    errors: list[str] = []
+    if not document.reserved:
+        for field in RECOMMENDED_CONCEPT_FIELDS:
+            if field not in document.metadata:
+                errors.append(
+                    "AIMS policy error: "
+                    f"{document.source}: recommended field '{field}' is missing"
+                )
+        tags = document.metadata.get("tags")
+        if not isinstance(tags, list) or not tags:
+            errors.append(
+                f"AIMS policy error: {document.source}: tags should be a non-empty list"
+            )
+        else:
+            for tag in tags:
+                if not TAG.fullmatch(str(tag)):
+                    errors.append(
+                        f"AIMS policy error: {document.source}: invalid tag '{tag}'"
+                    )
+    errors.extend(validate_links(document, sources, src_root))
+    return errors
+
+
+def pending_link(target: str) -> bool:
+    """Return whether a link explicitly declares itself pending."""
+    return "pending=true" in target or target.endswith("#pending")
+
+
+def validate_links(
+    document: OkfDocument, sources: set[Path], src_root: Path
+) -> list[str]:
+    """Validate resolvable relative and bundle-absolute Markdown links."""
     errors: list[str] = []
     for match in LINK.finditer(document.body):
-        target = match.group("target").split("#", 1)[0]
-        if not target or "://" in target or target.startswith(("mailto:", "/")):
+        target = match.group("target")
+        clean_target = target.split("?", 1)[0].split("#", 1)[0]
+        if (
+            not clean_target
+            or "://" in clean_target
+            or clean_target.startswith("mailto:")
+            or pending_link(target)
+        ):
             continue
-        resolved = (document.source.parent / target).resolve()
+        resolved = (
+            src_root / clean_target.removeprefix("/")
+            if clean_target.startswith("/")
+            else document.source.parent / clean_target
+        ).resolve()
         if resolved not in sources:
-            errors.append(f"{document.source}: broken link '{match.group('target')}'")
+            errors.append(
+                f"AIMS policy error: {document.source}: broken link '{target}'"
+            )
     return errors
 
 
@@ -216,13 +324,17 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> int:
     """Run the OKF-to-Hugo adapter."""
     args = parse_args(sys.argv[1:] if argv is None else argv)
-    documents = load_documents(args.src, args.dst)
+    documents, parse_errors = load_documents(args.src, args.dst)
     if args.check:
-        errors = validate_documents(documents, args.src, args.dst)
+        errors = validate_documents(documents, parse_errors, args.src, args.dst)
         for error in errors:
             print(error, file=sys.stderr)
         return 1 if errors else 0
-    write_documents(documents, args.dst, args.clean)
+    if parse_errors:
+        for error in parse_errors:
+            print(error, file=sys.stderr)
+        return 1
+    write_documents(documents, args.src, args.dst, args.clean)
     return 0
 
 

--- a/tools/okf_hugo_adapter.py
+++ b/tools/okf_hugo_adapter.py
@@ -13,12 +13,26 @@ from typing import Any
 
 import yaml
 
+
+class OkfYamlLoader(yaml.SafeLoader):
+    """YAML loader that leaves OKF scalar values such as timestamps as strings."""
+
+
+for first_character, resolvers in list(OkfYamlLoader.yaml_implicit_resolvers.items()):
+    OkfYamlLoader.yaml_implicit_resolvers[first_character] = [
+        (tag, regexp)
+        for tag, regexp in resolvers
+        if tag != "tag:yaml.org,2002:timestamp"
+    ]
+
+
 FRONT_MATTER = re.compile(r"\A---\n(?P<meta>.*?)\n---\n(?P<body>.*)\Z", re.DOTALL)
 LINK = re.compile(r"(?<!!)\[[^\]]+\]\((?P<target>[^)]+)\)")
 TAG = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 RECOMMENDED_CONCEPT_FIELDS = ("title", "description", "tags", "timestamp")
 ROOT_INDEX_ALLOWED_FIELDS = {"okf_version"}
 RESERVED_NAMES = {"index.md", "log.md"}
+HUGO_TOP_LEVEL_KEYS = {"title", "description", "tags", "resource", "timestamp"}
 
 
 @dataclass(frozen=True)
@@ -39,7 +53,7 @@ def split_front_matter(path: Path) -> tuple[dict[str, Any], str, bool]:
     match = FRONT_MATTER.match(text)
     if match is None:
         return {}, text, False
-    metadata = yaml.safe_load(match.group("meta"))
+    metadata = yaml.load(match.group("meta"), Loader=OkfYamlLoader)
     if metadata is None:
         metadata = {}
     if not isinstance(metadata, dict):
@@ -117,11 +131,22 @@ def heading_title(body: str, fallback: str) -> str:
 
 def hugo_metadata(document: OkfDocument, src_root: Path) -> dict[str, Any]:
     """Map OKF metadata to Hugo-safe metadata."""
-    converted = dict(document.metadata)
-    okf_type = converted.pop("type", None)
-    params = dict(converted.pop("params", {}) or {})
+    converted = {
+        key: value
+        for key, value in document.metadata.items()
+        if key in HUGO_TOP_LEVEL_KEYS
+    }
+    extra = {
+        key: value
+        for key, value in document.metadata.items()
+        if key not in HUGO_TOP_LEVEL_KEYS and key != "type"
+    }
+    params: dict[str, Any] = {}
+    okf_type = document.metadata.get("type")
     if okf_type is not None:
         params["okf_type"] = okf_type
+    if extra:
+        params["okf_extra"] = extra
     if document.reserved:
         params["okf_reserved"] = document.source.name.removesuffix(".md")
     converted["params"] = params

--- a/tools/okf_hugo_adapter.py
+++ b/tools/okf_hugo_adapter.py
@@ -163,14 +163,29 @@ def hugo_metadata(document: OkfDocument, src_root: Path) -> dict[str, Any]:
     return converted
 
 
-def hugo_url_for_okf_path(path: Path, src_root: Path) -> str:
-    """Return the Hugo knowledge URL for an OKF Markdown source path."""
-    relative = path.resolve().relative_to(src_root.resolve())
-    if relative.name == "index.md":
-        section = relative.parent.as_posix()
-        return "/knowledge/" if section == "." else f"/knowledge/{section}/"
-    page = relative.with_suffix("").as_posix()
-    return f"/knowledge/{page}/"
+def page_url_parts(destination: Path, dst_root: Path) -> tuple[str, ...]:
+    """Return URL directory components for a Hugo destination file."""
+    relative = destination.relative_to(dst_root)
+    if relative.name == "_index.md":
+        return tuple(relative.parent.parts) if relative.parent != Path() else ()
+    return tuple(relative.with_suffix("").parts)
+
+
+def relative_hugo_link(
+    from_destination: Path, to_destination: Path, dst_root: Path
+) -> str:
+    """Return a baseURL-safe relative link between two Hugo destination files."""
+    from_parts = page_url_parts(from_destination, dst_root)
+    to_parts = page_url_parts(to_destination, dst_root)
+    common = 0
+    for left, right in zip(from_parts, to_parts, strict=False):
+        if left != right:
+            break
+        common += 1
+    up = len(from_parts) - common
+    down = to_parts[common:]
+    path = "/".join(down) if up == 0 else "/".join([".."] * up + list(down))
+    return f"{path}/" if path else "./"
 
 
 def split_link_target(target: str) -> tuple[str, str]:
@@ -184,7 +199,7 @@ def split_link_target(target: str) -> tuple[str, str]:
     return target[:split_at], target[split_at:]
 
 
-def hugo_body(document: OkfDocument, src_root: Path) -> str:
+def hugo_body(document: OkfDocument, src_root: Path, dst_root: Path) -> str:
     """Rewrite OKF internal Markdown links for Hugo knowledge URLs."""
 
     def replace(match: re.Match[str]) -> str:
@@ -203,16 +218,20 @@ def hugo_body(document: OkfDocument, src_root: Path) -> str:
             okf_path = document.source.parent / target_path
         if okf_path.suffix != ".md":
             return match.group(0)
-        rewritten = f"{hugo_url_for_okf_path(okf_path, src_root)}{suffix}"
+        target_destination = destination_for(okf_path, src_root, dst_root)
+        rewritten = (
+            f"{relative_hugo_link(document.destination, target_destination, dst_root)}"
+            f"{suffix}"
+        )
         return match.group(0).replace(target, rewritten)
 
     return LINK.sub(replace, document.body)
 
 
-def render_document(document: OkfDocument, src_root: Path) -> str:
+def render_document(document: OkfDocument, src_root: Path, dst_root: Path) -> str:
     """Render a Hugo Markdown document from an OKF document."""
     front_matter = dump_yaml(hugo_metadata(document, src_root))
-    return f"---\n{front_matter}---\n{hugo_body(document, src_root)}"
+    return f"---\n{front_matter}---\n{hugo_body(document, src_root, dst_root)}"
 
 
 def write_documents(
@@ -224,7 +243,7 @@ def write_documents(
     for document in documents:
         document.destination.parent.mkdir(parents=True, exist_ok=True)
         document.destination.write_text(
-            render_document(document, src_root), encoding="utf-8"
+            render_document(document, src_root, dst_root), encoding="utf-8"
         )
 
 
@@ -240,7 +259,7 @@ def validate_documents(
     for document in documents:
         errors.extend(validate_reserved_or_concept(document, src_root))
         errors.extend(validate_aims_policy(document, sources, src_root))
-        expected = render_document(document, src_root)
+        expected = render_document(document, src_root, dst_root)
         if not document.destination.exists():
             errors.append(
                 f"AIMS policy error: {document.destination}: generated file is missing"

--- a/tools/okf_hugo_adapter.py
+++ b/tools/okf_hugo_adapter.py
@@ -78,7 +78,7 @@ def dump_yaml(metadata: dict[str, Any]) -> str:
 
 def destination_for(source: Path, src_root: Path, dst_root: Path) -> Path:
     """Return the Hugo destination path for an OKF Markdown source path."""
-    relative = source.relative_to(src_root)
+    relative = source.resolve().relative_to(src_root.resolve())
     if relative.name == "index.md":
         relative = relative.with_name("_index.md")
     return dst_root / relative
@@ -203,6 +203,21 @@ def split_link_target(target: str) -> tuple[str, str]:
     return target[:split_at], target[split_at:]
 
 
+def resolve_internal_okf_target(
+    document: OkfDocument, target_path: str, src_root: Path
+) -> Path | None:
+    """Resolve an internal OKF link target to an absolute path inside the bundle."""
+    if target_path.startswith("/"):
+        okf_path = src_root / target_path.removeprefix("/")
+    else:
+        okf_path = document.source.parent / target_path
+    resolved = okf_path.resolve()
+    src_resolved = src_root.resolve()
+    if not resolved.is_relative_to(src_resolved):
+        return None
+    return resolved
+
+
 def hugo_body(document: OkfDocument, src_root: Path, dst_root: Path) -> str:
     """Rewrite OKF internal Markdown links for Hugo knowledge URLs."""
 
@@ -216,13 +231,10 @@ def hugo_body(document: OkfDocument, src_root: Path, dst_root: Path) -> str:
             or pending_link(target)
         ):
             return match.group(0)
-        if target_path.startswith("/"):
-            okf_path = src_root / target_path.removeprefix("/")
-        else:
-            okf_path = document.source.parent / target_path
-        if okf_path.suffix != ".md":
+        resolved = resolve_internal_okf_target(document, target_path, src_root)
+        if resolved is None or resolved.suffix != ".md":
             return match.group(0)
-        target_destination = destination_for(okf_path, src_root, dst_root)
+        target_destination = destination_for(resolved, src_root, dst_root)
         rewritten = (
             f"{relative_hugo_link(document.destination, target_destination, dst_root)}"
             f"{suffix}"
@@ -372,11 +384,14 @@ def validate_links(
             or pending_link(target)
         ):
             continue
-        resolved = (
-            src_root / clean_target.removeprefix("/")
-            if clean_target.startswith("/")
-            else document.source.parent / clean_target
-        ).resolve()
+        resolved = resolve_internal_okf_target(document, clean_target, src_root)
+        if resolved is None:
+            errors.append(
+                "AIMS policy error: "
+                f"{document.source}: unsafe internal link '{target}' "
+                "escapes OKF bundle"
+            )
+            continue
         if resolved not in sources:
             errors.append(
                 f"AIMS policy error: {document.source}: broken link '{target}'"

--- a/tools/okf_hugo_adapter.py
+++ b/tools/okf_hugo_adapter.py
@@ -163,31 +163,56 @@ def hugo_metadata(document: OkfDocument, src_root: Path) -> dict[str, Any]:
     return converted
 
 
-def hugo_body(body: str) -> str:
-    """Rewrite OKF bundle-absolute Markdown links for Hugo knowledge URLs."""
+def hugo_url_for_okf_path(path: Path, src_root: Path) -> str:
+    """Return the Hugo knowledge URL for an OKF Markdown source path."""
+    relative = path.resolve().relative_to(src_root.resolve())
+    if relative.name == "index.md":
+        section = relative.parent.as_posix()
+        return "/knowledge/" if section == "." else f"/knowledge/{section}/"
+    page = relative.with_suffix("").as_posix()
+    return f"/knowledge/{page}/"
+
+
+def split_link_target(target: str) -> tuple[str, str]:
+    """Split a Markdown link target into path and suffix components."""
+    separators = [
+        index for index in (target.find("?"), target.find("#")) if index != -1
+    ]
+    if not separators:
+        return target, ""
+    split_at = min(separators)
+    return target[:split_at], target[split_at:]
+
+
+def hugo_body(document: OkfDocument, src_root: Path) -> str:
+    """Rewrite OKF internal Markdown links for Hugo knowledge URLs."""
 
     def replace(match: re.Match[str]) -> str:
         target = match.group("target")
+        target_path, suffix = split_link_target(target)
         if (
-            not target.startswith("/")
-            or "://" in target
-            or target.startswith("mailto:")
+            not target_path
+            or "://" in target_path
+            or target_path.startswith("mailto:")
+            or pending_link(target)
         ):
             return match.group(0)
-        target_path, separator, suffix = target.partition("#")
-        path = target_path.removesuffix(".md")
-        rewritten = f"/knowledge{path}/"
-        if separator:
-            rewritten = f"{rewritten}#{suffix}"
+        if target_path.startswith("/"):
+            okf_path = src_root / target_path.removeprefix("/")
+        else:
+            okf_path = document.source.parent / target_path
+        if okf_path.suffix != ".md":
+            return match.group(0)
+        rewritten = f"{hugo_url_for_okf_path(okf_path, src_root)}{suffix}"
         return match.group(0).replace(target, rewritten)
 
-    return LINK.sub(replace, body)
+    return LINK.sub(replace, document.body)
 
 
 def render_document(document: OkfDocument, src_root: Path) -> str:
     """Render a Hugo Markdown document from an OKF document."""
     front_matter = dump_yaml(hugo_metadata(document, src_root))
-    return f"---\n{front_matter}---\n{hugo_body(document.body)}"
+    return f"---\n{front_matter}---\n{hugo_body(document, src_root)}"
 
 
 def write_documents(

--- a/tools/okf_hugo_adapter.py
+++ b/tools/okf_hugo_adapter.py
@@ -18,6 +18,10 @@ class OkfYamlLoader(yaml.SafeLoader):
     """YAML loader that leaves OKF scalar values such as timestamps as strings."""
 
 
+OkfYamlLoader.yaml_implicit_resolvers = {
+    first_character: list(resolvers)
+    for first_character, resolvers in yaml.SafeLoader.yaml_implicit_resolvers.items()
+}
 for first_character, resolvers in list(OkfYamlLoader.yaml_implicit_resolvers.items()):
     OkfYamlLoader.yaml_implicit_resolvers[first_character] = [
         (tag, regexp)
@@ -27,7 +31,7 @@ for first_character, resolvers in list(OkfYamlLoader.yaml_implicit_resolvers.ite
 
 
 FRONT_MATTER = re.compile(r"\A---\n(?P<meta>.*?)\n---\n(?P<body>.*)\Z", re.DOTALL)
-LINK = re.compile(r"(?<!!)\[[^\]]+\]\((?P<target>[^)]+)\)")
+LINK = re.compile(r"(?<!!)\[(?P<label>[^\]]+)\]\((?P<target>[^)]+)\)")
 TAG = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 RECOMMENDED_CONCEPT_FIELDS = ("title", "description", "tags", "timestamp")
 ROOT_INDEX_ALLOWED_FIELDS = {"okf_version"}
@@ -223,7 +227,7 @@ def hugo_body(document: OkfDocument, src_root: Path, dst_root: Path) -> str:
             f"{relative_hugo_link(document.destination, target_destination, dst_root)}"
             f"{suffix}"
         )
-        return match.group(0).replace(target, rewritten)
+        return f"[{match.group('label')}]({rewritten})"
 
     return LINK.sub(replace, document.body)
 

--- a/tools/okf_hugo_adapter.py
+++ b/tools/okf_hugo_adapter.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Generate and validate Hugo shadow content from AIMS OKF Markdown."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+FRONT_MATTER = re.compile(r"\A---\n(?P<meta>.*?)\n---\n(?P<body>.*)\Z", re.DOTALL)
+LINK = re.compile(r"(?<!!)\[[^\]]+\]\((?P<target>[^)]+)\)")
+TAG = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+REQUIRED_CONCEPT_FIELDS = ("title", "description", "type", "tags", "timestamp")
+
+
+@dataclass(frozen=True)
+class OkfDocument:
+    """Parsed OKF Markdown document."""
+
+    source: Path
+    destination: Path
+    metadata: dict[str, Any]
+    body: str
+
+
+def parse_front_matter(path: Path) -> tuple[dict[str, Any], str]:
+    """Parse the YAML-like front matter used by repository OKF files."""
+    text = path.read_text(encoding="utf-8")
+    match = FRONT_MATTER.match(text)
+    if match is None:
+        msg = f"{path}: missing YAML front matter"
+        raise ValueError(msg)
+    return parse_simple_yaml(match.group("meta"), path), match.group("body")
+
+
+def parse_simple_yaml(text: str, path: Path) -> dict[str, Any]:
+    """Parse the small YAML subset used by OKF metadata."""
+    result: dict[str, Any] = {}
+    lines = text.splitlines()
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        if not line.strip():
+            index += 1
+            continue
+        if line.startswith(" ") or ":" not in line:
+            msg = f"{path}: invalid front matter line: {line}"
+            raise ValueError(msg)
+        key, raw_value = line.split(":", 1)
+        key = key.strip()
+        value = raw_value.strip()
+        if value:
+            result[key] = value
+            index += 1
+            continue
+        index += 1
+        items: list[str] = []
+        mapping: dict[str, str] = {}
+        while index < len(lines) and lines[index].startswith("  "):
+            child = lines[index][2:]
+            if child.startswith("- "):
+                items.append(child[2:].strip())
+            elif ":" in child:
+                child_key, child_value = child.split(":", 1)
+                mapping[child_key.strip()] = child_value.strip()
+            else:
+                msg = f"{path}: invalid nested front matter line: {lines[index]}"
+                raise ValueError(msg)
+            index += 1
+        result[key] = items or mapping
+    return result
+
+
+def dump_simple_yaml(metadata: dict[str, Any]) -> str:
+    """Serialize metadata deterministically for Hugo front matter."""
+    lines: list[str] = []
+    for key in sorted(metadata):
+        value = metadata[key]
+        if isinstance(value, dict):
+            lines.append(f"{key}:")
+            for child_key in sorted(value):
+                lines.append(f"  {child_key}: {value[child_key]}")
+        elif isinstance(value, list):
+            lines.append(f"{key}:")
+            for item in value:
+                lines.append(f"  - {item}")
+        else:
+            lines.append(f"{key}: {value}")
+    return "\n".join(lines) + "\n"
+
+
+def destination_for(source: Path, src_root: Path, dst_root: Path) -> Path:
+    """Return the Hugo destination path for an OKF Markdown source path."""
+    relative = source.relative_to(src_root)
+    if relative.name == "index.md":
+        relative = relative.with_name("_index.md")
+    return dst_root / relative
+
+
+def iter_markdown(root: Path) -> list[Path]:
+    """List Markdown files below a root in stable order."""
+    return sorted(path for path in root.rglob("*.md") if path.is_file())
+
+
+def load_documents(src_root: Path, dst_root: Path) -> list[OkfDocument]:
+    """Load OKF documents from source root."""
+    documents: list[OkfDocument] = []
+    for source in iter_markdown(src_root):
+        metadata, body = parse_front_matter(source)
+        documents.append(
+            OkfDocument(
+                source=source,
+                destination=destination_for(source, src_root, dst_root),
+                metadata=metadata,
+                body=body,
+            )
+        )
+    return documents
+
+
+def hugo_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
+    """Map OKF metadata to Hugo-safe metadata."""
+    converted = dict(metadata)
+    okf_type = converted.pop("type", None)
+    params = dict(converted.pop("params", {}))
+    if okf_type is not None:
+        params["okf_type"] = okf_type
+    converted["params"] = params
+    converted["type"] = "knowledge"
+    return converted
+
+
+def render_document(document: OkfDocument) -> str:
+    """Render a Hugo Markdown document from an OKF document."""
+    return (
+        f"---\n{dump_simple_yaml(hugo_metadata(document.metadata))}---\n{document.body}"
+    )
+
+
+def write_documents(documents: list[OkfDocument], dst_root: Path, clean: bool) -> None:
+    """Write generated Hugo content to disk."""
+    if clean and dst_root.exists():
+        shutil.rmtree(dst_root)
+    for document in documents:
+        document.destination.parent.mkdir(parents=True, exist_ok=True)
+        document.destination.write_text(render_document(document), encoding="utf-8")
+
+
+def validate_documents(
+    documents: list[OkfDocument], src_root: Path, dst_root: Path
+) -> list[str]:
+    """Validate OKF metadata, links, and generated-content drift."""
+    errors: list[str] = []
+    sources = {document.source.resolve() for document in documents}
+    for document in documents:
+        errors.extend(validate_metadata(document))
+        errors.extend(validate_links(document, sources))
+        expected = render_document(document)
+        if not document.destination.exists():
+            errors.append(f"{document.destination}: generated file is missing")
+        elif document.destination.read_text(encoding="utf-8") != expected:
+            errors.append(f"{document.destination}: generated file is out of date")
+    if not (src_root / "index.md").exists():
+        errors.append(f"{src_root / 'index.md'}: required OKF index is missing")
+    if not (src_root / "logs" / "log.md").exists():
+        errors.append(f"{src_root / 'logs' / 'log.md'}: required OKF log is missing")
+    for generated in iter_markdown(dst_root) if dst_root.exists() else []:
+        if generated not in {document.destination for document in documents}:
+            errors.append(f"{generated}: stale generated file")
+    return errors
+
+
+def validate_metadata(document: OkfDocument) -> list[str]:
+    """Validate required OKF metadata fields."""
+    errors: list[str] = []
+    for field in REQUIRED_CONCEPT_FIELDS:
+        if document.source.match("*/concepts/*.md") and field not in document.metadata:
+            errors.append(f"{document.source}: missing required field '{field}'")
+    tags = document.metadata.get("tags")
+    if not isinstance(tags, list) or not tags:
+        errors.append(f"{document.source}: tags must be a non-empty list")
+    else:
+        for tag in tags:
+            if not TAG.fullmatch(str(tag)):
+                errors.append(f"{document.source}: invalid tag '{tag}'")
+    return errors
+
+
+def validate_links(document: OkfDocument, sources: set[Path]) -> list[str]:
+    """Validate resolvable relative Markdown links inside OKF bodies."""
+    errors: list[str] = []
+    for match in LINK.finditer(document.body):
+        target = match.group("target").split("#", 1)[0]
+        if not target or "://" in target or target.startswith(("mailto:", "/")):
+            continue
+        resolved = (document.source.parent / target).resolve()
+        if resolved not in sources:
+            errors.append(f"{document.source}: broken link '{match.group('target')}'")
+    return errors
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--src", type=Path, default=Path("okf"))
+    parser.add_argument("--dst", type=Path, default=Path("content/knowledge"))
+    parser.add_argument("--check", action="store_true")
+    parser.add_argument("--clean", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the OKF-to-Hugo adapter."""
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    documents = load_documents(args.src, args.dst)
+    if args.check:
+        errors = validate_documents(documents, args.src, args.dst)
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1 if errors else 0
+    write_documents(documents, args.dst, args.clean)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,41 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11, <3.14"
+
+[[package]]
+name = "aims"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "pyyaml" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "ipython" },
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-mock" },
+    { name = "pytest-stub" },
+    { name = "ruff" },
+    { name = "vulture" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pyyaml", specifier = ">=6.0.0" }]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "ipython", specifier = ">=9.14.0" },
+    { name = "pyright", specifier = ">=1.1.407" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-mock", specifier = ">=3.15.1" },
+    { name = "pytest-stub", specifier = ">=1.1.0" },
+    { name = "ruff", specifier = ">=0.11.0" },
+    { name = "vulture", specifier = ">=2.16" },
+]
 
 [[package]]
 name = "asttokens"
@@ -110,37 +145,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
-]
-
-[[package]]
-name = "aims"
-version = "0.1.0"
-source = { virtual = "." }
-
-[package.dev-dependencies]
-dev = [
-    { name = "ipython" },
-    { name = "pyright" },
-    { name = "pytest" },
-    { name = "pytest-cov" },
-    { name = "pytest-mock" },
-    { name = "pytest-stub" },
-    { name = "ruff" },
-    { name = "vulture" },
-]
-
-[package.metadata]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "ipython", specifier = ">=9.14.0" },
-    { name = "pyright", specifier = ">=1.1.407" },
-    { name = "pytest", specifier = ">=9.0.3" },
-    { name = "pytest-cov", specifier = ">=7.1.0" },
-    { name = "pytest-mock", specifier = ">=3.15.1" },
-    { name = "pytest-stub", specifier = ">=1.1.0" },
-    { name = "ruff", specifier = ">=0.11.0" },
-    { name = "vulture", specifier = ">=2.16" },
 ]
 
 [[package]]
@@ -385,6 +389,43 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/32/67/d22676636e337c058b15178bcf6e3f1cd71b8fd52782791c46152bd79e4c/pytest-stub-1.1.0.tar.gz", hash = "sha256:276043d91cbad863ba56b99f6b781a4a1bc19e1d2e928a5f8e76979ee02c8099", size = 5852, upload-time = "2020-04-28T10:31:22.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/34/30/13f00e1af36577df3e355827cdc02e1a7cbb4fce31966a72a692573ae683/pytest_stub-1.1.0-py2.py3-none-any.whl", hash = "sha256:5de0e3247f8e51321c4dc6d94bbe53c8a96a51edcf722d3df3cb20d4d32b27d7", size = 5700, upload-time = "2020-04-28T10:31:23.943Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Motivation

- Provide a repository-native canonical knowledge model (OKF) instead of the earlier LLM-driven wiki, so durable operational and architectural knowledge is managed in `okf/` and not authored in generated site output. 
- Produce reproducible, Hugo-compatible shadow content from OKF so the static site can publish knowledge without making `content/knowledge/` the source of truth. 
- Give repository-local Agent Skills clear authoring, curation, site-generation, and PR-review workflows to keep human and automation responsibilities explicit. 
- Add lightweight validation and CI/local QA checks so generated content and OKF metadata do not drift silently from the canonical source.

### Description

- Added a seeded OKF canonical tree under `okf/` with `okf/index.md`, `okf/concepts/*`, and a curation log at `okf/logs/log.md`. 
- Implemented a deterministic adapter `tools/okf_hugo_adapter.py` that reads OKF Markdown, converts `index.md`→`_index.md`, moves OKF `type` into `params.okf_type`, sets `type: knowledge` for Hugo, preserves metadata/body, validates links/tags/front matter, and supports `--clean` and `--check`. 
- Generated Hugo shadow content under `content/knowledge/` and added repository-local Agent Skills in `.agents/skills/` (`aims-okf-author`, `aims-okf-curator`, `aims-okf-site`, `aims-okf-pr-review`) with commands/guardrails. 
- Integrated OKF validation into local QA (`.agents/skills/local-qa/scripts/qa.sh`) and CI (`.github/workflows/ci.yml` job `okf-validate`), updated navigation (`config/_default/menus.en.toml`), added tests (`tests/test_okf_hugo_adapter.py`), and adjusted `pyproject.toml` per-file ignores for `tools/*.py` to match lint expectations.

### Testing

- Ran formatting and linting with `uv run ruff format .` and `uv run ruff check --fix .`, which completed successfully. 
- Ran static type checks with `uv run pyright .`, which reported no errors. 
- Executed the full Python test suite with `uv run pytest`, with all tests passing (`264 passed`) and coverage requirements satisfied. 
- Exercised the adapter: `uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge --check` succeeded and `uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge --clean` produced the expected generated shadow content. 
- Validated CFD data with `uv run python .agents/skills/update-cfd-instruments/scripts/validate_cfd_instruments.py`, which succeeded. 
- Ran local QA flow `.agents/skills/local-qa/scripts/qa.sh` and repository checks (`prettier`, `zizmor`, `actionlint`, `yamllint`, `checkov`) which completed, but the Hugo site build step could not fully finish in this environment because the Hugo module build requires Go >= 1.26.3 and the container environment could not download the Go toolchain through the proxy, resulting in an environment limitation rather than a code failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a316658636483218f44ac00ede5a388)