### PR TITLE
feat(analysis): add score history artifacts

### DIFF
--- a/.agents/skills/market-analysis/SKILL.md
+++ b/.agents/skills/market-analysis/SKILL.md
@@ -33,6 +33,18 @@ Validate a generated JSON artifact against the expected schema.
 
 Generate a Hugo Markdown report from a JSON analysis artifact and write it to `content/results/`.
 
+### `generate_history.py`
+
+Generate a versioned `data/history/YYYY-MM-DD.json` artifact by comparing the
+current analysis with prior available artifacts. It records score/rank deltas,
+top-k entry/dropout, consecutive reliable/top-k report counts, and risk-gate
+transitions. Consecutive counts follow available reports, so skipped dates do not
+break a streak.
+
+### `validate_history.py`
+
+Validate a generated score-history artifact before report publication.
+
 ### `notify_slack.py`
 
 Send a Slack notification (success or failure) via an incoming webhook. Reads `SLACK_WEBHOOK_URL` from the environment; exits silently if the variable is not set. Success notifications include a coverage summary when `metadata.coverage` is present.
@@ -70,6 +82,7 @@ uv run .agents/skills/market-analysis/scripts/validate_analysis.py \
 # Generate a Hugo Markdown report from the artifact
 uv run .agents/skills/market-analysis/scripts/generate_report.py \
     --input data/analysis/$(date +%Y-%m-%d).json \
+    --history data/history/$(date +%Y-%m-%d).json \
     --output content/results/
 
 # Send a Slack success notification
@@ -94,7 +107,9 @@ data/
 │   ├── AAPL.US_d.csv        # Daily OHLCV for AAPL.US
 │   └── MSFT.US_d.csv
 └── analysis/
-    └── YYYY-MM-DD.json      # Analysis artifact
+│   └── YYYY-MM-DD.json      # Analysis artifact
+└── history/
+    └── YYYY-MM-DD.json      # Versioned score-history artifact
 ```
 
 Each `data/prices/<SYMBOL>_<INTERVAL>.csv` has columns:

--- a/.agents/skills/market-analysis/scripts/generate_history.py
+++ b/.agents/skills/market-analysis/scripts/generate_history.py
@@ -26,6 +26,14 @@ def _date(artifact: dict[str, Any]) -> str:
     return generated_at[:10]
 
 
+def _interval(artifact: dict[str, Any]) -> str:
+    interval = artifact.get("metadata", {}).get("config", {}).get("interval")
+    if interval not in {"d", "w", "m"}:
+        msg = "analysis artifact has no valid metadata.config.interval"
+        raise ValueError(msg)
+    return str(interval)
+
+
 def _by_symbol(artifact: dict[str, Any]) -> dict[str, dict[str, Any]]:
     instruments = artifact.get("instruments")
     if not isinstance(instruments, list):
@@ -52,6 +60,10 @@ def build_history(
         msg = "at least one analysis artifact is required"
         raise ValueError(msg)
     ordered = sorted(artifacts, key=_date)
+    intervals = {_interval(artifact) for artifact in ordered}
+    if len(intervals) != 1:
+        msg = "analysis artifacts must use the same interval"
+        raise ValueError(msg)
     dates = [_date(item) for item in ordered]
     if len(set(dates)) != len(dates):
         msg = "analysis dates must be unique"
@@ -118,14 +130,20 @@ def build_history(
 def generate_history(
     current_path: Path, analysis_dir: Path, output_dir: Path, top_k: int
 ) -> Path:
-    current_date = _date(_load(current_path))
+    current = _load(current_path)
+    current_date = _date(current)
+    current_interval = _interval(current)
     paths = sorted(
         path
         for path in analysis_dir.glob("*.json")
         if path.stem <= current_date and path.resolve() != current_path.resolve()
     )
-    artifacts = [_load(path) for path in paths]
-    artifacts.append(_load(current_path))
+    artifacts = [
+        artifact
+        for path in paths
+        if _interval(artifact := _load(path)) == current_interval
+    ]
+    artifacts.append(current)
     history = build_history(artifacts, top_k)
     output_dir.mkdir(parents=True, exist_ok=True)
     output = output_dir / f"{current_date}.json"

--- a/.agents/skills/market-analysis/scripts/generate_history.py
+++ b/.agents/skills/market-analysis/scripts/generate_history.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Generate deterministic score-history artifacts from saved analyses."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Final
+
+HISTORY_VERSION: Final[str] = "1.0.0"
+DEFAULT_TOP_K: Final[int] = 5
+
+
+def _load(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as stream:
+        value: dict[str, Any] = json.load(stream)
+    return value
+
+
+def _date(artifact: dict[str, Any]) -> str:
+    generated_at = artifact.get("metadata", {}).get("generated_at")
+    if not isinstance(generated_at, str) or len(generated_at) < 10:
+        msg = "analysis artifact has no valid metadata.generated_at"
+        raise TypeError(msg)
+    return generated_at[:10]
+
+
+def _by_symbol(artifact: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    instruments = artifact.get("instruments")
+    if not isinstance(instruments, list):
+        msg = "analysis artifact has no valid instruments list"
+        raise TypeError(msg)
+    return {str(item["symbol"]): item for item in instruments}
+
+
+def _top_symbols(artifact: dict[str, Any], top_k: int) -> set[str]:
+    return {
+        str(item["symbol"])
+        for item in artifact["instruments"]
+        if item.get("is_reliable") and int(item["rank"]) <= top_k
+    }
+
+
+def build_history(
+    artifacts: list[dict[str, Any]], top_k: int = DEFAULT_TOP_K
+) -> dict[str, Any]:
+    if top_k < 1:
+        msg = "top_k must be at least 1"
+        raise ValueError(msg)
+    if not artifacts:
+        msg = "at least one analysis artifact is required"
+        raise ValueError(msg)
+    ordered = sorted(artifacts, key=_date)
+    dates = [_date(item) for item in ordered]
+    if len(set(dates)) != len(dates):
+        msg = "analysis dates must be unique"
+        raise ValueError(msg)
+    current = ordered[-1]
+    previous = ordered[-2] if len(ordered) > 1 else None
+    current_items = _by_symbol(current)
+    previous_items = _by_symbol(previous) if previous else {}
+    current_top = _top_symbols(current, top_k)
+    previous_top = _top_symbols(previous, top_k) if previous else set()
+
+    rows: list[dict[str, Any]] = []
+    for symbol, item in sorted(
+        current_items.items(), key=lambda pair: (int(pair[1]["rank"]), pair[0])
+    ):
+        old = previous_items.get(symbol)
+        current_gates = sorted(str(gate) for gate in item.get("risk_gates", []))
+        old_gates = (
+            sorted(str(gate) for gate in old.get("risk_gates", [])) if old else []
+        )
+        reliable_days = 0
+        top_days = 0
+        for artifact in reversed(ordered):
+            historical = _by_symbol(artifact).get(symbol)
+            if historical is None or not historical.get("is_reliable"):
+                break
+            reliable_days += 1
+        for artifact in reversed(ordered):
+            if symbol not in _top_symbols(artifact, top_k):
+                break
+            top_days += 1
+        old_rank = int(old["rank"]) if old else None
+        old_score = float(old["score"]) if old else None
+        score = float(item["score"])
+        rank = int(item["rank"])
+        rows.append({
+            "symbol": symbol,
+            "current_rank": rank,
+            "previous_rank": old_rank,
+            "rank_delta": old_rank - rank if old_rank is not None else None,
+            "current_score": score,
+            "previous_score": old_score,
+            "score_delta": round(score - old_score, 6)
+            if old_score is not None
+            else None,
+            "is_reliable": bool(item.get("is_reliable")),
+            "new_top_k": previous is not None and symbol in current_top - previous_top,
+            "consecutive_reliable_reports": reliable_days,
+            "consecutive_top_k_reports": top_days,
+            "risk_gates_added": sorted(set(current_gates) - set(old_gates)),
+            "risk_gates_removed": sorted(set(old_gates) - set(current_gates)),
+        })
+    dropped = sorted(previous_top - current_top) if previous else []
+    return {
+        "version": HISTORY_VERSION,
+        "analysis_date": dates[-1],
+        "previous_analysis_date": dates[-2] if previous else None,
+        "top_k": top_k,
+        "instruments": rows,
+        "dropped_from_top_k": dropped,
+    }
+
+
+def generate_history(
+    current_path: Path, analysis_dir: Path, output_dir: Path, top_k: int
+) -> Path:
+    current_date = _date(_load(current_path))
+    paths = sorted(
+        path
+        for path in analysis_dir.glob("*.json")
+        if path.stem <= current_date and path.resolve() != current_path.resolve()
+    )
+    artifacts = [_load(path) for path in paths]
+    artifacts.append(_load(current_path))
+    history = build_history(artifacts, top_k)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output = output_dir / f"{current_date}.json"
+    output.write_text(
+        json.dumps(history, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(f"History written to {output}")
+    return output
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, type=Path)
+    parser.add_argument("--analysis-dir", default=Path("data/analysis"), type=Path)
+    parser.add_argument("--output", default=Path("data/history"), type=Path)
+    parser.add_argument("--top-k", default=DEFAULT_TOP_K, type=int)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        generate_history(args.input, args.analysis_dir, args.output, args.top_k)
+    except (
+        FileNotFoundError,
+        json.JSONDecodeError,
+        KeyError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        print(f"ERROR: {exc}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/market-analysis/scripts/generate_report.py
+++ b/.agents/skills/market-analysis/scripts/generate_report.py
@@ -67,7 +67,9 @@ def _market_regime(scores: list[float]) -> str:
     return "Neutral"
 
 
-def _build_front_matter(artifact: dict[str, Any], date_str: str) -> str:
+def _build_front_matter(
+    artifact: dict[str, Any], date_str: str, history: dict[str, Any] | None = None
+) -> str:
     meta = artifact.get("metadata", {})
     generated_at = meta.get("generated_at", "1970-01-01T00:00:00+00:00")
     if not isinstance(generated_at, str):
@@ -87,7 +89,10 @@ def _build_front_matter(artifact: dict[str, Any], date_str: str) -> str:
     all_symbols = sorted(str(i.get("symbol", "")) for i in instruments)
     symbols_toml = ", ".join(f'"{_toml_escape(s)}"' for s in all_symbols)
 
-    source_file = f"data/analysis/{date_str}.json"
+    source_files = [f"data/analysis/{date_str}.json"]
+    if history is not None:
+        source_files.append(f"data/history/{date_str}.json")
+    sources_toml = ", ".join(f'"{_toml_escape(path)}"' for path in source_files)
 
     if reliable:
         top = max(reliable, key=lambda i: float(i.get("score", 0)))
@@ -107,7 +112,7 @@ def _build_front_matter(artifact: dict[str, Any], date_str: str) -> str:
         "draft = false",
         f'summary = "{_toml_escape(summary)}"',
         f"ticker_symbols = [{symbols_toml}]",
-        f'source_files = ["{_toml_escape(source_file)}"]',
+        f"source_files = [{sources_toml}]",
         f'market_regime = "{_toml_escape(regime)}"',
         f'data_source = "{_toml_escape(data_source)}"',
         f'scoring_version = "{_toml_escape(scoring_version)}"',
@@ -165,6 +170,48 @@ def _section_instruments_to_avoid(unreliable: list[dict[str, Any]]) -> str:
         gates_str = ", ".join(str(g) for g in gates)
         lines.append(f"- **{symbol}** — {gates_str}")
     return f"{header}\n\n{preamble}\n\n" + "\n".join(lines)
+
+
+def _section_signal_history(history: dict[str, Any] | None) -> str:
+    header = "## Signal History"
+    if history is None:
+        return f"{header}\n\n_No previous analysis artifact available._"
+    previous = history.get("previous_analysis_date")
+    if previous is None:
+        return f"{header}\n\n_No previous analysis artifact available._"
+    rows = history.get("instruments", [])
+    new_top = sorted(str(row["symbol"]) for row in rows if row.get("new_top_k"))
+    persistent = sorted(
+        (row for row in rows if int(row.get("consecutive_top_k_reports", 0)) >= 2),
+        key=lambda row: (-int(row["consecutive_top_k_reports"]), str(row["symbol"])),
+    )
+    transitions = sorted(
+        (
+            row
+            for row in rows
+            if row.get("risk_gates_added") or row.get("risk_gates_removed")
+        ),
+        key=lambda row: str(row["symbol"]),
+    )
+    lines = [f"Compared with the previous available report (**{previous}**)."]
+    lines.append(
+        f"- **New top-{history.get('top_k', 5)}:** {', '.join(new_top) or 'None'}"
+    )
+    persistent_text = ", ".join(
+        f"{row['symbol']} ({row['consecutive_top_k_reports']} reports)"
+        for row in persistent
+    )
+    lines.append(f"- **Persistent top signals:** {persistent_text or 'None'}")
+    dropped = history.get("dropped_from_top_k", [])
+    dropped_text = ", ".join(dropped) or "None"
+    lines.append(f"- **Dropped from top-{history.get('top_k', 5)}:** {dropped_text}")
+    for row in transitions:
+        added = ", ".join(row.get("risk_gates_added", [])) or "none"
+        removed = ", ".join(row.get("risk_gates_removed", [])) or "none"
+        lines.append(
+            f"- **{row['symbol']} risk gates:** added {added}; removed {removed}"
+        )
+    return f"{header}\n\n" + "\n".join(lines)
 
 
 def _format_markdown_table(
@@ -346,7 +393,9 @@ def _validate_for_report(artifact: dict[str, Any]) -> None:
         raise ValueError(msg)
 
 
-def generate_report(artifact: dict[str, Any]) -> str:
+def generate_report(
+    artifact: dict[str, Any], history: dict[str, Any] | None = None
+) -> str:
     meta = artifact.get("metadata", {})
     generated_at = meta.get("generated_at", "")
     if not isinstance(generated_at, str) or not generated_at:
@@ -371,11 +420,12 @@ def generate_report(artifact: dict[str, Any]) -> str:
     n_reliable = len(reliable)
     total = len(instruments)
 
-    front_matter = _build_front_matter(artifact, date_str)
+    front_matter = _build_front_matter(artifact, date_str, history)
 
     sections = [
         _section_market_regime(regime, n_reliable, total),
         _section_top_opportunities(reliable),
+        _section_signal_history(history),
         _section_instruments_to_avoid(unreliable),
         _section_key_risks(instruments),
         _section_instrument_scores(instruments),
@@ -400,11 +450,16 @@ def report_filename(artifact: dict[str, Any]) -> str:
 def generate_and_save(
     artifact_path: Path,
     output_dir: Path = _DEFAULT_OUTPUT_DIR,
+    history_path: Path | None = None,
 ) -> Path:
     with artifact_path.open(encoding="utf-8") as fh:
         artifact: dict[str, Any] = json.load(fh)
     _validate_for_report(artifact)
-    content = generate_report(artifact)
+    history = None
+    if history_path is not None:
+        with history_path.open(encoding="utf-8") as fh:
+            history = json.load(fh)
+    content = generate_report(artifact, history)
     filename = report_filename(artifact)
     output_dir.mkdir(parents=True, exist_ok=True)
     output_path = output_dir / filename
@@ -421,6 +476,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         required=True,
         help="Path to analysis artifact JSON file",
     )
+    parser.add_argument("--history", type=Path, help="Path to score-history JSON")
     parser.add_argument(
         "--output",
         type=Path,
@@ -433,7 +489,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     try:
-        generate_and_save(args.input, args.output)
+        generate_and_save(args.input, args.output, args.history)
     except FileNotFoundError:
         print(f"ERROR: file not found: {args.input}")
         return 1

--- a/.agents/skills/market-analysis/scripts/notify_slack.py
+++ b/.agents/skills/market-analysis/scripts/notify_slack.py
@@ -47,6 +47,7 @@ def build_success_payload(
     report_url: str = "",
     *,
     pr_url: str | None = None,
+    history: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     meta = artifact.get("metadata", {})
     generated_at = meta.get("generated_at", "")
@@ -85,6 +86,25 @@ def build_success_payload(
             "type": "mrkdwn",
             "text": f"*⚠️ No data:* {', '.join(stale)}",
         })
+    if history is not None and history.get("previous_analysis_date") is not None:
+        rows = history.get("instruments", [])
+        new_top = sorted(str(row["symbol"]) for row in rows if row.get("new_top_k"))
+        persistent = sorted(
+            str(row["symbol"])
+            for row in rows
+            if int(row.get("consecutive_top_k_reports", 0)) >= 2
+        )
+        risk_changes = sorted(
+            str(row["symbol"])
+            for row in rows
+            if row.get("risk_gates_added") or row.get("risk_gates_removed")
+        )
+        summary = (
+            f"*History:* new top: {', '.join(new_top) or 'none'}; "
+            f"persistent: {', '.join(persistent) or 'none'}; "
+            f"risk changes: {', '.join(risk_changes) or 'none'}"
+        )
+        fields.append({"type": "mrkdwn", "text": summary})
 
     coverage_raw = meta.get("coverage")
     if isinstance(coverage_raw, dict):
@@ -187,6 +207,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Send a failure notification instead of a success notification",
     )
+    parser.add_argument("--history", type=str, help="Path to score-history JSON")
     parser.add_argument(
         "--artifact",
         type=str,
@@ -220,7 +241,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def main(argv: list[str] | None = None) -> int:
+def main(argv: list[str] | None = None) -> int:  # noqa: PLR0911
     args = parse_args(argv)
     webhook_url = os.environ.get("SLACK_WEBHOOK_URL", "")
     if not webhook_url:
@@ -244,8 +265,16 @@ def main(argv: list[str] | None = None) -> int:
             print(f"ERROR: invalid JSON in {args.artifact}: {exc}")
             return 1
         report_url = args.report_url or ""
+        history = None
+        if args.history:
+            try:
+                with open(args.history, encoding="utf-8") as fh:  # noqa: PTH123
+                    history = json.load(fh)
+            except (FileNotFoundError, json.JSONDecodeError) as exc:
+                print(f"ERROR: invalid history artifact: {exc}")
+                return 1
         payload = build_success_payload(
-            artifact, report_url, pr_url=args.pr_url or None
+            artifact, report_url, pr_url=args.pr_url or None, history=history
         )
 
     try:

--- a/.agents/skills/market-analysis/scripts/validate_history.py
+++ b/.agents/skills/market-analysis/scripts/validate_history.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Validate an AIMS score-history artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from generate_history import HISTORY_VERSION
+
+
+def validate(history: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    required = {
+        "version",
+        "analysis_date",
+        "previous_analysis_date",
+        "top_k",
+        "instruments",
+        "dropped_from_top_k",
+    }
+    missing = sorted(required - history.keys())
+    if missing:
+        errors.append(f"missing keys: {', '.join(missing)}")
+    if history.get("version") != HISTORY_VERSION:
+        errors.append(f"version must be {HISTORY_VERSION}")
+    if not isinstance(history.get("analysis_date"), str):
+        errors.append("analysis_date must be a string")
+    previous = history.get("previous_analysis_date")
+    if previous is not None and not isinstance(previous, str):
+        errors.append("previous_analysis_date must be a string or null")
+    top_k = history.get("top_k")
+    if not isinstance(top_k, int) or isinstance(top_k, bool) or top_k < 1:
+        errors.append("top_k must be a positive integer")
+    if not isinstance(history.get("instruments"), list):
+        errors.append("instruments must be an array")
+    if not isinstance(history.get("dropped_from_top_k"), list):
+        errors.append("dropped_from_top_k must be an array")
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, type=Path)
+    args = parser.parse_args(argv)
+    try:
+        with args.input.open(encoding="utf-8") as stream:
+            history: dict[str, Any] = json.load(stream)
+    except (FileNotFoundError, json.JSONDecodeError) as exc:
+        print(f"ERROR: {exc}")
+        return 1
+    errors = validate(history)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        return 1
+    print(f"validated {args.input}: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/market-analysis/scripts/validate_history.py
+++ b/.agents/skills/market-analysis/scripts/validate_history.py
@@ -11,6 +11,72 @@ from typing import Any
 from generate_history import HISTORY_VERSION
 
 
+def _is_number(value: object) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _validate_row(row: object, index: int) -> list[str]:
+    prefix = f"instruments[{index}]"
+    if not isinstance(row, dict):
+        return [f"{prefix} must be an object"]
+    errors: list[str] = []
+    required = {
+        "symbol",
+        "current_rank",
+        "previous_rank",
+        "rank_delta",
+        "current_score",
+        "previous_score",
+        "score_delta",
+        "is_reliable",
+        "new_top_k",
+        "consecutive_reliable_reports",
+        "consecutive_top_k_reports",
+        "risk_gates_added",
+        "risk_gates_removed",
+    }
+    missing = sorted(required - row.keys())
+    if missing:
+        errors.append(f"{prefix} missing keys: {', '.join(missing)}")
+    if not isinstance(row.get("symbol"), str):
+        errors.append(f"{prefix}.symbol must be a string")
+    current_rank = row.get("current_rank")
+    if (
+        not isinstance(current_rank, int)
+        or isinstance(current_rank, bool)
+        or current_rank < 1
+    ):
+        errors.append(f"{prefix}.current_rank must be a positive integer")
+    for field in ("consecutive_reliable_reports", "consecutive_top_k_reports"):
+        value = row.get(field)
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            errors.append(f"{prefix}.{field} must be a non-negative integer")
+    for field in ("previous_rank", "rank_delta"):
+        value = row.get(field)
+        if value is not None and (
+            not isinstance(value, int) or isinstance(value, bool)
+        ):
+            errors.append(f"{prefix}.{field} must be an integer or null")
+    for field in ("current_score", "previous_score", "score_delta"):
+        value = row.get(field)
+        if field == "current_score" and not _is_number(value):
+            errors.append(f"{prefix}.{field} must be a number")
+        elif field != "current_score" and value is not None and not _is_number(value):
+            errors.append(f"{prefix}.{field} must be a number or null")
+    errors.extend(
+        f"{prefix}.{field} must be a boolean"
+        for field in ("is_reliable", "new_top_k")
+        if not isinstance(row.get(field), bool)
+    )
+    for field in ("risk_gates_added", "risk_gates_removed"):
+        value = row.get(field)
+        if not isinstance(value, list) or not all(
+            isinstance(item, str) for item in value
+        ):
+            errors.append(f"{prefix}.{field} must be an array of strings")
+    return errors
+
+
 def validate(history: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     required = {
@@ -34,9 +100,16 @@ def validate(history: dict[str, Any]) -> list[str]:
     top_k = history.get("top_k")
     if not isinstance(top_k, int) or isinstance(top_k, bool) or top_k < 1:
         errors.append("top_k must be a positive integer")
-    if not isinstance(history.get("instruments"), list):
+    instruments = history.get("instruments")
+    if not isinstance(instruments, list):
         errors.append("instruments must be an array")
-    if not isinstance(history.get("dropped_from_top_k"), list):
+    else:
+        for index, row in enumerate(instruments):
+            errors.extend(_validate_row(row, index))
+    dropped = history.get("dropped_from_top_k")
+    if not isinstance(dropped, list) or not all(
+        isinstance(symbol, str) for symbol in dropped
+    ):
         errors.append("dropped_from_top_k must be an array")
     return errors
 

--- a/.github/workflows/daily-market-analysis.yml
+++ b/.github/workflows/daily-market-analysis.yml
@@ -131,6 +131,22 @@ jobs:
         run: |
           uv run python .agents/skills/market-analysis/scripts/validate_analysis.py \
             --input "data/analysis/${DATE}.json"
+      - name: Generate score history
+        if: steps.symbols.outputs.symbols != ''
+        env:
+          DATE: ${{ steps.date.outputs.date }}
+        run: |
+          uv run python .agents/skills/market-analysis/scripts/generate_history.py \
+            --input "data/analysis/${DATE}.json" \
+            --analysis-dir data/analysis \
+            --output data/history
+      - name: Validate score history
+        if: steps.symbols.outputs.symbols != ''
+        env:
+          DATE: ${{ steps.date.outputs.date }}
+        run: |
+          uv run python .agents/skills/market-analysis/scripts/validate_history.py \
+            --input "data/history/${DATE}.json"
       - name: Generate Hugo report
         if: steps.symbols.outputs.symbols != ''
         env:
@@ -138,6 +154,7 @@ jobs:
         run: |
           uv run python .agents/skills/market-analysis/scripts/generate_report.py \
             --input "data/analysis/${DATE}.json" \
+            --history "data/history/${DATE}.json" \
             --output content/results/
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -162,7 +179,7 @@ jobs:
           gh auth setup-git
           git fetch origin "$BRANCH" 2>/dev/null || true
           git checkout -B "$BRANCH"
-          git add data/analysis/ content/results/
+          git add data/analysis/ data/history/ content/results/
           if git diff --cached --quiet; then
             echo "No changes to commit."
             echo "pr_url=" >> "$GITHUB_OUTPUT"
@@ -192,6 +209,7 @@ jobs:
         run: |
           uv run python .agents/skills/market-analysis/scripts/notify_slack.py \
             --artifact "data/analysis/${DATE}.json" \
+            --history "data/history/${DATE}.json" \
             --pr-url "${PR_URL}"
       - name: Notify Slack (failure)
         if: failure() && env.SLACK_NOTIFICATIONS_ENABLED == 'true'

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -188,7 +188,8 @@ versioned `data/history/YYYY-MM-DD.json` artifact. Version 1.0.0 records previou
 rank/score, deltas (positive rank delta means improvement), new and dropped top-5
 signals, consecutive reliable and top-5 available-report counts, and added/removed
 risk gates. Missing calendar dates are intentionally ignored. The format reference
-is `data/schema/history.schema.json`; numeric history remains separate from OKF.
+is `data/schema/history.schema.json`; candidates with a different configured bar
+interval are excluded, and numeric history remains separate from OKF.
 
 ### Output format
 

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -182,6 +182,14 @@ uv run .agents/skills/market-analysis/scripts/generate_report.py \
 
 The script reads the JSON artifact produced by `market_analysis.py generate` and writes a Hugo-compatible Markdown file to `content/results/YYYY-MM-DD-market-analysis.md`.
 
+Before report generation, `generate_history.py` reads the current and all earlier
+available `data/analysis/YYYY-MM-DD.json` files and writes the deterministic,
+versioned `data/history/YYYY-MM-DD.json` artifact. Version 1.0.0 records previous
+rank/score, deltas (positive rank delta means improvement), new and dropped top-5
+signals, consecutive reliable and top-5 available-report counts, and added/removed
+risk gates. Missing calendar dates are intentionally ignored. The format reference
+is `data/schema/history.schema.json`; numeric history remains separate from OKF.
+
 ### Output format
 
 The report includes:
@@ -189,6 +197,7 @@ The report includes:
 - TOML front matter: title, date, draft status, summary, ticker symbols, market regime, scoring metadata
 - Market regime section
 - Top opportunities (up to 5 reliable instruments)
+- Changes versus the previous available report and persistent top signals
 - Instruments to avoid (unreliable instruments)
 - Key risks (triggered risk gates)
 - Full instrument scores table
@@ -220,10 +229,11 @@ Pipeline order:
 4. Initialize `data/prices/fetch_status_<interval>.json` and fetch market data from Stooq (1-year lookback), recording per-symbol outcomes in fetch status
 5. Generate JSON analysis artifact (`data/analysis/YYYY-MM-DD.json`) using `--fetch-status`; fail if coverage gates are violated
 6. Validate artifact
-7. Generate Hugo Markdown report (`content/results/YYYY-MM-DD-market-analysis.md`)
-8. Build Hugo site (validation only — catches template or content errors before commit)
-9. Create a pull-request branch `generated/analysis-YYYY-MM-DD` with the artifact and report
-10. A Slack notification is sent with a link to the analysis PR.
+7. Generate score history (`data/history/YYYY-MM-DD.json`)
+8. Generate Hugo Markdown report (`content/results/YYYY-MM-DD-market-analysis.md`)
+9. Build Hugo site (validation only — catches template or content errors before commit)
+10. Create a pull-request branch `generated/analysis-YYYY-MM-DD` with both artifacts and the report
+11. A Slack notification summarizes new/persistent signals and risk-gate changes and links to the analysis PR.
 
 ### Manual dispatch
 

--- a/data/schema/history.schema.json
+++ b/data/schema/history.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AIMS score-history artifact",
+  "artifact_version": "1.0.0",
+  "required_top_keys": [
+    "version",
+    "analysis_date",
+    "previous_analysis_date",
+    "top_k",
+    "instruments",
+    "dropped_from_top_k"
+  ],
+  "notes": {
+    "rank_delta": "Previous rank minus current rank; positive values indicate improvement.",
+    "consecutive_reports": "Counts consecutive available artifacts, not calendar days."
+  }
+}

--- a/data/schema/history.schema.json
+++ b/data/schema/history.schema.json
@@ -12,6 +12,7 @@
   ],
   "notes": {
     "rank_delta": "Previous rank minus current rank; positive values indicate improvement.",
-    "consecutive_reports": "Counts consecutive available artifacts, not calendar days."
+    "consecutive_reports": "Counts consecutive available artifacts, not calendar days.",
+    "instrument_rows": "Rows require symbol, current/previous ranks and scores, deltas, reliability/top-k booleans, consecutive report counts, and added/removed risk-gate string arrays."
   }
 }

--- a/tests/golden/2024-01-01-market-analysis.md
+++ b/tests/golden/2024-01-01-market-analysis.md
@@ -20,6 +20,10 @@ git_commit = "abc1234"
 - **^SPX** — score 72.5, 20d return +5.3%, RSI14=62. 20d up +5.3%; above MA20 by 2.1%; RSI14=62
 - **^DJI** — score 58.3, 20d return +2.1%, RSI14=55. 20d up +2.1%; above MA20 by 0.8%; RSI14=55
 
+## Signal History
+
+_No previous analysis artifact available._
+
 ## Instruments to Avoid
 
 These instruments have quality or risk issues and are excluded from ranking:

--- a/tests/test_generate_history.py
+++ b/tests/test_generate_history.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+SCRIPT = (
+    Path(__file__).parents[1]
+    / ".agents/skills/market-analysis/scripts/generate_history.py"
+)
+
+
+@pytest.fixture(scope="module")
+def gh() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("generate_history", SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _artifact(date: str, rows: list[dict[str, Any]]) -> dict[str, Any]:
+    instruments = []
+    for rank, row in enumerate(rows, 1):
+        instruments.append({
+            "symbol": row["symbol"],
+            "rank": row.get("rank", rank),
+            "score": row.get("score", 100 - rank),
+            "is_reliable": row.get("reliable", True),
+            "risk_gates": row.get("gates", []),
+        })
+    return {
+        "metadata": {"generated_at": f"{date}T00:00:00+00:00"},
+        "instruments": instruments,
+    }
+
+
+def test_first_artifact(gh: ModuleType) -> None:
+    result = gh.build_history([_artifact("2024-01-01", [{"symbol": "A"}])], 1)
+    assert result["previous_analysis_date"] is None
+    assert result["instruments"][0]["previous_rank"] is None
+    assert result["instruments"][0]["new_top_k"] is False
+    assert result["instruments"][0]["consecutive_reliable_reports"] == 1
+
+
+def test_changes_persistence_and_missing_date(gh: ModuleType) -> None:
+    old = _artifact(
+        "2024-01-01",
+        [
+            {"symbol": "A", "score": 80, "gates": ["stale_data"]},
+            {"symbol": "B", "score": 70},
+            {"symbol": "C", "score": 60},
+        ],
+    )
+    current = _artifact(
+        "2024-01-03",
+        [
+            {"symbol": "B", "score": 85},
+            {"symbol": "C", "score": 72},
+            {"symbol": "A", "score": 65, "gates": ["high_volatility"]},
+            {"symbol": "D", "score": 50},
+        ],
+    )
+    result = gh.build_history([current, old], 2)
+    rows = {row["symbol"]: row for row in result["instruments"]}
+    assert result["previous_analysis_date"] == "2024-01-01"
+    assert rows["B"]["rank_delta"] == 1
+    assert rows["B"]["score_delta"] == 15
+    assert rows["B"]["consecutive_top_k_reports"] == 2
+    assert rows["C"]["new_top_k"] is True
+    assert rows["A"]["risk_gates_added"] == ["high_volatility"]
+    assert rows["A"]["risk_gates_removed"] == ["stale_data"]
+    assert rows["D"]["previous_score"] is None
+    assert result["dropped_from_top_k"] == ["A"]
+
+
+def test_unreliable_breaks_streak(gh: ModuleType) -> None:
+    artifacts = [
+        _artifact("2024-01-01", [{"symbol": "A"}]),
+        _artifact("2024-01-02", [{"symbol": "A", "reliable": False}]),
+        _artifact("2024-01-03", [{"symbol": "A"}]),
+    ]
+    row = gh.build_history(artifacts, 1)["instruments"][0]
+    assert row["consecutive_reliable_reports"] == 1
+    assert row["consecutive_top_k_reports"] == 1
+
+
+@pytest.mark.parametrize(
+    ("artifacts", "top_k", "message"),
+    [([], 1, "at least one"), ([{}], 0, "top_k"), ([{}], 1, "generated_at")],
+)
+def test_invalid_input(
+    gh: ModuleType,
+    artifacts: list[dict[str, Any]],
+    top_k: int,
+    message: str,
+) -> None:
+    exception = TypeError if message == "generated_at" else ValueError
+    with pytest.raises(exception, match=message):
+        gh.build_history(artifacts, top_k)
+
+
+def test_invalid_instruments_and_duplicate_dates(gh: ModuleType) -> None:
+    bad = {"metadata": {"generated_at": "2024-01-01T00:00:00Z"}}
+    with pytest.raises(TypeError, match="instruments"):
+        gh.build_history([bad])
+    artifact = _artifact("2024-01-01", [])
+    with pytest.raises(ValueError, match="unique"):
+        gh.build_history([artifact, artifact])
+
+
+def test_generate_history_and_main(gh: ModuleType, tmp_path: Path) -> None:
+    analysis = tmp_path / "analysis"
+    analysis.mkdir()
+    old_path = analysis / "2024-01-01.json"
+    current_path = analysis / "2024-01-03.json"
+    future_path = analysis / "2024-01-04.json"
+    old_path.write_text(json.dumps(_artifact("2024-01-01", [{"symbol": "A"}])))
+    current_path.write_text(json.dumps(_artifact("2024-01-03", [{"symbol": "A"}])))
+    future_path.write_text(json.dumps(_artifact("2024-01-04", [{"symbol": "A"}])))
+    output = tmp_path / "history"
+    result = gh.generate_history(current_path, analysis, output, 1)
+    assert result == output / "2024-01-03.json"
+    assert json.loads(result.read_text())["previous_analysis_date"] == "2024-01-01"
+    assert (
+        gh.main([
+            "--input",
+            str(current_path),
+            "--analysis-dir",
+            str(analysis),
+            "--output",
+            str(output),
+        ])
+        == 0
+    )
+    assert gh.main(["--input", str(tmp_path / "missing.json")]) == 1
+
+
+def test_main_bad_json(gh: ModuleType, tmp_path: Path) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text("{")
+    assert gh.main(["--input", str(bad)]) == 1

--- a/tests/test_generate_history.py
+++ b/tests/test_generate_history.py
@@ -39,7 +39,10 @@ def _artifact(date: str, rows: list[dict[str, Any]]) -> dict[str, Any]:
             "risk_gates": row.get("gates", []),
         })
     return {
-        "metadata": {"generated_at": f"{date}T00:00:00+00:00"},
+        "metadata": {
+            "generated_at": f"{date}T00:00:00+00:00",
+            "config": {"interval": "d"},
+        },
         "instruments": instruments,
     }
 
@@ -110,12 +113,29 @@ def test_invalid_input(
 
 
 def test_invalid_instruments_and_duplicate_dates(gh: ModuleType) -> None:
-    bad = {"metadata": {"generated_at": "2024-01-01T00:00:00Z"}}
+    bad = {
+        "metadata": {
+            "generated_at": "2024-01-01T00:00:00Z",
+            "config": {"interval": "d"},
+        }
+    }
     with pytest.raises(TypeError, match="instruments"):
         gh.build_history([bad])
     artifact = _artifact("2024-01-01", [])
     with pytest.raises(ValueError, match="unique"):
         gh.build_history([artifact, artifact])
+
+
+def test_invalid_or_mixed_intervals(gh: ModuleType) -> None:
+    invalid = _artifact("2024-01-01", [])
+    invalid["metadata"]["config"]["interval"] = "h"
+    with pytest.raises(ValueError, match=r"config\.interval"):
+        gh.build_history([invalid])
+    daily = _artifact("2024-01-01", [])
+    weekly = _artifact("2024-01-02", [])
+    weekly["metadata"]["config"]["interval"] = "w"
+    with pytest.raises(ValueError, match="same interval"):
+        gh.build_history([daily, weekly])
 
 
 def test_generate_history_and_main(gh: ModuleType, tmp_path: Path) -> None:
@@ -124,9 +144,13 @@ def test_generate_history_and_main(gh: ModuleType, tmp_path: Path) -> None:
     old_path = analysis / "2024-01-01.json"
     current_path = analysis / "2024-01-03.json"
     future_path = analysis / "2024-01-04.json"
+    weekly_path = analysis / "2024-01-02.json"
     old_path.write_text(json.dumps(_artifact("2024-01-01", [{"symbol": "A"}])))
     current_path.write_text(json.dumps(_artifact("2024-01-03", [{"symbol": "A"}])))
     future_path.write_text(json.dumps(_artifact("2024-01-04", [{"symbol": "A"}])))
+    weekly = _artifact("2024-01-02", [{"symbol": "B"}])
+    weekly["metadata"]["config"]["interval"] = "w"
+    weekly_path.write_text(json.dumps(weekly))
     output = tmp_path / "history"
     result = gh.generate_history(current_path, analysis, output, 1)
     assert result == output / "2024-01-03.json"

--- a/tests/test_generate_report.py
+++ b/tests/test_generate_report.py
@@ -54,6 +54,45 @@ def test_generate_report_golden(
     assert actual == expected
 
 
+def test_generate_report_with_history(
+    gr: ModuleType, fixture_artifact: dict[str, Any]
+) -> None:
+    history = {
+        "previous_analysis_date": "2023-12-30",
+        "top_k": 2,
+        "instruments": [
+            {
+                "symbol": "^SPX",
+                "new_top_k": True,
+                "consecutive_top_k_reports": 2,
+                "risk_gates_added": [],
+                "risk_gates_removed": ["stale_data"],
+            },
+            {
+                "symbol": "^NDX",
+                "new_top_k": False,
+                "consecutive_top_k_reports": 1,
+                "risk_gates_added": [],
+                "risk_gates_removed": [],
+            },
+        ],
+        "dropped_from_top_k": ["^DJI"],
+    }
+    result = gr.generate_report(fixture_artifact, history)
+    assert "data/history/2024-01-01.json" in result
+    assert "New top-2:** ^SPX" in result
+    assert "Persistent top signals:** ^SPX (2 reports)" in result
+    assert "Dropped from top-2:** ^DJI" in result
+    assert "removed stale_data" in result
+
+
+def test_generate_report_history_without_previous(
+    gr: ModuleType, fixture_artifact: dict[str, Any]
+) -> None:
+    result = gr.generate_report(fixture_artifact, {"previous_analysis_date": None})
+    assert "No previous analysis artifact" in result
+
+
 # ── Edge-case artifact tests ────────────────────────────────────────────────────
 
 
@@ -231,6 +270,17 @@ def test_generate_and_save(gr: ModuleType, tmp_path: Path) -> None:
     result_path = gr.generate_and_save(artifact_path, output_dir)
     assert result_path.exists()
     assert result_path.name == "2024-01-01-market-analysis.md"
+
+
+def test_generate_and_save_with_history(gr: ModuleType, tmp_path: Path) -> None:
+    artifact_path = tmp_path / "analysis.json"
+    artifact_path.write_text(FIXTURE_PATH.read_text())
+    history_path = tmp_path / "history.json"
+    history_path.write_text(json.dumps({"previous_analysis_date": None}))
+    result_path = gr.generate_and_save(
+        artifact_path, tmp_path / "results", history_path
+    )
+    assert "data/history/2024-01-01.json" in result_path.read_text()
 
 
 def test_generate_and_save_file_not_found(gr: ModuleType, tmp_path: Path) -> None:

--- a/tests/test_notify_slack.py
+++ b/tests/test_notify_slack.py
@@ -81,6 +81,35 @@ def test_build_success_payload(
     assert "Bullish" in text
 
 
+def test_build_success_payload_history(
+    ns: ModuleType, fixture_artifact: dict[str, Any]
+) -> None:
+    history = {
+        "previous_analysis_date": "2023-12-30",
+        "instruments": [
+            {
+                "symbol": "^SPX",
+                "new_top_k": True,
+                "consecutive_top_k_reports": 2,
+                "risk_gates_added": ["high_volatility"],
+                "risk_gates_removed": [],
+            },
+            {
+                "symbol": "^NDX",
+                "new_top_k": False,
+                "consecutive_top_k_reports": 1,
+                "risk_gates_added": [],
+                "risk_gates_removed": [],
+            },
+        ],
+    }
+    payload = ns.build_success_payload(fixture_artifact, history=history)
+    text = json.dumps(payload, ensure_ascii=False)
+    assert "new top: ^SPX" in text
+    assert "persistent: ^SPX" in text
+    assert "risk changes: ^SPX" in text
+
+
 def test_build_success_payload_regime_in_blocks(
     ns: ModuleType, fixture_artifact: dict[str, Any]
 ) -> None:
@@ -374,6 +403,42 @@ def test_main_success_mode(ns: ModuleType, tmp_path: Path) -> None:
             "https://example.com/report/",
         ])
     assert result == 0
+
+
+def test_main_success_with_history(ns: ModuleType, tmp_path: Path) -> None:
+    artifact_path = tmp_path / "artifact.json"
+    artifact_path.write_text(FIXTURE_PATH.read_text())
+    history_path = tmp_path / "history.json"
+    history_path.write_text(json.dumps({"previous_analysis_date": None}))
+    mock_response = MagicMock()
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=False)
+    with (
+        patch.dict("os.environ", {"SLACK_WEBHOOK_URL": "https://hooks.slack.com/test"}),
+        patch("urllib.request.urlopen", return_value=mock_response),
+    ):
+        assert (
+            ns.main(["--artifact", str(artifact_path), "--history", str(history_path)])
+            == 0
+        )
+
+
+@pytest.mark.parametrize("content", [None, "{"])
+def test_main_invalid_history(
+    ns: ModuleType, tmp_path: Path, content: str | None
+) -> None:
+    artifact_path = tmp_path / "artifact.json"
+    artifact_path.write_text(FIXTURE_PATH.read_text())
+    history_path = tmp_path / "history.json"
+    if content is not None:
+        history_path.write_text(content)
+    with patch.dict(
+        "os.environ", {"SLACK_WEBHOOK_URL": "https://hooks.slack.com/test"}
+    ):
+        assert (
+            ns.main(["--artifact", str(artifact_path), "--history", str(history_path)])
+            == 1
+        )
 
 
 def test_main_failure_mode(ns: ModuleType) -> None:

--- a/tests/test_validate_history.py
+++ b/tests/test_validate_history.py
@@ -39,10 +39,29 @@ def _valid() -> dict[str, object]:
     }
 
 
+def _valid_row() -> dict[str, object]:
+    return {
+        "symbol": "A",
+        "current_rank": 1,
+        "previous_rank": None,
+        "rank_delta": None,
+        "current_score": 80.0,
+        "previous_score": None,
+        "score_delta": None,
+        "is_reliable": True,
+        "new_top_k": False,
+        "consecutive_reliable_reports": 1,
+        "consecutive_top_k_reports": 1,
+        "risk_gates_added": [],
+        "risk_gates_removed": [],
+    }
+
+
 def test_validate_valid_and_null_previous(vh: ModuleType) -> None:
     assert vh.validate(_valid()) == []
     artifact = _valid()
     artifact["previous_analysis_date"] = None
+    artifact["instruments"] = [_valid_row()]
     assert vh.validate(artifact) == []
 
 
@@ -56,6 +75,28 @@ def test_validate_errors(vh: ModuleType) -> None:
         "dropped_from_top_k": {},
     })
     assert len(errors) == 6
+
+
+def test_validate_malformed_rows(vh: ModuleType) -> None:
+    artifact = _valid()
+    malformed = dict.fromkeys(_valid_row(), True)
+    malformed["risk_gates_added"] = [1]
+    malformed["risk_gates_removed"] = "gate"
+    artifact["instruments"] = ["bad", {}, malformed]
+    artifact["dropped_from_top_k"] = [1]
+    errors = vh.validate(artifact)
+    assert "instruments[0] must be an object" in errors
+    assert any("instruments[1] missing keys" in error for error in errors)
+    assert any(".symbol must be a string" in error for error in errors)
+    assert any(".current_rank must be a positive integer" in error for error in errors)
+    assert any(".previous_rank must be an integer or null" in error for error in errors)
+    assert any(".current_score must be a number" in error for error in errors)
+    assert any(".previous_score must be a number or null" in error for error in errors)
+    assert any(".is_reliable must be a boolean" in error for error in errors)
+    assert any(
+        ".risk_gates_added must be an array of strings" in error for error in errors
+    )
+    assert "dropped_from_top_k must be an array" in errors
 
 
 def test_main(vh: ModuleType, tmp_path: Path) -> None:

--- a/tests/test_validate_history.py
+++ b/tests/test_validate_history.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+SCRIPTS = Path(__file__).parents[1] / ".agents/skills/market-analysis/scripts"
+
+
+@pytest.fixture(scope="module")
+def vh() -> ModuleType:
+    sys.path.insert(0, str(SCRIPTS))
+    spec = importlib.util.spec_from_file_location(
+        "validate_history", SCRIPTS / "validate_history.py"
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _valid() -> dict[str, object]:
+    return {
+        "version": "1.0.0",
+        "analysis_date": "2024-01-02",
+        "previous_analysis_date": "2024-01-01",
+        "top_k": 5,
+        "instruments": [],
+        "dropped_from_top_k": [],
+    }
+
+
+def test_validate_valid_and_null_previous(vh: ModuleType) -> None:
+    assert vh.validate(_valid()) == []
+    artifact = _valid()
+    artifact["previous_analysis_date"] = None
+    assert vh.validate(artifact) == []
+
+
+def test_validate_errors(vh: ModuleType) -> None:
+    errors = vh.validate({
+        "version": "2",
+        "analysis_date": 1,
+        "previous_analysis_date": 2,
+        "top_k": True,
+        "instruments": {},
+        "dropped_from_top_k": {},
+    })
+    assert len(errors) == 6
+
+
+def test_main(vh: ModuleType, tmp_path: Path) -> None:
+    valid = tmp_path / "valid.json"
+    valid.write_text(json.dumps(_valid()))
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text("{")
+    structurally_invalid = tmp_path / "structurally-invalid.json"
+    structurally_invalid.write_text("{}")
+    assert vh.main(["--input", str(valid)]) == 0
+    assert vh.main(["--input", str(invalid)]) == 1
+    assert vh.main(["--input", str(structurally_invalid)]) == 1
+    assert vh.main(["--input", str(tmp_path / "missing.json")]) == 1


### PR DESCRIPTION
## Summary

- generate versioned `data/history/YYYY-MM-DD.json` artifacts from current and prior available analysis artifacts
- track score/rank deltas, top-k entry/dropout and persistence, reliability persistence, and risk-gate transitions
- validate history artifacts before surfacing them in Hugo reports and Slack notifications
- document the format and daily workflow

The separate history artifact keeps `data/analysis/` stable and remains authoritative numeric input separate from OKF and generated knowledge content. Missing calendar dates are handled by comparing consecutive available reports.

## Examples

Reports now include a compact **Signal History** section showing the previous available report, new and persistent top signals, dropouts, and risk-gate transitions. Slack adds a compact field such as `new top: ^SPX; persistent: ^SPX; risk changes: ^NDX`.

## Validation

- `.agents/skills/local-qa/scripts/qa.sh`
- 352 tests, 100% branch coverage
- Hugo, actionlint, yamllint, zizmor, and checkov passed

Closes #42