### PR TITLE
feat: add walk-forward scoring backtest

### DIFF
--- a/.agents/skills/market-analysis/scripts/backtest.py
+++ b/.agents/skills/market-analysis/scripts/backtest.py
@@ -86,27 +86,21 @@ def run_backtest(
         previous = selected_symbols
         date_observed = False
         for horizon in horizons:
-            eligible = [
-                score
-                for score in scores
-                if positions[score.symbol][date] + horizon < len(data[score.symbol])
-            ]
-            if not eligible:
-                continue
-            date_observed = True
-            horizon_selected = eligible[:top_k]
             horizon_returns = []
-            for rank_index, score in enumerate(eligible):
-                bucket = min(buckets, rank_index * buckets // len(eligible) + 1)
+            for rank_index, score in enumerate(scores):
                 index = positions[score.symbol][date]
+                if index + horizon >= len(data[score.symbol]):
+                    continue
+                date_observed = True
+                bucket = min(buckets, rank_index * buckets // len(scores) + 1)
                 close = data[score.symbol][index].close
                 forward = data[score.symbol][index + horizon].close / close - 1.0
                 bucket_returns[horizon][bucket].append(forward)
-                if score in horizon_selected:
+                if score in selected:
                     top_returns[horizon].append(forward)
                     top_hits[horizon].append(forward > 0)
                     horizon_returns.append(forward)
-            if horizon == 1:
+            if horizon == 1 and horizon_returns:
                 daily_top_returns.append(sum(horizon_returns) / len(horizon_returns))
         observations += date_observed
 

--- a/.agents/skills/market-analysis/scripts/backtest.py
+++ b/.agents/skills/market-analysis/scripts/backtest.py
@@ -78,13 +78,6 @@ def run_backtest(
             continue
         selected = scores[:top_k]
         selected_symbols = {s.symbol for s in selected}
-        if previous is not None:
-            turnovers.append(
-                1.0
-                - len(previous & selected_symbols)
-                / max(len(previous), len(selected_symbols))
-            )
-        previous = selected_symbols
         date_observed = False
         for horizon in horizons:
             horizon_returns = []
@@ -104,6 +97,13 @@ def run_backtest(
             if horizon == 1 and horizon_returns:
                 daily_top_returns.append(sum(horizon_returns) / len(horizon_returns))
         if date_observed:
+            if previous is not None:
+                turnovers.append(
+                    1.0
+                    - len(previous & selected_symbols)
+                    / max(len(previous), len(selected_symbols))
+                )
+            previous = selected_symbols
             observations += 1
             observed_dates.append(date.date().isoformat())
 

--- a/.agents/skills/market-analysis/scripts/backtest.py
+++ b/.agents/skills/market-analysis/scripts/backtest.py
@@ -39,19 +39,11 @@ def run_backtest(
     buckets: int = 4,
     min_history: int = 60,
 ) -> dict[str, Any]:
-    """Score each common date without look-ahead and aggregate forward returns."""
+    """Score each available date without look-ahead and aggregate forward returns."""
     if top_k < 1 or buckets < 1 or min_history < 1 or not horizons:
         msg = "top-k, buckets, min-history, and horizons must be positive"
         raise ValueError(msg)
-    dates = (
-        sorted(
-            set.intersection(
-                *({bar.timestamp for bar in bars} for bars in data.values())
-            )
-        )
-        if data
-        else []
-    )
+    dates = sorted({bar.timestamp for bars in data.values() for bar in bars})
     positions = {
         symbol: {bar.timestamp: i for i, bar in enumerate(bars)}
         for symbol, bars in data.items()
@@ -67,8 +59,12 @@ def run_backtest(
     observations = 0
 
     for date in dates:
-        window = {s: bars[: positions[s][date] + 1] for s, bars in data.items()}
-        if any(len(bars) < min_history for bars in window.values()):
+        window = {
+            symbol: bars[: positions[symbol][date] + 1]
+            for symbol, bars in data.items()
+            if date in positions[symbol] and positions[symbol][date] + 1 >= min_history
+        }
+        if not window:
             continue
         scores = [
             s
@@ -77,17 +73,9 @@ def run_backtest(
             )
             if s.is_reliable
         ]
-        eligible = [
-            s
-            for s in scores
-            if all(
-                positions[s.symbol][date] + h < len(data[s.symbol]) for h in horizons
-            )
-        ]
-        if not eligible:
+        if not scores:
             continue
-        observations += 1
-        selected = eligible[:top_k]
+        selected = scores[:top_k]
         selected_symbols = {s.symbol for s in selected}
         if previous is not None:
             turnovers.append(
@@ -96,23 +84,31 @@ def run_backtest(
                 / max(len(previous), len(selected_symbols))
             )
         previous = selected_symbols
-        if 1 in horizons:
-            one_day = []
-            for score in selected:
+        date_observed = False
+        for horizon in horizons:
+            eligible = [
+                score
+                for score in scores
+                if positions[score.symbol][date] + horizon < len(data[score.symbol])
+            ]
+            if not eligible:
+                continue
+            date_observed = True
+            horizon_selected = eligible[:top_k]
+            horizon_returns = []
+            for rank_index, score in enumerate(eligible):
+                bucket = min(buckets, rank_index * buckets // len(eligible) + 1)
                 index = positions[score.symbol][date]
                 close = data[score.symbol][index].close
-                one_day.append(data[score.symbol][index + 1].close / close - 1.0)
-            daily_top_returns.append(sum(one_day) / len(one_day))
-        for rank_index, score in enumerate(eligible):
-            bucket = min(buckets, rank_index * buckets // len(eligible) + 1)
-            index = positions[score.symbol][date]
-            close = data[score.symbol][index].close
-            for horizon in horizons:
                 forward = data[score.symbol][index + horizon].close / close - 1.0
                 bucket_returns[horizon][bucket].append(forward)
-                if score in selected:
+                if score in horizon_selected:
                     top_returns[horizon].append(forward)
                     top_hits[horizon].append(forward > 0)
+                    horizon_returns.append(forward)
+            if horizon == 1:
+                daily_top_returns.append(sum(horizon_returns) / len(horizon_returns))
+        observations += date_observed
 
     metrics = {}
     for horizon in horizons:

--- a/.agents/skills/market-analysis/scripts/backtest.py
+++ b/.agents/skills/market-analysis/scripts/backtest.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import argparse
 import json
 from collections import defaultdict
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Final
 
@@ -42,6 +41,9 @@ def run_backtest(
     """Score each available date without look-ahead and aggregate forward returns."""
     if top_k < 1 or buckets < 1 or min_history < 1 or not horizons:
         msg = "top-k, buckets, min-history, and horizons must be positive"
+        raise ValueError(msg)
+    if len(horizons) != len(set(horizons)):
+        msg = "forward horizons must be unique"
         raise ValueError(msg)
     dates = sorted({bar.timestamp for bars in data.values() for bar in bars})
     positions = {
@@ -184,7 +186,6 @@ def main(argv: list[str] | None = None) -> int:
     artifact = {
         "schema_version": "1.0.0",
         "scoring_version": SCORING_VERSION,
-        "generated_at": datetime.now(UTC).isoformat(),
         "config": {
             "symbols": list(symbols),
             "interval": args.interval,

--- a/.agents/skills/market-analysis/scripts/backtest.py
+++ b/.agents/skills/market-analysis/scripts/backtest.py
@@ -57,6 +57,7 @@ def run_backtest(
     turnovers: list[float] = []
     previous: set[str] | None = None
     observations = 0
+    observed_dates: list[str] = []
 
     for date in dates:
         window = {
@@ -102,7 +103,9 @@ def run_backtest(
                     horizon_returns.append(forward)
             if horizon == 1 and horizon_returns:
                 daily_top_returns.append(sum(horizon_returns) / len(horizon_returns))
-        observations += date_observed
+        if date_observed:
+            observations += 1
+            observed_dates.append(date.date().isoformat())
 
     metrics = {}
     for horizon in horizons:
@@ -122,6 +125,10 @@ def run_backtest(
         }
     return {
         "observations": observations,
+        "date_range": {
+            "start": observed_dates[0] if observed_dates else None,
+            "end": observed_dates[-1] if observed_dates else None,
+        },
         "metrics": metrics,
         "turnover": _mean(turnovers),
         "max_drawdown": _drawdown(daily_top_returns),
@@ -167,13 +174,14 @@ def main(argv: list[str] | None = None) -> int:
         )
     except (FileNotFoundError, ValueError) as exc:
         parser.error(str(exc))
-    start = max(bars[0].timestamp for bars in data.values()).date().isoformat()
-    end = min(bars[-1].timestamp for bars in data.values()).date().isoformat()
+    start = result["date_range"]["start"]
+    end = result["date_range"]["end"]
+    if start is None or end is None:
+        parser.error("no backtest observations for the requested configuration")
     artifact = {
         "schema_version": "1.0.0",
         "scoring_version": SCORING_VERSION,
         "generated_at": datetime.now(UTC).isoformat(),
-        "date_range": {"start": start, "end": end},
         "config": {
             "symbols": list(symbols),
             "interval": args.interval,

--- a/.agents/skills/market-analysis/scripts/backtest.py
+++ b/.agents/skills/market-analysis/scripts/backtest.py
@@ -79,6 +79,7 @@ def run_backtest(
         selected = scores[:top_k]
         selected_symbols = {s.symbol for s in selected}
         date_observed = False
+        top_k_observed = False
         for horizon in horizons:
             horizon_returns = []
             for rank_index, score in enumerate(scores):
@@ -96,7 +97,11 @@ def run_backtest(
                     horizon_returns.append(forward)
             if horizon == 1 and horizon_returns:
                 daily_top_returns.append(sum(horizon_returns) / len(horizon_returns))
+            top_k_observed = top_k_observed or bool(horizon_returns)
         if date_observed:
+            observations += 1
+            observed_dates.append(date.date().isoformat())
+        if top_k_observed:
             if previous is not None:
                 turnovers.append(
                     1.0
@@ -104,8 +109,6 @@ def run_backtest(
                     / max(len(previous), len(selected_symbols))
                 )
             previous = selected_symbols
-            observations += 1
-            observed_dates.append(date.date().isoformat())
 
     metrics = {}
     for horizon in horizons:

--- a/.agents/skills/market-analysis/scripts/backtest.py
+++ b/.agents/skills/market-analysis/scripts/backtest.py
@@ -39,7 +39,13 @@ def run_backtest(
     min_history: int = 60,
 ) -> dict[str, Any]:
     """Score each available date without look-ahead and aggregate forward returns."""
-    if top_k < 1 or buckets < 1 or min_history < 1 or not horizons:
+    if (
+        top_k < 1
+        or buckets < 1
+        or min_history < 1
+        or not horizons
+        or any(horizon < 1 for horizon in horizons)
+    ):
         msg = "top-k, buckets, min-history, and horizons must be positive"
         raise ValueError(msg)
     if len(horizons) != len(set(horizons)):

--- a/.agents/skills/market-analysis/scripts/backtest.py
+++ b/.agents/skills/market-analysis/scripts/backtest.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Run deterministic walk-forward tests against saved daily OHLCV data."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Final
+
+from market_analysis import SCORING_VERSION, OhlcvBar, load_ohlcv, score_instruments
+
+DEFAULT_HORIZONS: Final[tuple[int, ...]] = (1, 5, 20, 60)
+
+
+def _mean(values: list[float]) -> float | None:
+    return sum(values) / len(values) if values else None
+
+
+def _drawdown(returns: list[float]) -> float | None:
+    if not returns:
+        return None
+    wealth = peak = 1.0
+    maximum = 0.0
+    for value in returns:
+        wealth *= 1.0 + value
+        peak = max(peak, wealth)
+        maximum = max(maximum, 1.0 - wealth / peak)
+    return maximum
+
+
+def run_backtest(
+    data: dict[str, list[OhlcvBar]],
+    *,
+    horizons: tuple[int, ...] = DEFAULT_HORIZONS,
+    top_k: int = 3,
+    buckets: int = 4,
+    min_history: int = 60,
+) -> dict[str, Any]:
+    """Score each common date without look-ahead and aggregate forward returns."""
+    if top_k < 1 or buckets < 1 or min_history < 1 or not horizons:
+        msg = "top-k, buckets, min-history, and horizons must be positive"
+        raise ValueError(msg)
+    dates = (
+        sorted(
+            set.intersection(
+                *({bar.timestamp for bar in bars} for bars in data.values())
+            )
+        )
+        if data
+        else []
+    )
+    positions = {
+        symbol: {bar.timestamp: i for i, bar in enumerate(bars)}
+        for symbol, bars in data.items()
+    }
+    bucket_returns: dict[int, dict[int, list[float]]] = defaultdict(
+        lambda: defaultdict(list)
+    )
+    top_returns: dict[int, list[float]] = defaultdict(list)
+    top_hits: dict[int, list[bool]] = defaultdict(list)
+    daily_top_returns: list[float] = []
+    turnovers: list[float] = []
+    previous: set[str] | None = None
+    observations = 0
+
+    for date in dates:
+        window = {s: bars[: positions[s][date] + 1] for s, bars in data.items()}
+        if any(len(bars) < min_history for bars in window.values()):
+            continue
+        scores = [
+            s
+            for s in score_instruments(
+                window, reference_time=date, min_history=min_history
+            )
+            if s.is_reliable
+        ]
+        eligible = [
+            s
+            for s in scores
+            if all(
+                positions[s.symbol][date] + h < len(data[s.symbol]) for h in horizons
+            )
+        ]
+        if not eligible:
+            continue
+        observations += 1
+        selected = eligible[:top_k]
+        selected_symbols = {s.symbol for s in selected}
+        if previous is not None:
+            turnovers.append(
+                1.0
+                - len(previous & selected_symbols)
+                / max(len(previous), len(selected_symbols))
+            )
+        previous = selected_symbols
+        if 1 in horizons:
+            one_day = []
+            for score in selected:
+                index = positions[score.symbol][date]
+                close = data[score.symbol][index].close
+                one_day.append(data[score.symbol][index + 1].close / close - 1.0)
+            daily_top_returns.append(sum(one_day) / len(one_day))
+        for rank_index, score in enumerate(eligible):
+            bucket = min(buckets, rank_index * buckets // len(eligible) + 1)
+            index = positions[score.symbol][date]
+            close = data[score.symbol][index].close
+            for horizon in horizons:
+                forward = data[score.symbol][index + horizon].close / close - 1.0
+                bucket_returns[horizon][bucket].append(forward)
+                if score in selected:
+                    top_returns[horizon].append(forward)
+                    top_hits[horizon].append(forward > 0)
+
+    metrics = {}
+    for horizon in horizons:
+        metrics[f"{horizon}d"] = {
+            "score_buckets": {
+                str(bucket): {
+                    "count": len(values),
+                    "average_return": _mean(values),
+                }
+                for bucket, values in sorted(bucket_returns[horizon].items())
+            },
+            "top_k": {
+                "count": len(top_returns[horizon]),
+                "average_return": _mean(top_returns[horizon]),
+                "hit_rate": _mean([float(hit) for hit in top_hits[horizon]]),
+            },
+        }
+    return {
+        "observations": observations,
+        "metrics": metrics,
+        "turnover": _mean(turnovers),
+        "max_drawdown": _drawdown(daily_top_returns),
+    }
+
+
+def _parse_positive_csv(value: str) -> tuple[int, ...]:
+    values = tuple(int(item) for item in value.split(","))
+    if not values or any(item < 1 for item in values):
+        msg = "horizons must be comma-separated positive integers"
+        raise argparse.ArgumentTypeError(msg)
+    return values
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Load saved prices, run the backtest, and write one JSON artifact."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--symbols", required=True, help="Comma-separated symbols")
+    parser.add_argument("--data-dir", type=Path, default=Path("data/prices"))
+    parser.add_argument("--output-dir", type=Path, default=Path("data/backtests"))
+    parser.add_argument("--interval", default="d", choices=("d",))
+    parser.add_argument(
+        "--horizons", type=_parse_positive_csv, default=DEFAULT_HORIZONS
+    )
+    parser.add_argument("--top-k", type=int, default=3)
+    parser.add_argument("--buckets", type=int, default=4)
+    parser.add_argument("--min-history", type=int, default=60)
+    args = parser.parse_args(argv)
+    symbols = tuple(item.strip() for item in args.symbols.split(",") if item.strip())
+    if not symbols:
+        parser.error("at least one symbol is required")
+    try:
+        data = {
+            symbol: load_ohlcv(symbol, args.interval, args.data_dir)
+            for symbol in symbols
+        }
+        result = run_backtest(
+            data,
+            horizons=args.horizons,
+            top_k=args.top_k,
+            buckets=args.buckets,
+            min_history=args.min_history,
+        )
+    except (FileNotFoundError, ValueError) as exc:
+        parser.error(str(exc))
+    start = max(bars[0].timestamp for bars in data.values()).date().isoformat()
+    end = min(bars[-1].timestamp for bars in data.values()).date().isoformat()
+    artifact = {
+        "schema_version": "1.0.0",
+        "scoring_version": SCORING_VERSION,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "date_range": {"start": start, "end": end},
+        "config": {
+            "symbols": list(symbols),
+            "interval": args.interval,
+            "forward_horizons": list(args.horizons),
+            "top_k": args.top_k,
+            "buckets": args.buckets,
+            "min_history": args.min_history,
+        },
+        **result,
+    }
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    path = args.output_dir / f"{start}_{end}_{args.interval}.json"
+    path.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n")
+    print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -65,6 +65,28 @@ The master is validated against `data/schema/cfd_instruments.schema.json` after 
 
 AIMS scores and ranks instruments cross-sectionally using ten features computed from daily OHLCV history.
 
+### Walk-forward backtesting
+
+Run the scoring engine historically against saved daily prices without using future
+data in each score:
+
+```bash
+uv run .agents/skills/market-analysis/scripts/backtest.py \
+    --symbols "^SPX,^DJI,^NDX" --horizons 1,5,20,60
+```
+
+The deterministic JSON artifact is written to
+`data/backtests/START_END_d.json`. It records the configuration, scoring version,
+date range, forward-return averages by score bucket (bucket 1 is highest), top-k
+average return and hit rate, top-k turnover, and the maximum drawdown of the
+equal-weighted one-day top-k return series.
+
+These results measure historical association, not causation or an executable
+strategy. They exclude fees, slippage, financing, order timing, survivorship bias,
+and market-impact constraints. Overlapping forward horizons are not independent;
+small samples and the selected universe can materially distort results. Backtest
+output is informational and is not investment advice.
+
 ### Features
 
 | Feature             | Window            | Direction        |

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -129,6 +129,24 @@ def test_missing_forward_bar_does_not_promote_lower_rank(
     assert bucket_count == 25
 
 
+def test_turnover_excludes_dates_without_forward_observations(
+    modules: tuple[ModuleType, ModuleType],
+) -> None:
+    ma, backtest = modules
+    leader = _bars(ma, "LEADER", 1.0, count=65)
+    late_leader = _bars(ma, "LATE", 0.0, count=65)
+    late_leader[-1] = replace(
+        late_leader[-1], open=1_000.0, high=1_000.0, low=1_000.0, close=1_000.0
+    )
+    result = backtest.run_backtest(
+        {"LEADER": leader, "LATE": late_leader},
+        horizons=(1,),
+        top_k=1,
+        min_history=60,
+    )
+    assert result["turnover"] == 0.0
+
+
 def test_main_writes_artifact(
     modules: tuple[ModuleType, ModuleType], tmp_path: Path
 ) -> None:

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+SCRIPTS = (
+    Path(__file__).resolve().parents[1]
+    / ".agents"
+    / "skills"
+    / "market-analysis"
+    / "scripts"
+)
+
+
+@pytest.fixture(scope="module")
+def modules() -> tuple[ModuleType, ModuleType]:
+    sys.path.insert(0, str(SCRIPTS))
+    loaded = []
+    for name in ("market_analysis", "backtest"):
+        spec = importlib.util.spec_from_file_location(name, SCRIPTS / f"{name}.py")
+        assert spec is not None
+        assert spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
+        loaded.append(module)
+    return loaded[0], loaded[1]
+
+
+def _bars(ma: ModuleType, symbol: str, slope: float, count: int = 70) -> list[object]:
+    start = datetime(2024, 1, 1, tzinfo=UTC)
+    return [
+        ma.OhlcvBar(
+            symbol,
+            start + timedelta(days=index),
+            100 + slope * index,
+            100 + slope * index,
+            100 + slope * index,
+            100 + slope * index,
+            1_000,
+            "test",
+            "d",
+        )
+        for index in range(count)
+    ]
+
+
+def test_helpers_and_validation(modules: tuple[ModuleType, ModuleType]) -> None:
+    _, backtest = modules
+    assert backtest._mean([]) is None
+    assert backtest._mean([1.0, 3.0]) == 2.0
+    assert backtest._drawdown([]) is None
+    assert backtest._drawdown([0.1, -0.2]) == pytest.approx(0.2)
+    assert backtest._parse_positive_csv("1,5") == (1, 5)
+    with pytest.raises(Exception, match="positive"):
+        backtest._parse_positive_csv("0")
+    for kwargs in ({"top_k": 0}, {"buckets": 0}, {"min_history": 0}, {"horizons": ()}):
+        with pytest.raises(ValueError, match="positive"):
+            backtest.run_backtest({}, **kwargs)
+
+
+def test_run_backtest_metrics(modules: tuple[ModuleType, ModuleType]) -> None:
+    ma, backtest = modules
+    data = {"UP": _bars(ma, "UP", 2.0), "DOWN": _bars(ma, "DOWN", -0.5)}
+    result = backtest.run_backtest(
+        data, horizons=(1, 5), top_k=1, buckets=2, min_history=60
+    )
+    assert result["observations"] == 6
+    assert result["metrics"]["1d"]["top_k"]["count"] == 6
+    assert result["metrics"]["1d"]["top_k"]["hit_rate"] == 1.0
+    assert result["metrics"]["5d"]["score_buckets"]["1"]["count"] == 6
+    assert result["turnover"] == 0.0
+    assert result["max_drawdown"] == 0.0
+    empty = backtest.run_backtest({}, horizons=(1,))
+    assert empty["observations"] == 0
+    assert empty["metrics"]["1d"]["top_k"]["average_return"] is None
+    no_daily = backtest.run_backtest(data, horizons=(5,), min_history=60)
+    assert no_daily["max_drawdown"] is None
+
+
+def test_main_writes_artifact(
+    modules: tuple[ModuleType, ModuleType], tmp_path: Path
+) -> None:
+    ma, backtest = modules
+    prices = tmp_path / "prices"
+    for symbol, slope in (("UP", 2.0), ("DOWN", -0.5)):
+        ma.save_ohlcv(_bars(ma, symbol, slope), prices)
+    output = tmp_path / "backtests"
+    assert (
+        backtest.main([
+            "--symbols",
+            "UP,DOWN",
+            "--data-dir",
+            str(prices),
+            "--output-dir",
+            str(output),
+            "--horizons",
+            "1,5",
+            "--top-k",
+            "1",
+        ])
+        == 0
+    )
+    artifact = json.loads(next(output.glob("*.json")).read_text())
+    assert artifact["scoring_version"] == ma.SCORING_VERSION
+    assert artifact["config"]["forward_horizons"] == [1, 5]
+    assert artifact["date_range"]["start"] == "2024-01-01"
+
+
+def test_main_rejects_missing_inputs(
+    modules: tuple[ModuleType, ModuleType], tmp_path: Path
+) -> None:
+    _, backtest = modules
+    with pytest.raises(SystemExit):
+        backtest.main(["--symbols", ","])
+    with pytest.raises(SystemExit):
+        backtest.main(["--symbols", "MISSING", "--data-dir", str(tmp_path)])

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -74,8 +75,8 @@ def test_run_backtest_metrics(modules: tuple[ModuleType, ModuleType]) -> None:
     result = backtest.run_backtest(
         data, horizons=(1, 5), top_k=1, buckets=2, min_history=60
     )
-    assert result["observations"] == 6
-    assert result["metrics"]["1d"]["top_k"]["count"] == 6
+    assert result["observations"] == 10
+    assert result["metrics"]["1d"]["top_k"]["count"] == 10
     assert result["metrics"]["1d"]["top_k"]["hit_rate"] == 1.0
     assert result["metrics"]["5d"]["score_buckets"]["1"]["count"] == 6
     assert result["turnover"] == 0.0
@@ -85,6 +86,26 @@ def test_run_backtest_metrics(modules: tuple[ModuleType, ModuleType]) -> None:
     assert empty["metrics"]["1d"]["top_k"]["average_return"] is None
     no_daily = backtest.run_backtest(data, horizons=(5,), min_history=60)
     assert no_daily["max_drawdown"] is None
+
+
+def test_short_history_symbol_does_not_suppress_mature_symbols(
+    modules: tuple[ModuleType, ModuleType],
+) -> None:
+    ma, backtest = modules
+    data = {
+        "MATURE": _bars(ma, "MATURE", 1.0),
+        "NEW": _bars(ma, "NEW", 2.0, count=10),
+    }
+    result = backtest.run_backtest(data, horizons=(1,), min_history=60)
+    assert result["observations"] == 10
+    assert result["metrics"]["1d"]["top_k"]["count"] == 10
+    gapped = _bars(ma, "GAPPED", 1.0, count=3)
+    gapped = [
+        replace(bar, timestamp=bar.timestamp + timedelta(days=10 * index))
+        for index, bar in enumerate(gapped)
+    ]
+    unreliable = backtest.run_backtest({"GAPPED": gapped}, horizons=(1,), min_history=2)
+    assert unreliable["observations"] == 0
 
 
 def test_main_writes_artifact(

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -64,7 +64,14 @@ def test_helpers_and_validation(modules: tuple[ModuleType, ModuleType]) -> None:
     assert backtest._parse_positive_csv("1,5") == (1, 5)
     with pytest.raises(Exception, match="positive"):
         backtest._parse_positive_csv("0")
-    for kwargs in ({"top_k": 0}, {"buckets": 0}, {"min_history": 0}, {"horizons": ()}):
+    for kwargs in (
+        {"top_k": 0},
+        {"buckets": 0},
+        {"min_history": 0},
+        {"horizons": ()},
+        {"horizons": (0,)},
+        {"horizons": (-1,)},
+    ):
         with pytest.raises(ValueError, match="positive"):
             backtest.run_backtest({}, **kwargs)
     with pytest.raises(ValueError, match="unique"):

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -83,6 +83,7 @@ def test_run_backtest_metrics(modules: tuple[ModuleType, ModuleType]) -> None:
     assert result["max_drawdown"] == 0.0
     empty = backtest.run_backtest({}, horizons=(1,))
     assert empty["observations"] == 0
+    assert empty["date_range"] == {"start": None, "end": None}
     assert empty["metrics"]["1d"]["top_k"]["average_return"] is None
     no_daily = backtest.run_backtest(data, horizons=(5,), min_history=60)
     assert no_daily["max_drawdown"] is None
@@ -99,6 +100,7 @@ def test_short_history_symbol_does_not_suppress_mature_symbols(
     result = backtest.run_backtest(data, horizons=(1,), min_history=60)
     assert result["observations"] == 10
     assert result["metrics"]["1d"]["top_k"]["count"] == 10
+    assert result["date_range"]["end"] == "2024-03-09"
     gapped = _bars(ma, "GAPPED", 1.0, count=3)
     gapped = [
         replace(bar, timestamp=bar.timestamp + timedelta(days=10 * index))
@@ -153,7 +155,24 @@ def test_main_writes_artifact(
     artifact = json.loads(next(output.glob("*.json")).read_text())
     assert artifact["scoring_version"] == ma.SCORING_VERSION
     assert artifact["config"]["forward_horizons"] == [1, 5]
-    assert artifact["date_range"]["start"] == "2024-01-01"
+    assert artifact["date_range"] == {"start": "2024-02-29", "end": "2024-03-09"}
+
+
+def test_main_rejects_no_observations(
+    modules: tuple[ModuleType, ModuleType], tmp_path: Path
+) -> None:
+    ma, backtest = modules
+    prices = tmp_path / "prices"
+    ma.save_ohlcv(_bars(ma, "SHORT", 1.0, count=2), prices)
+    with pytest.raises(SystemExit):
+        backtest.main([
+            "--symbols",
+            "SHORT",
+            "--data-dir",
+            str(prices),
+            "--min-history",
+            "2",
+        ])
 
 
 def test_main_rejects_missing_inputs(

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -67,6 +67,8 @@ def test_helpers_and_validation(modules: tuple[ModuleType, ModuleType]) -> None:
     for kwargs in ({"top_k": 0}, {"buckets": 0}, {"min_history": 0}, {"horizons": ()}):
         with pytest.raises(ValueError, match="positive"):
             backtest.run_backtest({}, **kwargs)
+    with pytest.raises(ValueError, match="unique"):
+        backtest.run_backtest({}, horizons=(1, 1))
 
 
 def test_run_backtest_metrics(modules: tuple[ModuleType, ModuleType]) -> None:
@@ -171,10 +173,28 @@ def test_main_writes_artifact(
         ])
         == 0
     )
-    artifact = json.loads(next(output.glob("*.json")).read_text())
+    path = next(output.glob("*.json"))
+    content = path.read_text()
+    artifact = json.loads(content)
     assert artifact["scoring_version"] == ma.SCORING_VERSION
     assert artifact["config"]["forward_horizons"] == [1, 5]
     assert artifact["date_range"] == {"start": "2024-02-29", "end": "2024-03-09"}
+    assert (
+        backtest.main([
+            "--symbols",
+            "UP,DOWN",
+            "--data-dir",
+            str(prices),
+            "--output-dir",
+            str(output),
+            "--horizons",
+            "1,5",
+            "--top-k",
+            "1",
+        ])
+        == 0
+    )
+    assert path.read_text() == content
 
 
 def test_main_rejects_no_observations(

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -108,6 +108,25 @@ def test_short_history_symbol_does_not_suppress_mature_symbols(
     assert unreliable["observations"] == 0
 
 
+def test_missing_forward_bar_does_not_promote_lower_rank(
+    modules: tuple[ModuleType, ModuleType],
+) -> None:
+    ma, backtest = modules
+    data = {
+        "TOP": _bars(ma, "TOP", 2.0, count=70),
+        "LOWER": _bars(ma, "LOWER", 1.0, count=75),
+    }
+    result = backtest.run_backtest(
+        data, horizons=(1,), top_k=1, buckets=2, min_history=60
+    )
+    top = result["metrics"]["1d"]["top_k"]
+    bucket_count = sum(
+        bucket["count"] for bucket in result["metrics"]["1d"]["score_buckets"].values()
+    )
+    assert top["count"] == 14
+    assert bucket_count == 25
+
+
 def test_main_writes_artifact(
     modules: tuple[ModuleType, ModuleType], tmp_path: Path
 ) -> None:

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -127,6 +127,7 @@ def test_missing_forward_bar_does_not_promote_lower_rank(
     )
     assert top["count"] == 14
     assert bucket_count == 25
+    assert result["turnover"] == pytest.approx(1 / 13)
 
 
 def test_turnover_excludes_dates_without_forward_observations(


### PR DESCRIPTION
## Summary

- add a deterministic walk-forward backtesting CLI for saved daily OHLCV data
- report forward returns by score bucket, top-k returns and hit rate, turnover, and drawdown
- write machine-readable artifacts under `data/backtests/`
- document usage, interpretation, and limitations

## Validation

- `.agents/skills/local-qa/scripts/qa.sh`
- 329 tests passed with 100% branch coverage

Closes #41