### PR TITLE
fix: dedupe risk gates and remove dead code found via live analysis run

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -41,11 +41,11 @@ Examples: `^GSPC` (S&P 500), `^DJI` (Dow Jones), `^NDX` (NASDAQ 100), `^N225` (N
 
 AIMS routes market-data fetches through a provider registry defined in `src/aims/market_analysis.py`. Registered providers:
 
-| Provider   | Supported intervals | Notes                                       |
-| ---------- | -------------------- | -------------------------------------------- |
-| `yfinance` | `d`, `w`, `m`       | Yahoo Finance via the `yfinance` library; default provider |
+| Provider   | Supported intervals | Notes                                                       |
+| ---------- | ------------------- | ----------------------------------------------------------- |
+| `yfinance` | `d`, `w`, `m`       | Yahoo Finance via the `yfinance` library; default provider  |
 | `stooq`    | `d`, `w`, `m`       | Free CSV download; registered fallback/alternative provider |
-| `csv`      | `d`, `w`, `m`       | Reads pre-downloaded CSVs from data dir     |
+| `csv`      | `d`, `w`, `m`       | Reads pre-downloaded CSVs from data dir                     |
 
 Pass `--provider <name>` to `init-fetch-status`, `fetch`, or `generate`. The default is `yfinance`.
 
@@ -216,6 +216,7 @@ The market regime label is derived from the median composite score of reliable i
 - Volatility and drawdown are historical. They do not predict future risk.
 - Missing or stale data can distort percentile ranks when the universe is small.
 - Short history (< 60 bars) triggers the `insufficient_history` gate and excludes an instrument from reliable rankings.
+- Score/rank deltas in `data/history/` and the Signal History report section compare each instrument only against the most recent prior report. If the analyzed instrument universe changes between reports (e.g. a mapping addition or removal), deltas reflect both genuine market moves and the change in cross-sectional population, and should be interpreted with care until the universe is stable across both dates.
 
 ---
 
@@ -295,14 +296,14 @@ Step 10 calls `gh pr merge --auto --squash --delete-branch`, which merges the PR
 
 The workflow supports `workflow_dispatch` with optional inputs:
 
-| Input                 | Default    | Description                                                                |
-| --------------------- | ---------- | --------------------------------------------------------------------------- |
-| `analysis_date`       | Today UTC  | Override the analysis date (YYYY-MM-DD)                                   |
-| `interval`            | `d`        | Price bar interval: `d` (daily), `w` (weekly), `m` (monthly)              |
-| `dry_run`             | `false`    | When `true`, skips PR creation, auto-merge, and Slack success notification |
-| `min_success_ratio`   | `0.8`      | Minimum symbol fetch success ratio for coverage gate                      |
+| Input                 | Default    | Description                                                                                       |
+| --------------------- | ---------- | ------------------------------------------------------------------------------------------------- |
+| `analysis_date`       | Today UTC  | Override the analysis date (YYYY-MM-DD)                                                           |
+| `interval`            | `d`        | Price bar interval: `d` (daily), `w` (weekly), `m` (monthly)                                      |
+| `dry_run`             | `false`    | When `true`, skips PR creation, auto-merge, and Slack success notification                        |
+| `min_success_ratio`   | `0.8`      | Minimum symbol fetch success ratio for coverage gate                                              |
 | `max_missing_symbols` | `4`        | Maximum allowed missing symbols for coverage gate (scaled for the ~20-instrument mapped universe) |
-| `provider`            | `yfinance` | Market data provider: `yfinance` or `stooq`                               |
+| `provider`            | `yfinance` | Market data provider: `yfinance` or `stooq`                                                       |
 
 ### Deployment gate
 
@@ -310,7 +311,7 @@ GitHub Pages deployment is handled by `ci.yml` (`hugo-deploy-to-gh-pages` job), 
 
 ### Rollback
 
-If a published report or artifact needs to be removed, see [Delete a published report](#delete-a-published-report) in Manual recovery. Reverting a bad *code* change (as opposed to a bad daily *report*) is a normal `git revert` on `main`, gated by the same CI checks as any other change.
+If a published report or artifact needs to be removed, see [Delete a published report](#delete-a-published-report) in Manual recovery. Reverting a bad _code_ change (as opposed to a bad daily _report_) is a normal `git revert` on `main`, gated by the same CI checks as any other change.
 
 ---
 

--- a/src/aims/mappings.py
+++ b/src/aims/mappings.py
@@ -169,10 +169,8 @@ def validate_mappings(
             for row in reader:
                 b = row.get("broker", "").strip()
                 n = row.get("broker_instrument_name", "").strip()
-                t = row.get("tradable", "").strip().lower()
                 if b and n:
                     mapped_broker_instruments.add((b, n))
-                _ = t
         unmapped = cfd_instruments - mapped_broker_instruments
         for broker, name in sorted(unmapped):
             warnings.append(

--- a/src/aims/market_analysis.py
+++ b/src/aims/market_analysis.py
@@ -886,13 +886,15 @@ def _collect_risk_gates(
     gates: list[str] = []
     for issue in report.issues:
         if "stale" in issue:
-            gates.append(RISK_GATE_STALE)
+            gate = RISK_GATE_STALE
         elif "insufficient" in issue:
-            gates.append(RISK_GATE_INSUFFICIENT)
+            gate = RISK_GATE_INSUFFICIENT
         elif "missing" in issue or "gap" in issue:
-            gates.append(RISK_GATE_MISSING_BARS)
+            gate = RISK_GATE_MISSING_BARS
         else:
-            gates.append(RISK_GATE_MALFORMED)
+            gate = RISK_GATE_MALFORMED
+        if gate not in gates:
+            gates.append(gate)
     if features.vol_20d is not None and features.vol_20d > _HIGH_VOL_THRESHOLD:
         gates.append(RISK_GATE_HIGH_VOL)
     return gates

--- a/src/aims/reports.py
+++ b/src/aims/reports.py
@@ -89,7 +89,6 @@ def _build_front_matter(
     reliable_scores = [float(i["score"]) for i in reliable if "score" in i]
     regime = _market_regime(reliable_scores)
     n_reliable = len(reliable)
-    total = len(instruments)
 
     all_symbols = sorted(str(i.get("symbol", "")) for i in instruments)
     symbols_toml = ", ".join(f'"{_toml_escape(s)}"' for s in all_symbols)
@@ -124,7 +123,6 @@ def _build_front_matter(
         f'git_commit = "{_toml_escape(git_commit)}"',
         "+++",
     ]
-    _ = total  # referenced in body, not front matter
     return "\n".join(lines)
 
 

--- a/tests/test_market_analysis.py
+++ b/tests/test_market_analysis.py
@@ -572,6 +572,14 @@ def test_collect_gates_malformed(ma: ModuleType) -> None:
     assert ma.RISK_GATE_MALFORMED in gates
 
 
+def test_collect_gates_dedupes_same_category(ma: ModuleType) -> None:
+    gates = ma._collect_risk_gates(
+        _report(ma, ["malformed OHLC at index 0", "duplicate timestamps detected"]),
+        _empty_features(ma),
+    )
+    assert gates == [ma.RISK_GATE_MALFORMED]
+
+
 def test_collect_gates_high_vol(ma: ModuleType) -> None:
     feats = ma.InstrumentFeatures(
         ret_1d=None,


### PR DESCRIPTION
## Summary

I ran the AIMS market-analysis pipeline end-to-end against live data (not fixtures) to find real code/analysis-quality gaps, then made minimal, targeted fixes. No architecture, data contracts, tests, or the informational-only disclaimer were changed in a breaking way.

### What was run

- Fetched 1 year of daily OHLCV via `yfinance` for all 20 instruments currently in `data/mappings/canonical_instrument_mappings.csv` (`provider=yfinance`, `interval=d`) — the universe `data/analysis/2026-07-02.json` will start using once tomorrow's daily workflow run picks up the recently-expanded mapping (PR #85 merged after today's run).
- Generated a full analysis artifact (`generate --mapping ...`), a score-history artifact, and a Hugo report end-to-end from that live data — including through a synthetic transition from yesterday's 5-instrument universe to today's 20-instrument universe, to exercise the exact situation the real pipeline will hit tomorrow.
- Ran `backtest.py` with `--horizons 1,5,20,60` over the fetched data (201 observations, 2025-09-23 to 2026-07-01).

### Market findings (informational only — not investment advice)

- Coverage was 20/20 (100%); no risk gates triggered on any instrument.
- Top-ranked by composite score: DAX (76.0), Dow (73.5), Euro Stoxx 50 (73.5); bottom-ranked: WTI/Brent crude (6.5 each, on ~-30% 20d/-40% 60d drawdowns).
- Backtest: the composite score bucket ordering was positively associated with forward returns at 1d/5d/20d horizons (top score bucket outperformed the bottom bucket), but **inverted at the 60d horizon** (bucket 1 avg +5.5% vs. bucket 4 avg +9.9%) in this ~9-month sample. This is consistent with OPERATIONS.md's existing caveat that "small samples and the selected universe can materially distort results" — flagging it here as an observed data point, not a methodology change.
- Regenerating history/report across the 5→20 instrument transition confirmed the pipeline handles it without errors, but score/rank deltas conflate real market moves with the change in cross-sectional population (e.g. DAX's reported score delta of +36.0 is partly an artifact of the larger universe). Documented as a known limitation (see below) rather than "fixed," since correcting for universe-composition changes would be new scope.

### Code changes

1. **`src/aims/market_analysis.py`** — `_collect_risk_gates` could append the same risk-gate string twice when two distinct data-quality issues (e.g. a malformed-OHLC issue and a duplicate-timestamp issue) both fell through to the same gate category. That inflates per-gate instrument counts in the report's "Key Risks" section. Now dedupes while preserving order. Added `test_collect_gates_dedupes_same_category`.
2. **`src/aims/reports.py`** / **`src/aims/mappings.py`** — removed two dead local variables (`total` in `_build_front_matter`, `t` in the mapping-warning loop) that were computed and then discarded via `_ = x` instead of being used or removed.
3. **`OPERATIONS.md`** — added a limitations bullet documenting that Signal History deltas compare only against the most recent prior report, so a universe change between reports shows up as score/rank movement that isn't purely a market move.

None of these change the artifact schema, CLI flags, or report structure.

## Validation

- `uv run pytest` — 493 passed, 100% branch coverage maintained (required by this repo).
- `uv run ruff format --check .` / `uv run ruff check .` — clean.
- `uv run pyright .` — 0 errors.
- `hugo --gc --minify` — site builds cleanly.
- `.agents/skills/local-qa/scripts/qa.sh` (full suite incl. `zizmor`, `actionlint`, `yamllint`, `checkov`) — all clean.
- Manually ran `fetch` → `generate` → `generate_history` → `generate_report` → `validate_analysis`/`validate_history` against live data in a scratch directory (not committed) to confirm the full pipeline works with the real, expanded universe.

## Remaining risks / follow-ups (not addressed here, out of scope for a minimal fix)

- Score/rank deltas are not adjusted for universe-composition changes (documented, not code-fixed — would be new scope).
- The 60-day horizon inversion observed in this backtest is based on ~9 months of daily data across a small, correlated instrument set; OPERATIONS.md already documents this class of limitation generically. No scoring-methodology change was made based on a single small-sample backtest, to avoid overfitting.
- Live fetched price data and scratch analysis/backtest artifacts used for this investigation were not committed (matches existing practice — `data/prices/` and `data/backtests/` have never been tracked in this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)