### PR TITLE
feat(analysis): interval-aware quality thresholds and coverage fail gates

### DIFF
--- a/.agents/skills/market-analysis/SKILL.md
+++ b/.agents/skills/market-analysis/SKILL.md
@@ -29,7 +29,11 @@ Generate a Hugo Markdown report from a JSON analysis artifact and write it to `c
 
 ### `notify_slack.py`
 
-Send a Slack notification (success or failure) via an incoming webhook. Reads `SLACK_WEBHOOK_URL` from the environment; exits silently if the variable is not set.
+Send a Slack notification (success or failure) via an incoming webhook. Reads `SLACK_WEBHOOK_URL` from the environment; exits silently if the variable is not set. Success notifications include a coverage summary when `metadata.coverage` is present.
+
+### `data_quality_policy.py`
+
+Single source of truth for interval-specific freshness and missing-bar thresholds (`d` / `w` / `m`) and workflow coverage fail gates.
 
 ## Usage
 
@@ -106,7 +110,24 @@ schema reference. Key structure:
     "data_source": "stooq",
     "data_freshness": {"AAPL.US": "2024-12-31"},
     "scoring_version": "1.0.0",
-    "config": {"stale_days": 5, "min_history": 60, "interval": "d"}
+    "config": {
+      "interval": "d",
+      "stale_days": 5,
+      "max_gap_days": 7,
+      "min_history": 60,
+      "coverage_policy": {
+        "min_success_ratio": 0.8,
+        "max_missing_symbols": 1
+      }
+    },
+    "coverage": {
+      "attempted_count": 2,
+      "fetched_count": 2,
+      "missing_symbols": [],
+      "success_ratio": 1.0,
+      "passed": true,
+      "violations": []
+    }
   },
   "instruments": [
     {
@@ -137,8 +158,11 @@ Instruments failing quality checks are included in output but marked
 
 | Gate                   | Trigger                                                       |
 | ---------------------- | ------------------------------------------------------------- |
-| `stale_data`           | Latest bar older than `stale_days` calendar days              |
+| `stale_data`           | Latest bar older than interval-specific `stale_days`          |
 | `insufficient_history` | Fewer than `min_history` bars                                 |
-| `missing_bars`         | Gap > 7 calendar days between consecutive bars                |
+| `missing_bars`         | Gap greater than interval-specific `max_gap_days`             |
 | `malformed_input`      | Non-positive prices, high < low, or price outside [low, high] |
 | `high_volatility`      | 20-day annualized volatility > 100%                           |
+| `missing_data`         | No price history available for the symbol                     |
+
+Interval thresholds and coverage policy defaults are defined in `data_quality_policy.py`. The `generate` command exits with a non-zero status when coverage gates fail, preventing publication and success Slack notifications while still writing an artifact for local inspection when some symbols loaded successfully.

--- a/.agents/skills/market-analysis/SKILL.md
+++ b/.agents/skills/market-analysis/SKILL.md
@@ -168,4 +168,6 @@ Instruments failing quality checks are included in output but marked
 
 Interval thresholds and coverage policy defaults are defined in `data_quality_policy.py`. The `generate` command exits with a non-zero status when coverage gates fail, preventing publication and success Slack notifications while still writing an artifact for local inspection when some symbols loaded successfully.
 
-In the daily workflow, coverage is derived from `data/prices/fetch_status_<interval>.json`, which records per-symbol fetch outcomes for the current run. Pass this file to `generate --fetch-status` so pre-existing price CSVs cannot mask fetch failures.
+In the daily workflow, coverage is derived from `data/prices/fetch_status_<interval>.json`, which records per-symbol fetch outcomes for the current run. Pass this file to `generate --fetch-status` so pre-existing price CSVs cannot mask fetch failures. `generate` rejects fetch-status files whose `interval` or `analysis_date` conflict with the current run.
+
+When coverage gates fail, `generate` may write a diagnostic artifact with `metadata.coverage.passed: false` and exit non-zero. The automated workflow stops before validation or publication; `validate_analysis.py` accepts `passed: false` structurally, but only `generate` exit code `0` artifacts reach the public pipeline.

--- a/.agents/skills/market-analysis/SKILL.md
+++ b/.agents/skills/market-analysis/SKILL.md
@@ -10,14 +10,15 @@ All scripts are in `.agents/skills/market-analysis/scripts/`.
 
 ### `market_analysis.py`
 
-Four sub-commands:
+Five sub-commands:
 
-| Command    | Purpose                                                   |
-| ---------- | --------------------------------------------------------- |
-| `fetch`    | Download OHLCV data from Stooq and save to `data/prices/` |
-| `check`    | Run data-quality checks on saved data                     |
-| `score`    | Score and rank instruments cross-sectionally              |
-| `generate` | Generate a versioned JSON analysis artifact               |
+| Command             | Purpose                                                   |
+| ------------------- | --------------------------------------------------------- |
+| `fetch`             | Download OHLCV data from Stooq and save to `data/prices/` |
+| `init-fetch-status` | Initialize per-run fetch-status JSON before a fetch loop  |
+| `check`             | Run data-quality checks on saved data                     |
+| `score`             | Score and rank instruments cross-sectionally              |
+| `generate`          | Generate a versioned JSON analysis artifact               |
 
 ### `validate_analysis.py`
 
@@ -166,3 +167,5 @@ Instruments failing quality checks are included in output but marked
 | `missing_data`         | No price history available for the symbol                     |
 
 Interval thresholds and coverage policy defaults are defined in `data_quality_policy.py`. The `generate` command exits with a non-zero status when coverage gates fail, preventing publication and success Slack notifications while still writing an artifact for local inspection when some symbols loaded successfully.
+
+In the daily workflow, coverage is derived from `data/prices/fetch_status_<interval>.json`, which records per-symbol fetch outcomes for the current run. Pass this file to `generate --fetch-status` so pre-existing price CSVs cannot mask fetch failures.

--- a/.agents/skills/market-analysis/scripts/data_quality_policy.py
+++ b/.agents/skills/market-analysis/scripts/data_quality_policy.py
@@ -1,0 +1,159 @@
+"""Single source of truth for AIMS market-data quality and coverage policy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Final, Literal
+
+Interval = Literal["d", "w", "m"]
+
+_SUPPORTED_INTERVALS: Final[tuple[str, ...]] = ("d", "w", "m")
+
+
+@dataclass(frozen=True)
+class IntervalQualityThresholds:
+    """Freshness and gap thresholds for one bar interval."""
+
+    stale_days: int
+    max_gap_days: int
+    min_history: int
+
+
+@dataclass(frozen=True)
+class CoveragePolicy:
+    """Workflow fail gates for systemic data-source failures."""
+
+    min_success_ratio: float
+    max_missing_symbols: int
+
+
+@dataclass(frozen=True)
+class DataQualityPolicy:
+    """Effective quality policy for a single analysis run."""
+
+    interval: str
+    thresholds: IntervalQualityThresholds
+    coverage: CoveragePolicy
+
+
+@dataclass(frozen=True)
+class CoverageResult:
+    """Observed symbol coverage for one analysis run."""
+
+    attempted_symbols: tuple[str, ...]
+    fetched_symbols: tuple[str, ...]
+    missing_symbols: tuple[str, ...]
+    success_ratio: float
+    passed: bool
+    violations: tuple[str, ...]
+
+
+_INTERVAL_THRESHOLDS: Final[dict[str, IntervalQualityThresholds]] = {
+    "d": IntervalQualityThresholds(stale_days=5, max_gap_days=7, min_history=60),
+    "w": IntervalQualityThresholds(stale_days=21, max_gap_days=21, min_history=60),
+    "m": IntervalQualityThresholds(stale_days=62, max_gap_days=62, min_history=60),
+}
+
+_DEFAULT_COVERAGE: Final[CoveragePolicy] = CoveragePolicy(
+    min_success_ratio=0.8,
+    max_missing_symbols=1,
+)
+DEFAULT_COVERAGE_POLICY: Final[CoveragePolicy] = _DEFAULT_COVERAGE
+
+
+def get_interval_thresholds(interval: str) -> IntervalQualityThresholds:
+    """Return interval-specific freshness and missing-bar thresholds."""
+    if interval not in _INTERVAL_THRESHOLDS:
+        msg = (
+            f"unsupported interval: {interval!r}"
+            f" (expected one of {_SUPPORTED_INTERVALS})"
+        )
+        raise ValueError(msg)
+    return _INTERVAL_THRESHOLDS[interval]
+
+
+def get_data_quality_policy(
+    interval: str,
+    *,
+    coverage: CoveragePolicy | None = None,
+) -> DataQualityPolicy:
+    """Return the effective policy for *interval*."""
+    return DataQualityPolicy(
+        interval=interval,
+        thresholds=get_interval_thresholds(interval),
+        coverage=coverage or _DEFAULT_COVERAGE,
+    )
+
+
+def build_config_dict(policy: DataQualityPolicy) -> dict[str, Any]:
+    """Serialize effective thresholds and coverage policy for artifact metadata."""
+    thresholds = policy.thresholds
+    coverage = policy.coverage
+    return {
+        "interval": policy.interval,
+        "stale_days": thresholds.stale_days,
+        "max_gap_days": thresholds.max_gap_days,
+        "min_history": thresholds.min_history,
+        "coverage_policy": {
+            "min_success_ratio": coverage.min_success_ratio,
+            "max_missing_symbols": coverage.max_missing_symbols,
+        },
+    }
+
+
+def evaluate_coverage(
+    attempted: list[str],
+    fetched: list[str],
+    missing: list[str],
+    policy: CoveragePolicy,
+) -> CoverageResult:
+    """Evaluate whether observed symbol coverage satisfies workflow fail gates."""
+    attempted_symbols = tuple(attempted)
+    fetched_symbols = tuple(fetched)
+    missing_symbols = tuple(missing)
+    attempted_count = len(attempted_symbols)
+
+    if attempted_count == 0:
+        return CoverageResult(
+            attempted_symbols=attempted_symbols,
+            fetched_symbols=fetched_symbols,
+            missing_symbols=missing_symbols,
+            success_ratio=0.0,
+            passed=False,
+            violations=("empty symbol universe",),
+        )
+
+    success_ratio = len(fetched_symbols) / attempted_count
+    violations: list[str] = []
+
+    if not fetched_symbols:
+        violations.append("all symbols failed to load")
+    if len(missing_symbols) > policy.max_missing_symbols:
+        violations.append(
+            f"missing symbols ({len(missing_symbols)} > {policy.max_missing_symbols})"
+        )
+    if success_ratio < policy.min_success_ratio:
+        violations.append(
+            f"success ratio ({success_ratio:.2%} < {policy.min_success_ratio:.0%})"
+        )
+
+    return CoverageResult(
+        attempted_symbols=attempted_symbols,
+        fetched_symbols=fetched_symbols,
+        missing_symbols=missing_symbols,
+        success_ratio=success_ratio,
+        passed=not violations,
+        violations=tuple(violations),
+    )
+
+
+def build_coverage_metadata(result: CoverageResult) -> dict[str, Any]:
+    """Serialize observed coverage statistics for artifact metadata."""
+    return {
+        "attempted_count": len(result.attempted_symbols),
+        "fetched_count": len(result.fetched_symbols),
+        "missing_symbols": list(result.missing_symbols),
+        "success_ratio": round(result.success_ratio, 4),
+        "passed": result.passed,
+        "violations": list(result.violations),
+    }

--- a/.agents/skills/market-analysis/scripts/market_analysis.py
+++ b/.agents/skills/market-analysis/scripts/market_analysis.py
@@ -290,9 +290,7 @@ def init_fetch_status(
         "version": _FETCH_STATUS_VERSION,
         "interval": interval,
         "analysis_date": analysis_date,
-        "symbols": {
-            symbol: {"status": _FETCH_STATUS_PENDING} for symbol in symbols
-        },
+        "symbols": {symbol: {"status": _FETCH_STATUS_PENDING} for symbol in symbols},
     }
     with path.open("w", encoding="utf-8") as fh:
         json.dump(payload, fh, indent=2)
@@ -329,6 +327,33 @@ def record_fetch_status(
     symbols[symbol] = entry
     with path.open("w", encoding="utf-8") as fh:
         json.dump(data, fh, indent=2)
+
+
+def validate_fetch_status(
+    fetch_status: dict[str, Any],
+    *,
+    interval: str,
+    analysis_date: str | None = None,
+) -> None:
+    """Reject fetch-status metadata that does not match the current run."""
+    status_interval = fetch_status.get("interval")
+    if status_interval != interval:
+        msg = (
+            f"fetch status interval {status_interval!r} does not match"
+            f" requested interval {interval!r}"
+        )
+        raise ValueError(msg)
+    status_date = fetch_status.get("analysis_date")
+    if (
+        analysis_date is not None
+        and status_date is not None
+        and status_date != analysis_date
+    ):
+        msg = (
+            f"fetch status analysis_date {status_date!r} does not match"
+            f" requested analysis_date {analysis_date!r}"
+        )
+        raise ValueError(msg)
 
 
 def resolve_symbols_from_fetch_status(
@@ -917,6 +942,11 @@ def _cmd_generate(args: argparse.Namespace) -> int:
     if fetch_status_path is not None:
         try:
             fetch_status = load_fetch_status(fetch_status_path)
+            validate_fetch_status(
+                fetch_status,
+                interval=args.interval,
+                analysis_date=getattr(args, "analysis_date", None) or None,
+            )
         except (FileNotFoundError, json.JSONDecodeError, TypeError, ValueError) as exc:
             print(f"ERROR: invalid fetch status file: {exc}")
             return 1

--- a/.agents/skills/market-analysis/scripts/market_analysis.py
+++ b/.agents/skills/market-analysis/scripts/market_analysis.py
@@ -50,6 +50,11 @@ _MIN_HISTORY: Final[int] = _DAILY_POLICY.thresholds.min_history
 _MAX_GAP_DAYS: Final[int] = _DAILY_POLICY.thresholds.max_gap_days
 _HIGH_VOL_THRESHOLD: Final[float] = 1.0
 
+_FETCH_STATUS_VERSION: Final[str] = "1.0.0"
+_FETCH_STATUS_SUCCESS: Final[str] = "success"
+_FETCH_STATUS_FAILED: Final[str] = "failed"
+_FETCH_STATUS_PENDING: Final[str] = "pending"
+
 SCORING_VERSION: Final[str] = "1.0.0"
 ARTIFACT_VERSION: Final[str] = "1.0.0"
 
@@ -267,6 +272,83 @@ def load_ohlcv(
                 )
             )
     return sorted(bars, key=lambda b: b.timestamp)
+
+
+# ── Fetch status (current-run coverage source of truth) ───────────────────────
+
+
+def init_fetch_status(
+    path: Path,
+    symbols: list[str],
+    *,
+    interval: str,
+    analysis_date: str | None = None,
+) -> None:
+    """Initialize a fetch-status file with all symbols marked pending."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "version": _FETCH_STATUS_VERSION,
+        "interval": interval,
+        "analysis_date": analysis_date,
+        "symbols": {
+            symbol: {"status": _FETCH_STATUS_PENDING} for symbol in symbols
+        },
+    }
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(payload, fh, indent=2)
+
+
+def load_fetch_status(path: Path) -> dict[str, Any]:
+    """Load a fetch-status JSON file."""
+    with path.open(encoding="utf-8") as fh:
+        data = json.load(fh)
+    if not isinstance(data, dict):
+        msg = f"fetch status at {path} must be a JSON object"
+        raise TypeError(msg)
+    return data
+
+
+def record_fetch_status(
+    path: Path,
+    symbol: str,
+    *,
+    success: bool,
+    error: str | None = None,
+) -> None:
+    """Record the outcome of a single-symbol fetch in *path*."""
+    data = load_fetch_status(path)
+    symbols = data.get("symbols")
+    if not isinstance(symbols, dict):
+        msg = f"fetch status at {path} is missing a valid 'symbols' object"
+        raise TypeError(msg)
+    entry: dict[str, str] = {
+        "status": _FETCH_STATUS_SUCCESS if success else _FETCH_STATUS_FAILED
+    }
+    if error:
+        entry["error"] = error
+    symbols[symbol] = entry
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+
+
+def resolve_symbols_from_fetch_status(
+    symbols: list[str],
+    fetch_status: dict[str, Any],
+) -> tuple[list[str], list[str]]:
+    """Return (fetched, missing) symbol lists from a fetch-status payload."""
+    raw_symbols = fetch_status.get("symbols")
+    if not isinstance(raw_symbols, dict):
+        msg = "fetch status is missing a valid 'symbols' object"
+        raise TypeError(msg)
+    fetched: list[str] = []
+    missing: list[str] = []
+    for symbol in symbols:
+        entry = raw_symbols.get(symbol)
+        if isinstance(entry, dict) and entry.get("status") == _FETCH_STATUS_SUCCESS:
+            fetched.append(symbol)
+        else:
+            missing.append(symbol)
+    return fetched, missing
 
 
 # ── Data quality ──────────────────────────────────────────────────────────────
@@ -712,16 +794,32 @@ def _cmd_fetch(args: argparse.Namespace) -> int:
     start = datetime.strptime(args.start, "%Y-%m-%d").replace(tzinfo=UTC)
     end = datetime.strptime(args.end, "%Y-%m-%d").replace(tzinfo=UTC)
     provider = StooqProvider()
+    fetch_status_path: Path | None = (
+        Path(args.fetch_status) if getattr(args, "fetch_status", None) else None
+    )
     try:
         bars = provider.fetch_ohlcv(args.symbol, start, end, args.interval)
     except (URLError, ValueError) as exc:
         print(f"ERROR: fetch failed for {args.symbol}: {exc}")
+        if fetch_status_path is not None:
+            record_fetch_status(
+                fetch_status_path, args.symbol, success=False, error=str(exc)
+            )
         return 1
     if not bars:
         print(f"ERROR: no data returned for {args.symbol}")
+        if fetch_status_path is not None:
+            record_fetch_status(
+                fetch_status_path,
+                args.symbol,
+                success=False,
+                error="no data returned",
+            )
         return 1
     path = save_ohlcv(bars, Path(args.output))
     print(f"saved {len(bars)} bars to {path}")
+    if fetch_status_path is not None:
+        record_fetch_status(fetch_status_path, args.symbol, success=True)
     if not args.no_validate:
         policy = get_data_quality_policy(args.interval)
         thresholds = policy.thresholds
@@ -785,6 +883,21 @@ def _cmd_score(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_init_fetch_status(args: argparse.Namespace) -> int:
+    symbols = [s.strip() for s in args.symbols.split(",") if s.strip()]
+    if not symbols:
+        print("ERROR: no symbols provided")
+        return 1
+    init_fetch_status(
+        Path(args.output),
+        symbols,
+        interval=args.interval,
+        analysis_date=getattr(args, "analysis_date", None) or None,
+    )
+    print(f"fetch status initialized for {len(symbols)} symbol(s) at {args.output}")
+    return 0
+
+
 def _cmd_generate(args: argparse.Namespace) -> int:
     symbols = [s.strip() for s in args.symbols.split(",") if s.strip()]
     if not symbols:
@@ -798,17 +911,49 @@ def _cmd_generate(args: argparse.Namespace) -> int:
     policy = get_data_quality_policy(args.interval, coverage=coverage_policy)
     thresholds = policy.thresholds
 
+    fetch_status_path: Path | None = (
+        Path(args.fetch_status) if getattr(args, "fetch_status", None) else None
+    )
+    if fetch_status_path is not None:
+        try:
+            fetch_status = load_fetch_status(fetch_status_path)
+        except (FileNotFoundError, json.JSONDecodeError, TypeError, ValueError) as exc:
+            print(f"ERROR: invalid fetch status file: {exc}")
+            return 1
+        fetched_symbols, missing = resolve_symbols_from_fetch_status(
+            symbols, fetch_status
+        )
+    else:
+        fetched_symbols = []
+        missing = []
+        for sym in symbols:
+            try:
+                load_ohlcv(sym, args.interval, Path(args.data_dir))
+            except FileNotFoundError:
+                missing.append(sym)
+            else:
+                fetched_symbols.append(sym)
+
+    coverage_result = evaluate_coverage(
+        symbols, fetched_symbols, missing, coverage_policy
+    )
+    coverage_metadata = build_coverage_metadata(coverage_result)
+
     data: dict[str, list[OhlcvBar]] = {}
-    missing: list[str] = []
-    for sym in symbols:
+    load_failures: list[str] = []
+    for sym in fetched_symbols:
         try:
             data[sym] = load_ohlcv(sym, args.interval, Path(args.data_dir))
         except FileNotFoundError:
-            print(f"WARNING: no data for {sym}, marking as missing")
-            missing.append(sym)
-
-    coverage_result = evaluate_coverage(symbols, list(data), missing, coverage_policy)
-    coverage_metadata = build_coverage_metadata(coverage_result)
+            print(f"WARNING: fetch status success but no data file for {sym}")
+            load_failures.append(sym)
+    if load_failures:
+        fetched_symbols = [s for s in fetched_symbols if s not in load_failures]
+        missing = sorted(set(missing) | set(load_failures))
+        coverage_result = evaluate_coverage(
+            symbols, fetched_symbols, missing, coverage_policy
+        )
+        coverage_metadata = build_coverage_metadata(coverage_result)
 
     if not data:
         print("ERROR: no symbols could be loaded")
@@ -861,6 +1006,30 @@ def main(argv: list[str] | None = None) -> int:
     p_fetch.add_argument("--interval", default=_DEFAULT_INTERVAL, help="d/w/m")
     p_fetch.add_argument("--output", default=str(_DEFAULT_PRICES_DIR))
     p_fetch.add_argument("--no-validate", action="store_true", dest="no_validate")
+    p_fetch.add_argument(
+        "--fetch-status",
+        default=None,
+        dest="fetch_status",
+        help="Path to fetch-status JSON updated with this fetch result",
+    )
+
+    p_init_status = sub.add_parser(
+        "init-fetch-status",
+        help="Initialize fetch-status JSON for a symbol list",
+    )
+    p_init_status.add_argument("--symbols", required=True, help="Comma-separated list")
+    p_init_status.add_argument("--interval", default=_DEFAULT_INTERVAL)
+    p_init_status.add_argument(
+        "--output",
+        required=True,
+        help="Path to fetch-status JSON file to create",
+    )
+    p_init_status.add_argument(
+        "--analysis-date",
+        default=None,
+        dest="analysis_date",
+        help="Analysis date (YYYY-MM-DD) recorded in fetch status",
+    )
 
     p_check = sub.add_parser("check", help="Check data quality of saved OHLCV")
     p_check.add_argument("--symbol", required=True)
@@ -901,6 +1070,12 @@ def main(argv: list[str] | None = None) -> int:
         dest="max_missing_symbols",
         help="Maximum allowed missing symbols (default: 1)",
     )
+    p_gen.add_argument(
+        "--fetch-status",
+        default=None,
+        dest="fetch_status",
+        help="Path to fetch-status JSON from the current fetch run",
+    )
 
     args = parser.parse_args(argv)
 
@@ -910,6 +1085,8 @@ def main(argv: list[str] | None = None) -> int:
         return _cmd_check(args)
     if args.command == "score":
         return _cmd_score(args)
+    if args.command == "init-fetch-status":
+        return _cmd_init_fetch_status(args)
     return _cmd_generate(args)
 
 

--- a/.agents/skills/market-analysis/scripts/market_analysis.py
+++ b/.agents/skills/market-analysis/scripts/market_analysis.py
@@ -30,15 +30,25 @@ from typing import Any, Final
 from urllib.error import URLError
 from urllib.request import urlopen
 
+from data_quality_policy import (
+    DEFAULT_COVERAGE_POLICY,
+    CoveragePolicy,
+    build_config_dict,
+    build_coverage_metadata,
+    evaluate_coverage,
+    get_data_quality_policy,
+)
+
 # ── Constants ────────────────────────────────────────────────────────────────
 
 _DEFAULT_PRICES_DIR: Final[Path] = Path("data/prices")
 _DEFAULT_ANALYSIS_DIR: Final[Path] = Path("data/analysis")
 _DEFAULT_INTERVAL: Final[str] = "d"
-_STALE_DAYS: Final[int] = 5
-_MIN_HISTORY: Final[int] = 60
+_DAILY_POLICY = get_data_quality_policy(_DEFAULT_INTERVAL)
+_STALE_DAYS: Final[int] = _DAILY_POLICY.thresholds.stale_days
+_MIN_HISTORY: Final[int] = _DAILY_POLICY.thresholds.min_history
+_MAX_GAP_DAYS: Final[int] = _DAILY_POLICY.thresholds.max_gap_days
 _HIGH_VOL_THRESHOLD: Final[float] = 1.0
-_MAX_GAP_DAYS: Final[int] = 7
 
 SCORING_VERSION: Final[str] = "1.0.0"
 ARTIFACT_VERSION: Final[str] = "1.0.0"
@@ -267,6 +277,7 @@ def check_data_quality(
     *,
     stale_days: int = _STALE_DAYS,
     min_history: int = _MIN_HISTORY,
+    max_gap_days: int = _MAX_GAP_DAYS,
     reference_time: datetime | None = None,
 ) -> DataQualityReport:
     if not bars:
@@ -315,7 +326,7 @@ def check_data_quality(
     if len(bars) >= 2:
         for i in range(1, len(bars)):
             gap = (bars[i].timestamp - bars[i - 1].timestamp).days
-            if gap > _MAX_GAP_DAYS:
+            if gap > max_gap_days:
                 report.issues.append(
                     f"possible missing bars: {gap}-day gap between"
                     f" {bars[i - 1].timestamp.date()} and"
@@ -497,6 +508,7 @@ def score_instruments(
     reference_time: datetime | None = None,
     stale_days: int = _STALE_DAYS,
     min_history: int = _MIN_HISTORY,
+    max_gap_days: int = _MAX_GAP_DAYS,
 ) -> list[InstrumentScore]:
     if not data:
         return []
@@ -507,6 +519,7 @@ def score_instruments(
             data[s],
             stale_days=stale_days,
             min_history=min_history,
+            max_gap_days=max_gap_days,
             reference_time=reference_time,
         )
         for s in symbols
@@ -611,6 +624,7 @@ def generate_artifact(
     *,
     analysis_date: str | None = None,
     missing_symbols: list[str] | None = None,
+    coverage: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     now = datetime.now(tz=UTC)
     generated_at = (
@@ -660,16 +674,19 @@ def generate_artifact(
             "features": _features_to_dict(empty_feats),
         })
         next_rank += 1
+    metadata: dict[str, Any] = {
+        "generated_at": generated_at,
+        "git_commit": _get_git_commit(),
+        "data_source": data_source,
+        "data_freshness": freshness,
+        "scoring_version": SCORING_VERSION,
+        "config": config,
+    }
+    if coverage is not None:
+        metadata["coverage"] = coverage
     return {
         "version": ARTIFACT_VERSION,
-        "metadata": {
-            "generated_at": generated_at,
-            "git_commit": _get_git_commit(),
-            "data_source": data_source,
-            "data_freshness": freshness,
-            "scoring_version": SCORING_VERSION,
-            "config": config,
-        },
+        "metadata": metadata,
         "instruments": instruments,
     }
 
@@ -706,7 +723,14 @@ def _cmd_fetch(args: argparse.Namespace) -> int:
     path = save_ohlcv(bars, Path(args.output))
     print(f"saved {len(bars)} bars to {path}")
     if not args.no_validate:
-        report = check_data_quality(bars)
+        policy = get_data_quality_policy(args.interval)
+        thresholds = policy.thresholds
+        report = check_data_quality(
+            bars,
+            stale_days=thresholds.stale_days,
+            min_history=thresholds.min_history,
+            max_gap_days=thresholds.max_gap_days,
+        )
         for issue in report.issues:
             print(f"WARNING: {issue}")
     return 0
@@ -718,7 +742,13 @@ def _cmd_check(args: argparse.Namespace) -> int:
     except FileNotFoundError as exc:
         print(f"ERROR: {exc}")
         return 1
-    report = check_data_quality(bars)
+    policy = get_data_quality_policy(args.interval)
+    report = check_data_quality(
+        bars,
+        stale_days=policy.thresholds.stale_days,
+        min_history=policy.thresholds.min_history,
+        max_gap_days=policy.thresholds.max_gap_days,
+    )
     if report.is_valid:
         sym_interval = f"{args.symbol}/{args.interval}"
         print(f"data quality OK: {report.bar_count} bars for {sym_interval}")
@@ -739,7 +769,14 @@ def _cmd_score(args: argparse.Namespace) -> int:
     if not data:
         print("ERROR: no symbols could be loaded")
         return 1
-    results = score_instruments(data)
+    policy = get_data_quality_policy(args.interval)
+    thresholds = policy.thresholds
+    results = score_instruments(
+        data,
+        stale_days=thresholds.stale_days,
+        min_history=thresholds.min_history,
+        max_gap_days=thresholds.max_gap_days,
+    )
     print(f"{'rank':>4}  {'symbol':<20}  {'score':>6}  {'reliable':>8}  gates")
     for s in results:
         reliable = "yes" if s.is_reliable else "no"
@@ -750,6 +787,17 @@ def _cmd_score(args: argparse.Namespace) -> int:
 
 def _cmd_generate(args: argparse.Namespace) -> int:
     symbols = [s.strip() for s in args.symbols.split(",") if s.strip()]
+    if not symbols:
+        print("ERROR: no symbols provided")
+        return 1
+
+    coverage_policy = CoveragePolicy(
+        min_success_ratio=args.min_success_ratio,
+        max_missing_symbols=args.max_missing_symbols,
+    )
+    policy = get_data_quality_policy(args.interval, coverage=coverage_policy)
+    thresholds = policy.thresholds
+
     data: dict[str, list[OhlcvBar]] = {}
     missing: list[str] = []
     for sym in symbols:
@@ -758,33 +806,47 @@ def _cmd_generate(args: argparse.Namespace) -> int:
         except FileNotFoundError:
             print(f"WARNING: no data for {sym}, marking as missing")
             missing.append(sym)
+
+    coverage_result = evaluate_coverage(symbols, list(data), missing, coverage_policy)
+    coverage_metadata = build_coverage_metadata(coverage_result)
+
     if not data:
         print("ERROR: no symbols could be loaded")
+        for violation in coverage_result.violations:
+            print(f"ERROR: coverage gate failed: {violation}")
         return 1
-    config: dict[str, Any] = {
-        "stale_days": _STALE_DAYS,
-        "min_history": _MIN_HISTORY,
-        "interval": args.interval,
-    }
+
+    config = build_config_dict(policy)
     analysis_date: str | None = getattr(args, "analysis_date", None) or None
     reference_time: datetime | None = None
     if analysis_date:
         reference_time = datetime.strptime(analysis_date, "%Y-%m-%d").replace(
             tzinfo=UTC
         )
-    results = score_instruments(data, reference_time=reference_time)
+    results = score_instruments(
+        data,
+        reference_time=reference_time,
+        stale_days=thresholds.stale_days,
+        min_history=thresholds.min_history,
+        max_gap_days=thresholds.max_gap_days,
+    )
     artifact = generate_artifact(
         results,
         data,
         config,
         analysis_date=analysis_date,
         missing_symbols=missing or None,
+        coverage=coverage_metadata,
     )
     path = save_artifact(artifact, Path(args.output))
     print(f"artifact saved to {path}")
     if missing:
         syms = ", ".join(sorted(missing))
         print(f"WARNING: {len(missing)} symbol(s) had no data: {syms}")
+    if not coverage_result.passed:
+        for violation in coverage_result.violations:
+            print(f"ERROR: coverage gate failed: {violation}")
+        return 1
     return 0
 
 
@@ -824,6 +886,20 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         dest="analysis_date",
         help="Override analysis date (YYYY-MM-DD; default: today UTC)",
+    )
+    p_gen.add_argument(
+        "--min-success-ratio",
+        type=float,
+        default=DEFAULT_COVERAGE_POLICY.min_success_ratio,
+        dest="min_success_ratio",
+        help="Minimum fetched/total symbol ratio (default: 0.8)",
+    )
+    p_gen.add_argument(
+        "--max-missing-symbols",
+        type=int,
+        default=DEFAULT_COVERAGE_POLICY.max_missing_symbols,
+        dest="max_missing_symbols",
+        help="Maximum allowed missing symbols (default: 1)",
     )
 
     args = parser.parse_args(argv)

--- a/.agents/skills/market-analysis/scripts/notify_slack.py
+++ b/.agents/skills/market-analysis/scripts/notify_slack.py
@@ -86,6 +86,23 @@ def build_success_payload(
             "text": f"*⚠️ No data:* {', '.join(stale)}",
         })
 
+    coverage_raw = meta.get("coverage")
+    if isinstance(coverage_raw, dict):
+        fetched = coverage_raw.get("fetched_count")
+        attempted = coverage_raw.get("attempted_count")
+        ratio = coverage_raw.get("success_ratio")
+        if (
+            isinstance(fetched, int)
+            and isinstance(attempted, int)
+            and isinstance(ratio, (int, float))
+        ):
+            fields.append({
+                "type": "mrkdwn",
+                "text": (
+                    f"*Coverage:* {fetched}/{attempted} ({float(ratio):.0%} success)"
+                ),
+            })
+
     if pr_url is not None:
         text = f"AIMS Market Analysis {date_str}: {regime} market. Analysis PR created."
         button_text = "View PR"

--- a/.agents/skills/market-analysis/scripts/validate_analysis.py
+++ b/.agents/skills/market-analysis/scripts/validate_analysis.py
@@ -105,12 +105,8 @@ def validate_artifact(data: dict[str, Any]) -> list[str]:
                 if key not in config
             )
             coverage_policy = config.get("coverage_policy")
-            if coverage_policy is not None and not isinstance(
-                coverage_policy, dict
-            ):
-                errors.append(
-                    "metadata.config.coverage_policy must be a JSON object"
-                )
+            if coverage_policy is not None and not isinstance(coverage_policy, dict):
+                errors.append("metadata.config.coverage_policy must be a JSON object")
 
         coverage = metadata.get("coverage")
         if coverage is None:
@@ -126,8 +122,6 @@ def validate_artifact(data: dict[str, Any]) -> list[str]:
             passed = coverage.get("passed")
             if passed is not None and not isinstance(passed, bool):
                 errors.append("metadata.coverage.passed must be a boolean")
-            elif passed is False:
-                errors.append("metadata.coverage.passed is false")
 
     instruments = data["instruments"]
     if not isinstance(instruments, list):

--- a/.agents/skills/market-analysis/scripts/validate_analysis.py
+++ b/.agents/skills/market-analysis/scripts/validate_analysis.py
@@ -94,38 +94,40 @@ def validate_artifact(data: dict[str, Any]) -> list[str]:
                         )
 
         config = metadata.get("config")
-        if config is not None:
-            if not isinstance(config, dict):
-                errors.append("metadata.config must be a JSON object")
-            else:
-                errors.extend(
-                    f"metadata.config missing required key: {key!r}"
-                    for key in _REQUIRED_CONFIG
-                    if key not in config
+        if config is None:
+            errors.append("metadata.config must not be null")
+        elif not isinstance(config, dict):
+            errors.append("metadata.config must be a JSON object")
+        else:
+            errors.extend(
+                f"metadata.config missing required key: {key!r}"
+                for key in _REQUIRED_CONFIG
+                if key not in config
+            )
+            coverage_policy = config.get("coverage_policy")
+            if coverage_policy is not None and not isinstance(
+                coverage_policy, dict
+            ):
+                errors.append(
+                    "metadata.config.coverage_policy must be a JSON object"
                 )
-                coverage_policy = config.get("coverage_policy")
-                if coverage_policy is not None and not isinstance(
-                    coverage_policy, dict
-                ):
-                    errors.append(
-                        "metadata.config.coverage_policy must be a JSON object"
-                    )
 
         coverage = metadata.get("coverage")
-        if coverage is not None:
-            if not isinstance(coverage, dict):
-                errors.append("metadata.coverage must be a JSON object")
-            else:
-                errors.extend(
-                    f"metadata.coverage missing required key: {key!r}"
-                    for key in _REQUIRED_COVERAGE
-                    if key not in coverage
-                )
-                passed = coverage.get("passed")
-                if passed is not None and not isinstance(passed, bool):
-                    errors.append("metadata.coverage.passed must be a boolean")
-                elif passed is False:
-                    errors.append("metadata.coverage.passed is false")
+        if coverage is None:
+            errors.append("metadata.coverage must not be null")
+        elif not isinstance(coverage, dict):
+            errors.append("metadata.coverage must be a JSON object")
+        else:
+            errors.extend(
+                f"metadata.coverage missing required key: {key!r}"
+                for key in _REQUIRED_COVERAGE
+                if key not in coverage
+            )
+            passed = coverage.get("passed")
+            if passed is not None and not isinstance(passed, bool):
+                errors.append("metadata.coverage.passed must be a boolean")
+            elif passed is False:
+                errors.append("metadata.coverage.passed is false")
 
     instruments = data["instruments"]
     if not isinstance(instruments, list):

--- a/.agents/skills/market-analysis/scripts/validate_analysis.py
+++ b/.agents/skills/market-analysis/scripts/validate_analysis.py
@@ -24,6 +24,22 @@ _REQUIRED_META: Final[tuple[str, ...]] = (
     "data_freshness",
     "scoring_version",
     "config",
+    "coverage",
+)
+_REQUIRED_CONFIG: Final[tuple[str, ...]] = (
+    "interval",
+    "stale_days",
+    "max_gap_days",
+    "min_history",
+    "coverage_policy",
+)
+_REQUIRED_COVERAGE: Final[tuple[str, ...]] = (
+    "attempted_count",
+    "fetched_count",
+    "missing_symbols",
+    "success_ratio",
+    "passed",
+    "violations",
 )
 _FRESHNESS_SENTINEL: Final[str] = "n/a"
 _DATE_LEN: Final[int] = 10
@@ -76,6 +92,40 @@ def validate_artifact(data: dict[str, Any]) -> list[str]:
                             f"metadata.data_freshness[{sym!r}]: {val!r} is not"
                             f" a YYYY-MM-DD date or {_FRESHNESS_SENTINEL!r}"
                         )
+
+        config = metadata.get("config")
+        if config is not None:
+            if not isinstance(config, dict):
+                errors.append("metadata.config must be a JSON object")
+            else:
+                errors.extend(
+                    f"metadata.config missing required key: {key!r}"
+                    for key in _REQUIRED_CONFIG
+                    if key not in config
+                )
+                coverage_policy = config.get("coverage_policy")
+                if coverage_policy is not None and not isinstance(
+                    coverage_policy, dict
+                ):
+                    errors.append(
+                        "metadata.config.coverage_policy must be a JSON object"
+                    )
+
+        coverage = metadata.get("coverage")
+        if coverage is not None:
+            if not isinstance(coverage, dict):
+                errors.append("metadata.coverage must be a JSON object")
+            else:
+                errors.extend(
+                    f"metadata.coverage missing required key: {key!r}"
+                    for key in _REQUIRED_COVERAGE
+                    if key not in coverage
+                )
+                passed = coverage.get("passed")
+                if passed is not None and not isinstance(passed, bool):
+                    errors.append("metadata.coverage.passed must be a boolean")
+                elif passed is False:
+                    errors.append("metadata.coverage.passed is false")
 
     instruments = data["instruments"]
     if not isinstance(instruments, list):

--- a/.github/workflows/daily-market-analysis.yml
+++ b/.github/workflows/daily-market-analysis.yml
@@ -24,6 +24,16 @@ on:
         required: false
         default: "false"
         type: boolean
+      min_success_ratio:
+        description: "Minimum symbol fetch success ratio (default 0.8)"
+        required: false
+        default: "0.8"
+        type: string
+      max_missing_symbols:
+        description: "Maximum allowed missing symbols (default 1)"
+        required: false
+        default: "1"
+        type: string
 permissions:
   contents: read
 jobs:
@@ -36,6 +46,8 @@ jobs:
       ANALYSIS_DATE: ${{ inputs.analysis_date || '' }}
       INTERVAL: ${{ inputs.interval || 'd' }}
       DRY_RUN: ${{ inputs.dry_run || 'false' }}
+      MIN_SUCCESS_RATIO: ${{ inputs.min_success_ratio || '0.8' }}
+      MAX_MISSING_SYMBOLS: ${{ inputs.max_missing_symbols || '1' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10   # v6.0.3
         with:
@@ -110,6 +122,8 @@ jobs:
             --interval "$INTERVAL" \
             --analysis-date "${DATE}" \
             --fetch-status "data/prices/fetch_status_${INTERVAL}.json" \
+            --min-success-ratio "${MIN_SUCCESS_RATIO}" \
+            --max-missing-symbols "${MAX_MISSING_SYMBOLS}" \
             --output data/analysis/
       - name: Validate artifact
         if: steps.symbols.outputs.symbols != ''

--- a/.github/workflows/daily-market-analysis.yml
+++ b/.github/workflows/daily-market-analysis.yml
@@ -83,11 +83,19 @@ jobs:
           d = datetime.strptime('${DATE}', '%Y-%m-%d')
           print((d - timedelta(days=365)).strftime('%Y-%m-%d'))
           ")
+          FETCH_STATUS="data/prices/fetch_status_${INTERVAL}.json"
+          uv run python .agents/skills/market-analysis/scripts/market_analysis.py \
+            init-fetch-status \
+            --symbols "${SYMBOLS}" \
+            --interval "$INTERVAL" \
+            --analysis-date "${DATE}" \
+            --output "${FETCH_STATUS}"
           IFS=',' read -ra SYMS <<< "${SYMBOLS}"
           for SYM in "${SYMS[@]}"; do
             uv run python .agents/skills/market-analysis/scripts/market_analysis.py \
               fetch --symbol "$SYM" --start "$START" --end "$DATE" \
               --interval "$INTERVAL" \
+              --fetch-status "${FETCH_STATUS}" \
               || echo "WARNING: fetch failed for $SYM; symbol will be marked missing in artifact"
           done
       - name: Generate analysis artifact
@@ -101,6 +109,7 @@ jobs:
             --symbols "${SYMBOLS}" \
             --interval "$INTERVAL" \
             --analysis-date "${DATE}" \
+            --fetch-status "data/prices/fetch_status_${INTERVAL}.json" \
             --output data/analysis/
       - name: Validate artifact
         if: steps.symbols.outputs.symbols != ''

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -116,11 +116,13 @@ The daily workflow evaluates systemic data-source health before publishing resul
 
 **Isolated missing symbols:** When coverage policy passes, the workflow still generates an artifact and marks affected instruments with the `missing_data` risk gate. One missing symbol out of five configured symbols (80% success ratio) is within policy.
 
-**Systemic data-source failure:** When coverage policy fails (too many missing symbols, success ratio below threshold, empty symbol universe, or all symbols failed), the `generate` step exits with a non-zero status. The workflow stops before artifact validation, Hugo report generation, pull-request creation, and Slack success notification. The failure Slack notification still links to the GitHub Actions run.
+**Systemic data-source failure:** When coverage policy fails (too many missing symbols, success ratio below threshold, empty symbol universe, or all symbols failed), the `generate` step may write a diagnostic JSON artifact with `metadata.coverage.passed: false`, then exits with a non-zero status. The automated workflow stops before artifact validation, Hugo report generation, pull-request creation, and Slack success notification. Diagnostic artifacts are for local inspection only — do not validate or publish them manually. The failure Slack notification still links to the GitHub Actions run.
 
-Override coverage gates locally or in manual workflow runs via `market_analysis.py generate --min-success-ratio` and `--max-missing-symbols`.
+**Artifact validation contract:** `validate_analysis.py` accepts `metadata.coverage.passed: false` as structurally valid JSON. Publication safety comes from the workflow gate: `generate` must exit `0` before validation, report generation, or PR creation run. Only artifacts with `coverage.passed: true` reach the public pipeline.
 
-**Current-run fetch status:** The daily workflow initializes `data/prices/fetch_status_<interval>.json` before fetching, records per-symbol success or failure during each `fetch` call, and passes that file to `generate --fetch-status`. Coverage gates use this fetch-status file as the source of truth, not merely the presence of pre-existing local price CSVs. A stale on-disk price file cannot mask a failed fetch in the current run.
+Override coverage gates locally or in manual workflow runs via `market_analysis.py generate --min-success-ratio` and `--max-missing-symbols`, or through the `workflow_dispatch` inputs of the same name (defaults: `0.8` and `1`).
+
+**Current-run fetch status:** The daily workflow initializes `data/prices/fetch_status_<interval>.json` before fetching, records per-symbol success or failure during each `fetch` call, and passes that file to `generate --fetch-status`. Coverage gates use this fetch-status file as the source of truth, not merely the presence of pre-existing local price CSVs. A stale on-disk price file cannot mask a failed fetch in the current run. `generate` rejects fetch-status files whose `interval` or `analysis_date` do not match the current run.
 
 ### Market regime
 
@@ -203,13 +205,15 @@ Pipeline order:
 
 ### Manual dispatch
 
-The workflow supports `workflow_dispatch` with three optional inputs:
+The workflow supports `workflow_dispatch` with optional inputs:
 
-| Input           | Default   | Description                                                   |
-| --------------- | --------- | ------------------------------------------------------------- |
-| `analysis_date` | Today UTC | Override the analysis date (YYYY-MM-DD)                       |
-| `interval`      | `d`       | Price bar interval: `d` (daily), `w` (weekly), `m` (monthly)  |
-| `dry_run`       | `false`   | When `true`, skips PR creation and Slack success notification |
+| Input                 | Default   | Description                                                   |
+| --------------------- | --------- | ------------------------------------------------------------- |
+| `analysis_date`       | Today UTC | Override the analysis date (YYYY-MM-DD)                       |
+| `interval`            | `d`       | Price bar interval: `d` (daily), `w` (weekly), `m` (monthly)  |
+| `dry_run`             | `false`   | When `true`, skips PR creation and Slack success notification |
+| `min_success_ratio`   | `0.8`     | Minimum symbol fetch success ratio for coverage gate          |
+| `max_missing_symbols` | `1`       | Maximum allowed missing symbols for coverage gate             |
 
 ### Deployment gate
 

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -120,6 +120,8 @@ The daily workflow evaluates systemic data-source health before publishing resul
 
 Override coverage gates locally or in manual workflow runs via `market_analysis.py generate --min-success-ratio` and `--max-missing-symbols`.
 
+**Current-run fetch status:** The daily workflow initializes `data/prices/fetch_status_<interval>.json` before fetching, records per-symbol success or failure during each `fetch` call, and passes that file to `generate --fetch-status`. Coverage gates use this fetch-status file as the source of truth, not merely the presence of pre-existing local price CSVs. A stale on-disk price file cannot mask a failed fetch in the current run.
+
 ### Market regime
 
 The market regime label is derived from the median composite score of reliable instruments:
@@ -191,8 +193,8 @@ Pipeline order:
 1. Validate CFD instrument master
 2. Set analysis date (default: today UTC)
 3. Load symbols from `data/stooq_symbols.txt`
-4. Fetch market data from Stooq (1-year lookback)
-5. Generate JSON analysis artifact (`data/analysis/YYYY-MM-DD.json`); fail if coverage gates are violated
+4. Initialize `data/prices/fetch_status_<interval>.json` and fetch market data from Stooq (1-year lookback), recording per-symbol outcomes in fetch status
+5. Generate JSON analysis artifact (`data/analysis/YYYY-MM-DD.json`) using `--fetch-status`; fail if coverage gates are violated
 6. Validate artifact
 7. Generate Hugo Markdown report (`content/results/YYYY-MM-DD-market-analysis.md`)
 8. Build Hugo site (validation only — catches template or content errors before commit)

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -90,11 +90,35 @@ Instruments that fail quality checks are included in output but marked `is_relia
 
 | Gate                   | Trigger                                                       |
 | ---------------------- | ------------------------------------------------------------- |
-| `stale_data`           | Latest bar older than `stale_days` calendar days (default: 5) |
+| `stale_data`           | Latest bar older than interval-specific `stale_days`          |
 | `insufficient_history` | Fewer than `min_history` bars (default: 60)                   |
-| `missing_bars`         | Gap > 7 calendar days between consecutive bars                |
+| `missing_bars`         | Gap greater than interval-specific `max_gap_days`             |
 | `malformed_input`      | Non-positive prices, high < low, or price outside [low, high] |
 | `high_volatility`      | 20-day annualised volatility > 100%                           |
+| `missing_data`         | No price history returned for the symbol                      |
+
+Interval-specific freshness and missing-bar thresholds are defined in `data_quality_policy.py` and recorded in each artifact under `metadata.config`:
+
+| Interval | `stale_days` | `max_gap_days` | `min_history` |
+| -------- | ------------ | -------------- | ------------- |
+| `d`      | 5            | 7              | 60            |
+| `w`      | 21           | 21             | 60            |
+| `m`      | 62           | 62             | 60            |
+
+### Data coverage gates
+
+The daily workflow evaluates systemic data-source health before publishing results. Coverage statistics are stored in `metadata.coverage`; policy defaults live in `metadata.config.coverage_policy`.
+
+| Policy                | Default | Description                                              |
+| --------------------- | ------- | -------------------------------------------------------- |
+| `min_success_ratio`   | `0.8`   | Minimum fraction of configured symbols with fetched data |
+| `max_missing_symbols` | `1`     | Maximum allowed count of symbols with no fetched data    |
+
+**Isolated missing symbols:** When coverage policy passes, the workflow still generates an artifact and marks affected instruments with the `missing_data` risk gate. One missing symbol out of five configured symbols (80% success ratio) is within policy.
+
+**Systemic data-source failure:** When coverage policy fails (too many missing symbols, success ratio below threshold, empty symbol universe, or all symbols failed), the `generate` step exits with a non-zero status. The workflow stops before artifact validation, Hugo report generation, pull-request creation, and Slack success notification. The failure Slack notification still links to the GitHub Actions run.
+
+Override coverage gates locally or in manual workflow runs via `market_analysis.py generate --min-success-ratio` and `--max-missing-symbols`.
 
 ### Market regime
 
@@ -168,7 +192,7 @@ Pipeline order:
 2. Set analysis date (default: today UTC)
 3. Load symbols from `data/stooq_symbols.txt`
 4. Fetch market data from Stooq (1-year lookback)
-5. Generate JSON analysis artifact (`data/analysis/YYYY-MM-DD.json`)
+5. Generate JSON analysis artifact (`data/analysis/YYYY-MM-DD.json`); fail if coverage gates are violated
 6. Validate artifact
 7. Generate Hugo Markdown report (`content/results/YYYY-MM-DD-market-analysis.md`)
 8. Build Hugo site (validation only — catches template or content errors before commit)
@@ -230,9 +254,9 @@ The `ci.yml` workflow adds:
 ERROR: fetch failed for ^SPX
 ```
 
-Stooq may be temporarily unavailable or the symbol may be invalid. Per-symbol fetch failures are non-fatal — a `WARNING` is logged and the fetch loop continues. The symbol is passed to the `generate` step which marks it as `missing_data` in the artifact and report. The workflow only fails if no symbols at all can be fetched and the artifact cannot be generated.
+Stooq may be temporarily unavailable or the symbol may be invalid. Per-symbol fetch failures are non-fatal — a `WARNING` is logged and the fetch loop continues. The symbol is passed to the `generate` step which marks it as `missing_data` in the artifact and report when coverage policy still passes. The workflow fails before publishing when coverage gates detect a systemic data-source failure (too many missing symbols or success ratio below threshold). It also fails when no symbols at all can be fetched.
 
-**Fix:** Check `data/stooq_symbols.txt` for typos. Verify the symbol at https://stooq.com. Remove permanently unavailable symbols to keep the analysis clean.
+**Fix:** Check `data/stooq_symbols.txt` for typos. Verify the symbol at https://stooq.com. Remove permanently unavailable symbols to keep the analysis clean. Re-run the workflow after the data source recovers.
 
 ### Artifact validation failure
 
@@ -268,7 +292,14 @@ All new Python scripts in `.agents/skills/market-analysis/scripts/` are included
 
 ### Re-run the daily workflow
 
-Trigger it from **Actions → Daily market analysis → Run workflow** with the desired `analysis_date`.
+Trigger it from **Actions → Daily market analysis → Run workflow** with the desired `analysis_date`. Use `dry_run = true` to test fetch, scoring, and artifact generation without opening a pull request or sending a success Slack notification.
+
+### Recover from a coverage gate failure
+
+1. Inspect the failed GitHub Actions run log for `ERROR: coverage gate failed` messages and the saved artifact (if generated locally).
+2. Verify Stooq availability and symbol validity in `data/stooq_symbols.txt`.
+3. Re-run the workflow manually once the data source has recovered.
+4. For temporary outages affecting multiple symbols, wait for recovery rather than lowering coverage thresholds in automation.
 
 ### Re-fetch data for a symbol
 

--- a/data/schema/analysis.schema.json
+++ b/data/schema/analysis.schema.json
@@ -10,7 +10,23 @@
     "data_source",
     "data_freshness",
     "scoring_version",
-    "config"
+    "config",
+    "coverage"
+  ],
+  "required_config_keys": [
+    "interval",
+    "stale_days",
+    "max_gap_days",
+    "min_history",
+    "coverage_policy"
+  ],
+  "required_coverage_keys": [
+    "attempted_count",
+    "fetched_count",
+    "missing_symbols",
+    "success_ratio",
+    "passed",
+    "violations"
   ],
   "notes": {
     "data_source": "Sorted comma-separated provider names, e.g. 'stooq' or 'csv,stooq'.",

--- a/tests/fixtures/analysis_2024-01-01.json
+++ b/tests/fixtures/analysis_2024-01-01.json
@@ -7,7 +7,7 @@
     "data_freshness": {
       "^SPX": "2024-01-01",
       "^DJI": "2023-12-29",
-      "^NDX": "n/a"
+      "^NDX": "2023-12-28"
     },
     "scoring_version": "1.0.0",
     "config": {
@@ -22,13 +22,11 @@
     },
     "coverage": {
       "attempted_count": 3,
-      "fetched_count": 2,
-      "missing_symbols": ["^NDX"],
-      "success_ratio": 0.6667,
-      "passed": false,
-      "violations": [
-        "success ratio (66.67% < 80%)"
-      ]
+      "fetched_count": 3,
+      "missing_symbols": [],
+      "success_ratio": 1.0,
+      "passed": true,
+      "violations": []
     }
   },
   "instruments": [

--- a/tests/fixtures/analysis_2024-01-01.json
+++ b/tests/fixtures/analysis_2024-01-01.json
@@ -12,8 +12,23 @@
     "scoring_version": "1.0.0",
     "config": {
       "stale_days": 5,
+      "max_gap_days": 7,
       "min_history": 60,
-      "interval": "d"
+      "interval": "d",
+      "coverage_policy": {
+        "min_success_ratio": 0.8,
+        "max_missing_symbols": 1
+      }
+    },
+    "coverage": {
+      "attempted_count": 3,
+      "fetched_count": 2,
+      "missing_symbols": ["^NDX"],
+      "success_ratio": 0.6667,
+      "passed": false,
+      "violations": [
+        "success ratio (66.67% < 80%)"
+      ]
     }
   },
   "instruments": [

--- a/tests/golden/2024-01-01-market-analysis.md
+++ b/tests/golden/2024-01-01-market-analysis.md
@@ -45,10 +45,8 @@ Data source: **stooq**
 | Symbol | Latest Bar |
 | ------ | ---------- |
 | ^DJI   | 2023-12-29 |
-| ^NDX   | n/a        |
+| ^NDX   | 2023-12-28 |
 | ^SPX   | 2024-01-01 |
-
-> **Warning:** 1 instrument(s) have no data: ^NDX.
 
 ## Methodology
 

--- a/tests/test_data_quality_policy.py
+++ b/tests/test_data_quality_policy.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / ".agents"
+    / "skills"
+    / "market-analysis"
+    / "scripts"
+    / "data_quality_policy.py"
+)
+
+
+@pytest.fixture(scope="module")
+def policy() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("data_quality_policy", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        pytest.fail("Failed to load data_quality_policy.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_daily_thresholds(policy: ModuleType) -> None:
+    thresholds = policy.get_interval_thresholds("d")
+    assert thresholds.stale_days == 5
+    assert thresholds.max_gap_days == 7
+    assert thresholds.min_history == 60
+
+
+def test_weekly_thresholds(policy: ModuleType) -> None:
+    thresholds = policy.get_interval_thresholds("w")
+    assert thresholds.stale_days == 21
+    assert thresholds.max_gap_days == 21
+
+
+def test_monthly_thresholds(policy: ModuleType) -> None:
+    thresholds = policy.get_interval_thresholds("m")
+    assert thresholds.stale_days == 62
+    assert thresholds.max_gap_days == 62
+
+
+def test_unsupported_interval(policy: ModuleType) -> None:
+    with pytest.raises(ValueError, match="unsupported interval"):
+        policy.get_interval_thresholds("h")
+
+
+def test_build_config_dict(policy: ModuleType) -> None:
+    quality_policy = policy.get_data_quality_policy("d")
+    config = policy.build_config_dict(quality_policy)
+    assert config["interval"] == "d"
+    assert config["stale_days"] == 5
+    assert config["max_gap_days"] == 7
+    assert config["coverage_policy"]["min_success_ratio"] == 0.8
+
+
+def test_evaluate_coverage_all_available(policy: ModuleType) -> None:
+    result = policy.evaluate_coverage(
+        ["A", "B", "C", "D", "E"],
+        ["A", "B", "C", "D", "E"],
+        [],
+        policy.DEFAULT_COVERAGE_POLICY,
+    )
+    assert result.passed is True
+    assert result.success_ratio == 1.0
+
+
+def test_evaluate_coverage_one_missing_within_policy(policy: ModuleType) -> None:
+    result = policy.evaluate_coverage(
+        ["A", "B", "C", "D", "E"],
+        ["A", "B", "C", "D"],
+        ["E"],
+        policy.DEFAULT_COVERAGE_POLICY,
+    )
+    assert result.passed is True
+    assert result.success_ratio == 0.8
+
+
+def test_evaluate_coverage_too_many_missing(policy: ModuleType) -> None:
+    result = policy.evaluate_coverage(
+        ["A", "B", "C", "D", "E"],
+        ["A", "B", "C"],
+        ["D", "E"],
+        policy.DEFAULT_COVERAGE_POLICY,
+    )
+    assert result.passed is False
+    assert any("missing symbols" in v for v in result.violations)
+
+
+def test_evaluate_coverage_success_ratio_below_threshold(policy: ModuleType) -> None:
+    result = policy.evaluate_coverage(
+        ["A", "B", "C"],
+        ["A"],
+        ["B", "C"],
+        policy.DEFAULT_COVERAGE_POLICY,
+    )
+    assert result.passed is False
+    assert any("success ratio" in v for v in result.violations)
+
+
+def test_evaluate_coverage_empty_universe(policy: ModuleType) -> None:
+    result = policy.evaluate_coverage([], [], [], policy.DEFAULT_COVERAGE_POLICY)
+    assert result.passed is False
+    assert result.violations == ("empty symbol universe",)
+
+
+def test_evaluate_coverage_all_failed(policy: ModuleType) -> None:
+    result = policy.evaluate_coverage(
+        ["A", "B"],
+        [],
+        ["A", "B"],
+        policy.DEFAULT_COVERAGE_POLICY,
+    )
+    assert result.passed is False
+    assert any("all symbols failed" in v for v in result.violations)
+
+
+def test_build_coverage_metadata(policy: ModuleType) -> None:
+    result = policy.evaluate_coverage(
+        ["A", "B", "C", "D", "E"],
+        ["A", "B", "C", "D"],
+        ["E"],
+        policy.DEFAULT_COVERAGE_POLICY,
+    )
+    metadata = policy.build_coverage_metadata(result)
+    assert metadata["attempted_count"] == 5
+    assert metadata["fetched_count"] == 4
+    assert metadata["missing_symbols"] == ["E"]
+    assert metadata["passed"] is True

--- a/tests/test_market_analysis.py
+++ b/tests/test_market_analysis.py
@@ -1566,5 +1566,247 @@ def test_cmd_generate_all_symbols_failed(ma: ModuleType, tmp_path: Path) -> None
         analysis_date = None
         min_success_ratio = 0.8
         max_missing_symbols = 1
+        fetch_status = None
 
     assert ma._cmd_generate(Args()) == 1
+
+
+# ── Fetch status coverage ─────────────────────────────────────────────────────
+
+
+def test_fetch_status_masks_stale_price_file(
+    ma: ModuleType, mocker: MockerFixture, tmp_path: Path
+) -> None:
+    """A pre-existing price file must not count as fetched when status says failed."""
+    mocker.patch.object(ma, "_get_git_commit", return_value="abc")
+    symbols = ["G1", "G2", "G3", "G4", "STALE"]
+    for sym in symbols:
+        bars = _make_bars(ma, sym, [float(100 + i) for i in range(70)])
+        ma.save_ohlcv(bars, tmp_path)
+    status_path = tmp_path / "fetch_status.json"
+    ma.init_fetch_status(status_path, symbols, interval="d")
+    for sym in ("G1", "G2", "G3", "G4"):
+        ma.record_fetch_status(status_path, sym, success=True)
+    ma.record_fetch_status(status_path, "STALE", success=False, error="fetch failed")
+
+    class Args:
+        symbols = "G1,G2,G3,G4,STALE"
+        interval = "d"
+        data_dir = str(tmp_path)
+        output = str(tmp_path / "analysis")
+        analysis_date = "2024-07-01"
+        min_success_ratio = 0.8
+        max_missing_symbols = 1
+        fetch_status = str(status_path)
+
+    assert ma._cmd_generate(Args()) == 0
+    artifact = json.loads((tmp_path / "analysis" / "2024-07-01.json").read_text())
+    assert artifact["metadata"]["coverage"]["missing_symbols"] == ["STALE"]
+    stale_inst = next(i for i in artifact["instruments"] if i["symbol"] == "STALE")
+    assert ma.RISK_GATE_MISSING_DATA in stale_inst["risk_gates"]
+
+
+def test_fetch_status_success_counts_fetched_symbol(
+    ma: ModuleType, mocker: MockerFixture, tmp_path: Path
+) -> None:
+    mocker.patch.object(ma, "_get_git_commit", return_value="abc")
+    bars = _make_bars(ma, "GOOD", [float(100 + i) for i in range(70)])
+    ma.save_ohlcv(bars, tmp_path)
+    status_path = tmp_path / "fetch_status.json"
+    ma.init_fetch_status(status_path, ["GOOD"], interval="d")
+    ma.record_fetch_status(status_path, "GOOD", success=True)
+
+    class Args:
+        symbols = "GOOD"
+        interval = "d"
+        data_dir = str(tmp_path)
+        output = str(tmp_path / "analysis")
+        analysis_date = "2024-07-02"
+        min_success_ratio = 0.8
+        max_missing_symbols = 0
+        fetch_status = str(status_path)
+
+    assert ma._cmd_generate(Args()) == 0
+    artifact = json.loads((tmp_path / "analysis" / "2024-07-02.json").read_text())
+    assert artifact["metadata"]["coverage"]["passed"] is True
+
+
+def test_cmd_init_fetch_status(ma: ModuleType, tmp_path: Path) -> None:
+    class Args:
+        symbols = "A,B"
+        interval = "d"
+        output = str(tmp_path / "fetch_status.json")
+        analysis_date = "2024-07-03"
+
+    assert ma._cmd_init_fetch_status(Args()) == 0
+    status = ma.load_fetch_status(tmp_path / "fetch_status.json")
+    assert status["symbols"]["A"]["status"] == ma._FETCH_STATUS_PENDING
+
+
+def test_cmd_fetch_records_failed_status(
+    ma: ModuleType, mocker: MockerFixture, tmp_path: Path
+) -> None:
+    mocker.patch("market_analysis.urlopen", side_effect=URLError("network error"))
+    status_path = tmp_path / "fetch_status.json"
+    ma.init_fetch_status(status_path, ["FAIL"], interval="d")
+
+    class Args:
+        symbol = "FAIL"
+        start = "2024-01-01"
+        end = "2024-01-31"
+        interval = "d"
+        output = str(tmp_path)
+        no_validate = True
+        fetch_status = str(status_path)
+
+    assert ma._cmd_fetch(Args()) == 1
+    status = ma.load_fetch_status(status_path)
+    assert status["symbols"]["FAIL"]["status"] == ma._FETCH_STATUS_FAILED
+
+
+def test_cmd_fetch_records_success_status(
+    ma: ModuleType, mocker: MockerFixture, tmp_path: Path
+) -> None:
+    csv_content = "Date,Open,High,Low,Close,Volume\n2024-01-02,100,110,90,105,1000\n"
+    mock_resp = mocker.MagicMock()
+    mock_resp.read.return_value = csv_content.encode()
+    mock_resp.__enter__ = mocker.MagicMock(return_value=mock_resp)
+    mock_resp.__exit__ = mocker.MagicMock(return_value=False)
+    mocker.patch("market_analysis.urlopen", return_value=mock_resp)
+    status_path = tmp_path / "fetch_status.json"
+    ma.init_fetch_status(status_path, ["AAPL.US"], interval="d")
+
+    class Args:
+        symbol = "AAPL.US"
+        start = "2024-01-01"
+        end = "2024-01-31"
+        interval = "d"
+        output = str(tmp_path)
+        no_validate = True
+        fetch_status = str(status_path)
+
+    assert ma._cmd_fetch(Args()) == 0
+    status = ma.load_fetch_status(status_path)
+    assert status["symbols"]["AAPL.US"]["status"] == ma._FETCH_STATUS_SUCCESS
+
+
+def test_cmd_fetch_records_empty_result_status(
+    ma: ModuleType, mocker: MockerFixture, tmp_path: Path
+) -> None:
+    csv_content = "Date,Open,High,Low,Close,Volume\n"
+    mock_resp = mocker.MagicMock()
+    mock_resp.read.return_value = csv_content.encode()
+    mock_resp.__enter__ = mocker.MagicMock(return_value=mock_resp)
+    mock_resp.__exit__ = mocker.MagicMock(return_value=False)
+    mocker.patch("market_analysis.urlopen", return_value=mock_resp)
+    status_path = tmp_path / "fetch_status.json"
+    ma.init_fetch_status(status_path, ["EMPTY"], interval="d")
+
+    class Args:
+        symbol = "EMPTY"
+        start = "2024-01-01"
+        end = "2024-01-31"
+        interval = "d"
+        output = str(tmp_path)
+        no_validate = True
+        fetch_status = str(status_path)
+
+    assert ma._cmd_fetch(Args()) == 1
+    status = ma.load_fetch_status(status_path)
+    assert status["symbols"]["EMPTY"]["status"] == ma._FETCH_STATUS_FAILED
+
+
+def test_load_fetch_status_rejects_non_object(ma: ModuleType, tmp_path: Path) -> None:
+    path = tmp_path / "bad.json"
+    path.write_text("[1, 2, 3]")
+    with pytest.raises(TypeError):
+        ma.load_fetch_status(path)
+
+
+def test_record_fetch_status_rejects_invalid_symbols(
+    ma: ModuleType, tmp_path: Path
+) -> None:
+    path = tmp_path / "bad.json"
+    path.write_text('{"symbols": "bad"}')
+    with pytest.raises(TypeError):
+        ma.record_fetch_status(path, "X", success=True)
+
+
+def test_resolve_symbols_from_fetch_status_rejects_invalid(
+    ma: ModuleType,
+) -> None:
+    with pytest.raises(TypeError):
+        ma.resolve_symbols_from_fetch_status(["A"], {"symbols": "bad"})
+
+
+def test_cmd_generate_invalid_fetch_status_file(
+    ma: ModuleType, tmp_path: Path
+) -> None:
+    bad_status = tmp_path / "bad.json"
+    bad_status.write_text("not json")
+
+    class Args:
+        symbols = "A"
+        interval = "d"
+        data_dir = str(tmp_path)
+        output = str(tmp_path / "analysis")
+        analysis_date = None
+        min_success_ratio = 0.8
+        max_missing_symbols = 1
+        fetch_status = str(bad_status)
+
+    assert ma._cmd_generate(Args()) == 1
+
+
+def test_cmd_generate_fetch_status_success_without_price_file(
+    ma: ModuleType, mocker: MockerFixture, tmp_path: Path
+) -> None:
+    mocker.patch.object(ma, "_get_git_commit", return_value="abc")
+    status_path = tmp_path / "fetch_status.json"
+    ma.init_fetch_status(status_path, ["GHOST"], interval="d")
+    ma.record_fetch_status(status_path, "GHOST", success=True)
+
+    class Args:
+        symbols = "GHOST"
+        interval = "d"
+        data_dir = str(tmp_path)
+        output = str(tmp_path / "analysis")
+        analysis_date = "2024-07-04"
+        min_success_ratio = 0.8
+        max_missing_symbols = 0
+        fetch_status = str(status_path)
+
+    assert ma._cmd_generate(Args()) == 1
+
+
+def test_cmd_init_fetch_status_empty_symbols(ma: ModuleType, tmp_path: Path) -> None:
+    class Args:
+        symbols = ""
+        interval = "d"
+        output = str(tmp_path / "fetch_status.json")
+        analysis_date = None
+
+    assert ma._cmd_init_fetch_status(Args()) == 1
+
+
+def test_main_routes_init_fetch_status(ma: ModuleType, mocker: MockerFixture) -> None:
+    called = []
+    mocker.patch.object(
+        ma,
+        "_cmd_init_fetch_status",
+        side_effect=lambda _a: called.append("init-fetch-status") or 0,
+    )
+    mocker.patch.object(
+        sys,
+        "argv",
+        [
+            "market_analysis.py",
+            "init-fetch-status",
+            "--symbols",
+            "X",
+            "--output",
+            "status.json",
+        ],
+    )
+    ma.main()
+    assert called == ["init-fetch-status"]

--- a/tests/test_market_analysis.py
+++ b/tests/test_market_analysis.py
@@ -308,8 +308,66 @@ def test_quality_large_gap_detected(ma: ModuleType) -> None:
     bar1 = ma.OhlcvBar("X", ts1, 100.0, 100.0, 100.0, 100.0, 0.0, "test", "d")
     bar2 = ma.OhlcvBar("X", ts2, 100.0, 100.0, 100.0, 100.0, 0.0, "test", "d")
     ref = ts2 + timedelta(days=1)
-    report = ma.check_data_quality([bar1, bar2], min_history=1, reference_time=ref)
+    report = ma.check_data_quality(
+        [bar1, bar2], min_history=1, max_gap_days=7, reference_time=ref
+    )
     assert any("gap" in i or "missing" in i for i in report.issues)
+
+
+def test_quality_weekly_gap_within_threshold(ma: ModuleType) -> None:
+    ts1 = datetime(2024, 1, 2, tzinfo=UTC)
+    ts2 = datetime(2024, 1, 16, tzinfo=UTC)
+    bars = [
+        ma.OhlcvBar("X", ts1, 100.0, 100.0, 100.0, 100.0, 0.0, "test", "w"),
+        ma.OhlcvBar("X", ts2, 100.0, 100.0, 100.0, 100.0, 0.0, "test", "w"),
+    ]
+    report = ma.check_data_quality(
+        bars, min_history=1, max_gap_days=21, reference_time=ts2
+    )
+    assert not any("gap" in i or "missing" in i for i in report.issues)
+
+
+def test_quality_weekly_gap_exceeds_threshold(ma: ModuleType) -> None:
+    ts1 = datetime(2024, 1, 2, tzinfo=UTC)
+    ts2 = datetime(2024, 3, 1, tzinfo=UTC)
+    bars = [
+        ma.OhlcvBar("X", ts1, 100.0, 100.0, 100.0, 100.0, 0.0, "test", "w"),
+        ma.OhlcvBar("X", ts2, 100.0, 100.0, 100.0, 100.0, 0.0, "test", "w"),
+    ]
+    report = ma.check_data_quality(
+        bars, min_history=1, max_gap_days=21, reference_time=ts2
+    )
+    assert any("gap" in i or "missing" in i for i in report.issues)
+
+
+def test_quality_weekly_stale_threshold(ma: ModuleType) -> None:
+    ts = datetime(2024, 1, 1, tzinfo=UTC)
+    bar = ma.OhlcvBar("X", ts, 100.0, 100.0, 100.0, 100.0, 0.0, "test", "w")
+    fresh_ref = ts + timedelta(days=20)
+    stale_ref = ts + timedelta(days=22)
+    fresh = ma.check_data_quality(
+        [bar], min_history=1, stale_days=21, reference_time=fresh_ref
+    )
+    stale = ma.check_data_quality(
+        [bar], min_history=1, stale_days=21, reference_time=stale_ref
+    )
+    assert not any("stale" in i for i in fresh.issues)
+    assert any("stale" in i for i in stale.issues)
+
+
+def test_quality_monthly_stale_threshold(ma: ModuleType) -> None:
+    ts = datetime(2024, 1, 1, tzinfo=UTC)
+    bar = ma.OhlcvBar("X", ts, 100.0, 100.0, 100.0, 100.0, 0.0, "test", "m")
+    fresh_ref = ts + timedelta(days=61)
+    stale_ref = ts + timedelta(days=63)
+    fresh = ma.check_data_quality(
+        [bar], min_history=1, stale_days=62, reference_time=fresh_ref
+    )
+    stale = ma.check_data_quality(
+        [bar], min_history=1, stale_days=62, reference_time=stale_ref
+    )
+    assert not any("stale" in i for i in fresh.issues)
+    assert any("stale" in i for i in stale.issues)
 
 
 def test_quality_no_gap_with_two_bars(ma: ModuleType) -> None:
@@ -1123,6 +1181,8 @@ def test_cmd_generate_no_data(ma: ModuleType, tmp_path: Path) -> None:
         data_dir = str(tmp_path)
         output = str(tmp_path / "analysis")
         analysis_date = None
+        min_success_ratio = 0.8
+        max_missing_symbols = 1
 
     result = ma._cmd_generate(Args())
     assert result == 1
@@ -1141,6 +1201,8 @@ def test_cmd_generate_success(
         data_dir = str(tmp_path)
         output = str(tmp_path / "analysis")
         analysis_date = None
+        min_success_ratio = 0.8
+        max_missing_symbols = 1
 
     result = ma._cmd_generate(Args())
     assert result == 0
@@ -1162,6 +1224,8 @@ def test_cmd_generate_with_analysis_date(
         data_dir = str(tmp_path)
         output = str(tmp_path / "analysis")
         analysis_date = "2024-03-15"
+        min_success_ratio = 0.8
+        max_missing_symbols = 1
 
     result = ma._cmd_generate(Args())
     assert result == 0
@@ -1176,15 +1240,18 @@ def test_cmd_generate_partial_missing_in_artifact(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     mocker.patch.object(ma, "_get_git_commit", return_value="abc")
-    bars = _make_bars(ma, "G", [float(100 + i) for i in range(70)])
-    ma.save_ohlcv(bars, tmp_path)
+    for sym in ("G", "H", "I", "J"):
+        bars = _make_bars(ma, sym, [float(100 + i) for i in range(70)])
+        ma.save_ohlcv(bars, tmp_path)
 
     class Args:
-        symbols = "G,MISSING"
+        symbols = "G,H,I,J,MISSING"
         interval = "d"
         data_dir = str(tmp_path)
         output = str(tmp_path / "analysis")
         analysis_date = None
+        min_success_ratio = 0.8
+        max_missing_symbols = 1
 
     result = ma._cmd_generate(Args())
     assert result == 0
@@ -1326,6 +1393,8 @@ def test_cmd_generate_analysis_date_as_reference_time(
         data_dir = str(tmp_path)
         output = str(tmp_path / "analysis")
         analysis_date = "2024-01-05"
+        min_success_ratio = 0.8
+        max_missing_symbols = 1
 
     result = ma._cmd_generate(Args())
     assert result == 0
@@ -1352,6 +1421,8 @@ def test_cmd_generate_no_analysis_date_may_mark_stale(
         data_dir = str(tmp_path)
         output = str(tmp_path / "analysis")
         analysis_date = None
+        min_success_ratio = 0.8
+        max_missing_symbols = 1
 
     result = ma._cmd_generate(Args())
     assert result == 0
@@ -1360,3 +1431,140 @@ def test_cmd_generate_no_analysis_date_may_mark_stale(
     inst = next(i for i in artifact["instruments"] if i["symbol"] == "STALE")
     # Without reference_time fix, old bars stale relative to today
     assert ma.RISK_GATE_STALE in inst["risk_gates"]
+
+
+# ── Coverage gates and artifact metadata ───────────────────────────────────────
+
+
+def test_generate_artifact_includes_policy_and_coverage(
+    ma: ModuleType, mocker: MockerFixture
+) -> None:
+    mocker.patch.object(ma, "_get_git_commit", return_value="abc")
+    bars = _make_bars(ma, "A", [float(100 + i) for i in range(80)])
+    ref = bars[-1].timestamp + timedelta(days=1)
+    policy = ma.get_data_quality_policy("d")
+    scores = ma.score_instruments({"A": bars}, reference_time=ref)
+    coverage = ma.build_coverage_metadata(
+        ma.evaluate_coverage(["A"], ["A"], [], policy.coverage)
+    )
+    artifact = ma.generate_artifact(
+        scores,
+        {"A": bars},
+        ma.build_config_dict(policy),
+        coverage=coverage,
+    )
+    assert artifact["metadata"]["config"]["max_gap_days"] == 7
+    assert artifact["metadata"]["coverage"]["passed"] is True
+
+
+def test_cmd_generate_coverage_all_symbols(
+    ma: ModuleType, mocker: MockerFixture, tmp_path: Path
+) -> None:
+    mocker.patch.object(ma, "_get_git_commit", return_value="abc")
+    for sym in ("A", "B", "C", "D", "E"):
+        bars = _make_bars(ma, sym, [float(100 + i) for i in range(70)])
+        ma.save_ohlcv(bars, tmp_path)
+
+    class Args:
+        symbols = "A,B,C,D,E"
+        interval = "d"
+        data_dir = str(tmp_path)
+        output = str(tmp_path / "analysis")
+        analysis_date = "2024-06-01"
+        min_success_ratio = 0.8
+        max_missing_symbols = 1
+
+    assert ma._cmd_generate(Args()) == 0
+    artifact = json.loads((tmp_path / "analysis" / "2024-06-01.json").read_text())
+    assert artifact["metadata"]["coverage"]["passed"] is True
+
+
+def test_cmd_generate_one_missing_within_policy(
+    ma: ModuleType, mocker: MockerFixture, tmp_path: Path
+) -> None:
+    mocker.patch.object(ma, "_get_git_commit", return_value="abc")
+    for sym in ("A", "B", "C", "D"):
+        bars = _make_bars(ma, sym, [float(100 + i) for i in range(70)])
+        ma.save_ohlcv(bars, tmp_path)
+
+    class Args:
+        symbols = "A,B,C,D,MISSING"
+        interval = "d"
+        data_dir = str(tmp_path)
+        output = str(tmp_path / "analysis")
+        analysis_date = "2024-06-02"
+        min_success_ratio = 0.8
+        max_missing_symbols = 1
+
+    assert ma._cmd_generate(Args()) == 0
+    artifact = json.loads((tmp_path / "analysis" / "2024-06-02.json").read_text())
+    assert artifact["metadata"]["coverage"]["passed"] is True
+    missing_inst = next(i for i in artifact["instruments"] if i["symbol"] == "MISSING")
+    assert ma.RISK_GATE_MISSING_DATA in missing_inst["risk_gates"]
+
+
+def test_cmd_generate_too_many_missing_symbols(
+    ma: ModuleType, mocker: MockerFixture, tmp_path: Path
+) -> None:
+    mocker.patch.object(ma, "_get_git_commit", return_value="abc")
+    bars = _make_bars(ma, "A", [float(100 + i) for i in range(70)])
+    ma.save_ohlcv(bars, tmp_path)
+
+    class Args:
+        symbols = "A,MISS1,MISS2"
+        interval = "d"
+        data_dir = str(tmp_path)
+        output = str(tmp_path / "analysis")
+        analysis_date = "2024-06-03"
+        min_success_ratio = 0.8
+        max_missing_symbols = 1
+
+    assert ma._cmd_generate(Args()) == 1
+    artifact = json.loads((tmp_path / "analysis" / "2024-06-03.json").read_text())
+    assert artifact["metadata"]["coverage"]["passed"] is False
+
+
+def test_cmd_generate_success_ratio_below_threshold(
+    ma: ModuleType, mocker: MockerFixture, tmp_path: Path
+) -> None:
+    mocker.patch.object(ma, "_get_git_commit", return_value="abc")
+    for sym in ("A", "B"):
+        bars = _make_bars(ma, sym, [float(100 + i) for i in range(70)])
+        ma.save_ohlcv(bars, tmp_path)
+
+    class Args:
+        symbols = "A,B,MISS1,MISS2"
+        interval = "d"
+        data_dir = str(tmp_path)
+        output = str(tmp_path / "analysis")
+        analysis_date = "2024-06-04"
+        min_success_ratio = 0.8
+        max_missing_symbols = 2
+
+    assert ma._cmd_generate(Args()) == 1
+
+
+def test_cmd_generate_empty_symbol_universe(ma: ModuleType, tmp_path: Path) -> None:
+    class Args:
+        symbols = ""
+        interval = "d"
+        data_dir = str(tmp_path)
+        output = str(tmp_path / "analysis")
+        analysis_date = None
+        min_success_ratio = 0.8
+        max_missing_symbols = 1
+
+    assert ma._cmd_generate(Args()) == 1
+
+
+def test_cmd_generate_all_symbols_failed(ma: ModuleType, tmp_path: Path) -> None:
+    class Args:
+        symbols = "MISS1,MISS2"
+        interval = "d"
+        data_dir = str(tmp_path)
+        output = str(tmp_path / "analysis")
+        analysis_date = None
+        min_success_ratio = 0.8
+        max_missing_symbols = 1
+
+    assert ma._cmd_generate(Args()) == 1

--- a/tests/test_market_analysis.py
+++ b/tests/test_market_analysis.py
@@ -1739,9 +1739,75 @@ def test_resolve_symbols_from_fetch_status_rejects_invalid(
         ma.resolve_symbols_from_fetch_status(["A"], {"symbols": "bad"})
 
 
-def test_cmd_generate_invalid_fetch_status_file(
-    ma: ModuleType, tmp_path: Path
+def test_validate_fetch_status_rejects_interval_mismatch(ma: ModuleType) -> None:
+    with pytest.raises(ValueError, match="interval"):
+        ma.validate_fetch_status({"interval": "w"}, interval="d")
+
+
+def test_validate_fetch_status_rejects_analysis_date_mismatch(ma: ModuleType) -> None:
+    with pytest.raises(ValueError, match="analysis_date"):
+        ma.validate_fetch_status(
+            {"interval": "d", "analysis_date": "2024-01-01"},
+            interval="d",
+            analysis_date="2024-01-02",
+        )
+
+
+def test_validate_fetch_status_allows_matching_metadata(ma: ModuleType) -> None:
+    ma.validate_fetch_status(
+        {"interval": "d", "analysis_date": "2024-01-01"},
+        interval="d",
+        analysis_date="2024-01-01",
+    )
+
+
+def test_cmd_generate_rejects_wrong_interval_fetch_status(
+    ma: ModuleType, mocker: MockerFixture, tmp_path: Path
 ) -> None:
+    mocker.patch.object(ma, "_get_git_commit", return_value="abc")
+    bars = _make_bars(ma, "A", [float(100 + i) for i in range(70)])
+    ma.save_ohlcv(bars, tmp_path)
+    status_path = tmp_path / "fetch_status.json"
+    ma.init_fetch_status(status_path, ["A"], interval="w", analysis_date="2024-07-05")
+    ma.record_fetch_status(status_path, "A", success=True)
+
+    class Args:
+        symbols = "A"
+        interval = "d"
+        data_dir = str(tmp_path)
+        output = str(tmp_path / "analysis")
+        analysis_date = "2024-07-05"
+        min_success_ratio = 0.8
+        max_missing_symbols = 1
+        fetch_status = str(status_path)
+
+    assert ma._cmd_generate(Args()) == 1
+
+
+def test_cmd_generate_rejects_wrong_analysis_date_fetch_status(
+    ma: ModuleType, mocker: MockerFixture, tmp_path: Path
+) -> None:
+    mocker.patch.object(ma, "_get_git_commit", return_value="abc")
+    bars = _make_bars(ma, "A", [float(100 + i) for i in range(70)])
+    ma.save_ohlcv(bars, tmp_path)
+    status_path = tmp_path / "fetch_status.json"
+    ma.init_fetch_status(status_path, ["A"], interval="d", analysis_date="2024-07-05")
+    ma.record_fetch_status(status_path, "A", success=True)
+
+    class Args:
+        symbols = "A"
+        interval = "d"
+        data_dir = str(tmp_path)
+        output = str(tmp_path / "analysis")
+        analysis_date = "2024-07-06"
+        min_success_ratio = 0.8
+        max_missing_symbols = 1
+        fetch_status = str(status_path)
+
+    assert ma._cmd_generate(Args()) == 1
+
+
+def test_cmd_generate_invalid_fetch_status_file(ma: ModuleType, tmp_path: Path) -> None:
     bad_status = tmp_path / "bad.json"
     bad_status.write_text("not json")
 

--- a/tests/test_notify_slack.py
+++ b/tests/test_notify_slack.py
@@ -92,10 +92,30 @@ def test_build_success_payload_regime_in_blocks(
     assert "^SPX" in fields_text
 
 
-def test_build_success_payload_stale_warning(
-    ns: ModuleType, fixture_artifact: dict[str, Any]
-) -> None:
-    payload = ns.build_success_payload(fixture_artifact, "https://example.com/")
+def test_build_success_payload_stale_warning(ns: ModuleType) -> None:
+    artifact: dict[str, Any] = {
+        "version": "1.0.0",
+        "metadata": {
+            "generated_at": "2024-01-01T00:00:00+00:00",
+            "git_commit": "abc",
+            "data_source": "stooq",
+            "data_freshness": {"^SPX": "2024-01-01", "^NDX": "n/a"},
+            "scoring_version": "1.0.0",
+            "config": {},
+        },
+        "instruments": [
+            {
+                "symbol": "^SPX",
+                "rank": 1,
+                "score": 70.0,
+                "is_reliable": True,
+                "risk_gates": [],
+                "explanation": "Good",
+                "features": {},
+            }
+        ],
+    }
+    payload = ns.build_success_payload(artifact, "https://example.com/")
     fields_text = json.dumps(payload["blocks"], ensure_ascii=False)
     assert "^NDX" in fields_text
 
@@ -126,7 +146,7 @@ def test_build_success_payload_coverage_summary(
     payload = ns.build_success_payload(fixture_artifact, "https://example.com/")
     fields_text = json.dumps(payload["blocks"], ensure_ascii=False)
     assert "Coverage:" in fields_text
-    assert "2/3" in fields_text
+    assert "3/3" in fields_text
 
 
 def test_build_success_payload_no_reliable(ns: ModuleType) -> None:

--- a/tests/test_notify_slack.py
+++ b/tests/test_notify_slack.py
@@ -100,6 +100,35 @@ def test_build_success_payload_stale_warning(
     assert "^NDX" in fields_text
 
 
+def test_build_success_payload_coverage_invalid_types(ns: ModuleType) -> None:
+    artifact: dict[str, Any] = {
+        "version": "1.0.0",
+        "metadata": {
+            "generated_at": "2024-01-01T00:00:00+00:00",
+            "data_source": "stooq",
+            "data_freshness": {},
+            "coverage": {
+                "attempted_count": "5",
+                "fetched_count": 4,
+                "success_ratio": 0.8,
+            },
+        },
+        "instruments": [],
+    }
+    payload = ns.build_success_payload(artifact, "https://example.com/")
+    fields_text = json.dumps(payload["blocks"], ensure_ascii=False)
+    assert "Coverage:" not in fields_text
+
+
+def test_build_success_payload_coverage_summary(
+    ns: ModuleType, fixture_artifact: dict[str, Any]
+) -> None:
+    payload = ns.build_success_payload(fixture_artifact, "https://example.com/")
+    fields_text = json.dumps(payload["blocks"], ensure_ascii=False)
+    assert "Coverage:" in fields_text
+    assert "2/3" in fields_text
+
+
 def test_build_success_payload_no_reliable(ns: ModuleType) -> None:
     artifact: dict[str, Any] = {
         "version": "1.0.0",

--- a/tests/test_validate_analysis.py
+++ b/tests/test_validate_analysis.py
@@ -52,7 +52,24 @@ VALID_ARTIFACT: dict[str, Any] = {
         "data_source": "stooq",
         "data_freshness": {"AAPL.US": "2024-01-01"},
         "scoring_version": "1.0.0",
-        "config": {"stale_days": 5},
+        "config": {
+            "interval": "d",
+            "stale_days": 5,
+            "max_gap_days": 7,
+            "min_history": 60,
+            "coverage_policy": {
+                "min_success_ratio": 0.8,
+                "max_missing_symbols": 1,
+            },
+        },
+        "coverage": {
+            "attempted_count": 1,
+            "fetched_count": 1,
+            "missing_symbols": [],
+            "success_ratio": 1.0,
+            "passed": True,
+            "violations": [],
+        },
     },
     "instruments": [VALID_INSTRUMENT],
 }
@@ -199,6 +216,114 @@ def test_validate_empty_instruments_list(va: ModuleType) -> None:
 
 
 # ── data_freshness validation ──────────────────────────────────────────────────
+
+
+def test_validate_coverage_failed(va: ModuleType) -> None:
+    data = {
+        **VALID_ARTIFACT,
+        "metadata": {
+            **VALID_ARTIFACT["metadata"],
+            "coverage": {
+                **VALID_ARTIFACT["metadata"]["coverage"],
+                "passed": False,
+                "violations": ["success ratio (50.00% < 80%)"],
+            },
+        },
+    }
+    errors = va.validate_artifact(data)
+    assert any("coverage.passed is false" in e for e in errors)
+
+
+def test_validate_config_missing_key(va: ModuleType) -> None:
+    bad_config = {
+        k: v
+        for k, v in VALID_ARTIFACT["metadata"]["config"].items()
+        if k != "max_gap_days"
+    }
+    data = {
+        **VALID_ARTIFACT,
+        "metadata": {**VALID_ARTIFACT["metadata"], "config": bad_config},
+    }
+    errors = va.validate_artifact(data)
+    assert any("max_gap_days" in e for e in errors)
+
+
+def test_validate_config_not_dict(va: ModuleType) -> None:
+    data = {
+        **VALID_ARTIFACT,
+        "metadata": {**VALID_ARTIFACT["metadata"], "config": "bad"},
+    }
+    errors = va.validate_artifact(data)
+    assert any("metadata.config must be a JSON object" in e for e in errors)
+
+
+def test_validate_coverage_policy_not_dict(va: ModuleType) -> None:
+    bad_config = {
+        **VALID_ARTIFACT["metadata"]["config"],
+        "coverage_policy": "bad",
+    }
+    data = {
+        **VALID_ARTIFACT,
+        "metadata": {**VALID_ARTIFACT["metadata"], "config": bad_config},
+    }
+    errors = va.validate_artifact(data)
+    assert any("coverage_policy must be a JSON object" in e for e in errors)
+
+
+def test_validate_coverage_not_dict(va: ModuleType) -> None:
+    data = {
+        **VALID_ARTIFACT,
+        "metadata": {**VALID_ARTIFACT["metadata"], "coverage": "bad"},
+    }
+    errors = va.validate_artifact(data)
+    assert any("metadata.coverage must be a JSON object" in e for e in errors)
+
+
+def test_validate_coverage_missing_key(va: ModuleType) -> None:
+    bad_coverage = {
+        k: v
+        for k, v in VALID_ARTIFACT["metadata"]["coverage"].items()
+        if k != "violations"
+    }
+    data = {
+        **VALID_ARTIFACT,
+        "metadata": {**VALID_ARTIFACT["metadata"], "coverage": bad_coverage},
+    }
+    errors = va.validate_artifact(data)
+    assert any("violations" in e for e in errors)
+
+
+def test_validate_coverage_passed_not_boolean(va: ModuleType) -> None:
+    data = {
+        **VALID_ARTIFACT,
+        "metadata": {
+            **VALID_ARTIFACT["metadata"],
+            "coverage": {
+                **VALID_ARTIFACT["metadata"]["coverage"],
+                "passed": "yes",
+            },
+        },
+    }
+    errors = va.validate_artifact(data)
+    assert any("coverage.passed must be a boolean" in e for e in errors)
+
+
+def test_validate_config_null_skips_nested_checks(va: ModuleType) -> None:
+    data = {
+        **VALID_ARTIFACT,
+        "metadata": {**VALID_ARTIFACT["metadata"], "config": None},
+    }
+    errors = va.validate_artifact(data)
+    assert not any("metadata.config must be a JSON object" in e for e in errors)
+
+
+def test_validate_coverage_null_skips_nested_checks(va: ModuleType) -> None:
+    data = {
+        **VALID_ARTIFACT,
+        "metadata": {**VALID_ARTIFACT["metadata"], "coverage": None},
+    }
+    errors = va.validate_artifact(data)
+    assert not any("metadata.coverage must be a JSON object" in e for e in errors)
 
 
 def test_validate_data_freshness_valid(va: ModuleType) -> None:

--- a/tests/test_validate_analysis.py
+++ b/tests/test_validate_analysis.py
@@ -308,22 +308,22 @@ def test_validate_coverage_passed_not_boolean(va: ModuleType) -> None:
     assert any("coverage.passed must be a boolean" in e for e in errors)
 
 
-def test_validate_config_null_skips_nested_checks(va: ModuleType) -> None:
+def test_validate_config_null_rejected(va: ModuleType) -> None:
     data = {
         **VALID_ARTIFACT,
         "metadata": {**VALID_ARTIFACT["metadata"], "config": None},
     }
     errors = va.validate_artifact(data)
-    assert not any("metadata.config must be a JSON object" in e for e in errors)
+    assert any("metadata.config must not be null" in e for e in errors)
 
 
-def test_validate_coverage_null_skips_nested_checks(va: ModuleType) -> None:
+def test_validate_coverage_null_rejected(va: ModuleType) -> None:
     data = {
         **VALID_ARTIFACT,
         "metadata": {**VALID_ARTIFACT["metadata"], "coverage": None},
     }
     errors = va.validate_artifact(data)
-    assert not any("metadata.coverage must be a JSON object" in e for e in errors)
+    assert any("metadata.coverage must not be null" in e for e in errors)
 
 
 def test_validate_data_freshness_valid(va: ModuleType) -> None:

--- a/tests/test_validate_analysis.py
+++ b/tests/test_validate_analysis.py
@@ -218,7 +218,7 @@ def test_validate_empty_instruments_list(va: ModuleType) -> None:
 # ── data_freshness validation ──────────────────────────────────────────────────
 
 
-def test_validate_coverage_failed(va: ModuleType) -> None:
+def test_validate_coverage_passed_false_allowed(va: ModuleType) -> None:
     data = {
         **VALID_ARTIFACT,
         "metadata": {
@@ -231,7 +231,7 @@ def test_validate_coverage_failed(va: ModuleType) -> None:
         },
     }
     errors = va.validate_artifact(data)
-    assert any("coverage.passed is false" in e for e in errors)
+    assert not any("coverage.passed is false" in e for e in errors)
 
 
 def test_validate_config_missing_key(va: ModuleType) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #39
Closes #40

## Summary

Adds a centralized market-data quality policy with interval-specific thresholds and workflow coverage fail gates. Daily (`d`) behavior is unchanged; weekly and monthly runs use appropriate freshness and missing-bar limits. Systemic data-source failures stop the pipeline before PR creation and success Slack notifications.

**Coverage source of truth:** The daily workflow initializes `data/prices/fetch_status_<interval>.json`, records per-symbol fetch success/failure during each `fetch --fetch-status` call, and passes that file to `generate --fetch-status`. Coverage gates use current-run fetch status—not pre-existing local price CSVs. `generate` rejects fetch-status files whose `interval` or `analysis_date` conflict with the current run.

## Interval threshold table

| Interval | `stale_days` | `max_gap_days` | `min_history` |
| -------- | ------------ | -------------- | ------------- |
| `d`      | 5            | 7              | 60            |
| `w`      | 21           | 21             | 60            |
| `m`      | 62           | 62             | 60            |

## Coverage policy defaults and configuration

| Setting | Default | Configuration |
| ------- | ------- | ------------- |
| `min_success_ratio` | `0.8` | `workflow_dispatch` input, or `generate --min-success-ratio` |
| `max_missing_symbols` | `1` | `workflow_dispatch` input, or `generate --max-missing-symbols` |

Fetch status path: `data/prices/fetch_status_<interval>.json` (workflow-managed). Local/manual runs without `--fetch-status` fall back to price-file presence for backward compatibility.

## Artifact validation contract

**Chosen behavior:** `validate_analysis.py` accepts `metadata.coverage.passed: false` as structurally valid JSON. Publication safety is enforced by the workflow gate: when coverage policy fails, `generate` may write a diagnostic artifact with `passed: false`, then exits non-zero. The automated workflow never reaches validation, report generation, PR creation, or success Slack notification. Diagnostic artifacts are for local inspection only.

`metadata.config` and `metadata.coverage` must not be `null`.

## Slack notification changes

Success notifications include coverage summary when `metadata.coverage` is present. No success notification when coverage gates fail.

## Tests added

- Fetch-status workflow: init, record success/failure, generate with `--fetch-status`
- Pre-existing price file + failed fetch status → symbol treated as missing
- Fetch-status interval/analysis_date mismatch rejection
- Validation rejects `null` config/coverage; accepts `coverage.passed: false`
- Interval-aware and coverage gate integration tests

## CI / QA result

**Remote CI (PR head):** ✅ [CI/CD run 27662609006](https://github.com/dceoy/aims/actions/runs/27662609006) — success (fixed `ruff format --check` failure from prior head)

**Local:**
```
uv run ruff format --check .  # pass
uv run ruff check .           # pass
uv run pyright .              # pass
uv run pytest                 # 325 passed, 100% branch coverage
```

`qa.sh` Hugo build fails in this cloud environment due to a pre-existing Congo theme / Hugo `Locale` compatibility issue; CI `okf-hugo-build` job passes on GitHub Actions.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4688f153-46b8-4433-b702-63c824fd034d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4688f153-46b8-4433-b702-63c824fd034d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

