### PR TITLE
fix: clean up Renovate dashboard config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,17 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "dependencyDashboard": true,
+  "enabledManagers": ["github-actions", "gomod", "pep621"],
+  "includePaths": [
+    ".github/workflows/ci.yml",
+    ".github/workflows/daily-market-analysis.yml",
+    ".github/workflows/update-cfd-instruments.yml",
+    "go.mod",
+    "go.sum",
+    "pyproject.toml",
+    "uv.lock"
+  ],
   "minimumReleaseAge": "7 days",
   "packageRules": [
     {

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -284,6 +284,18 @@ A generated Markdown file has invalid front matter or content that causes Hugo t
 
 **Fix:** Run `hugo --gc --minify` locally with the failing content file, fix the generator, and regenerate.
 
+### Renovate dashboard lists stale dependencies
+
+The Renovate Dependency Dashboard is generated from `.github/renovate.json`.
+Renovate is limited to the dependency files and workflow files listed in
+`includePaths`, so removed workflow files should disappear after Renovate refreshes
+the dashboard.
+
+**Fix:** Open the **Dependency Dashboard** issue, check the `manual job` checkbox,
+and wait for Renovate to run again. If the dashboard still references a removed
+workflow or the old repository identity after the next run, close the dashboard
+issue so Renovate recreates it from the current repository metadata.
+
 ### Stale data warning
 
 Reports include a freshness table. Symbols with `n/a` in the freshness column had no data returned from Stooq. Symbols with old dates may be delisted or have restricted access.


### PR DESCRIPTION
## Summary
- Limit Renovate to the current GitHub Actions, Python/uv, and Go/Hugo dependency files.
- Explicitly enable the Dependency Dashboard so stale metadata can be refreshed from the current repo layout.
- Document the manual dashboard refresh/recreate step for stale Renovate issues.

## Test plan
- [x] `.agents/skills/local-qa/scripts/qa.sh`
- [x] `python -m json.tool .github/renovate.json`
- [x] `npx -y --package renovate renovate-config-validator .github/renovate.json`

Closes #47

Made with [Cursor](https://cursor.com)