### PR TITLE
fix: add market analysis skill frontmatter

### DIFF
--- a/.agents/skills/market-analysis/SKILL.md
+++ b/.agents/skills/market-analysis/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: market-analysis
+description: Fetch and validate OHLCV market data, score and rank instruments, generate structured analysis artifacts and Hugo reports, and send analysis workflow notifications.
+---
+
 # market-analysis
 
 Fetch OHLCV market data, score instruments, and generate structured analysis artifacts.


### PR DESCRIPTION
## Summary

- add required YAML frontmatter to the market-analysis skill
- define the skill name and trigger description so Codex can load it

## Validation

- `.agents/skills/local-qa/scripts/qa.sh`
- 325 tests passed with 100% coverage
- Hugo build and workflow checks passed