### PR TITLE
fix(data): include individual stocks in daily analysis universe

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -78,7 +78,7 @@ The master is validated against `data/schema/cfd_instruments.schema.json` after 
 | ------------------------ | -------- | ------------------------------------------------------------ |
 | `canonical_id`           | Yes      | Stable lowercase identifier, e.g. `spx`                      |
 | `display_name`           | Yes      | Human-readable name shown in reports, e.g. `S&P 500`         |
-| `asset_class`            | Yes      | `equity_index`, `commodity`, etc.                            |
+| `asset_class`            | Yes      | `equity_index`, `equity`, `commodity`, etc.                  |
 | `broker`                 | No       | Broker name; leave blank if no broker link is needed         |
 | `broker_instrument_name` | No       | Broker CFD product name (used for CFD reference validation)  |
 | `broker_ticker_symbol`   | No       | Broker's own ticker symbol                                   |
@@ -105,6 +105,8 @@ Exits 0 when clean; exits 1 on hard errors (missing columns, unknown provider, u
 1. Add one or more rows to `canonical_instrument_mappings.csv` — one per provider/interval combination to analyze, plus one per broker CFD pairing. A row with `provider=yfinance` and `provider_interval=d` is picked up automatically by the daily workflow, which derives its symbol list from this file.
 2. Run the validator above to confirm no errors.
 3. Run `uv run pytest` to confirm 100% coverage still holds.
+
+**Individual stocks:** Individual stocks are configured the same way as indices and commodities — through rows in `canonical_instrument_mappings.csv` with `asset_class=equity`. There is no separate stock symbol list; the daily workflow's `yfinance`/`d` universe automatically includes any stock row added to this file (e.g. `AAPL`, `MSFT`, `NVDA`). A `broker`/`broker_instrument_name` pairing is optional — leave those columns blank for stocks with no CFD broker backing (e.g. Japanese large caps not offered as CFDs by GMO Click Securities or Rakuten Securities).
 
 **Connecting new CFD entries to canonical mappings:** After `update-cfd-instruments` adds new rows to `data/cfd_instruments.csv`, the mapping validator warns about tradable CFD entries with no mapping row. Add the corresponding canonical mapping rows to clear those warnings.
 

--- a/content/knowledge/concepts/data-sources.md
+++ b/content/knowledge/concepts/data-sources.md
@@ -25,6 +25,8 @@ Authoritative market and instrument data sources used by AIMS and the boundaries
 
 AIMS fetches daily OHLCV history from Yahoo Finance (`yfinance` library, default provider) with Stooq registered as a fallback/alternative provider. The daily workflow derives its symbol universe from `data/mappings/canonical_instrument_mappings.csv` for the configured provider and interval — there is no separate provider symbol list file.
 
+Individual stocks are configured the same way as equity indices and commodities: as rows in `canonical_instrument_mappings.csv` with `asset_class=equity`. Adding a stock row with `provider=yfinance` and `provider_interval=d` is sufficient for the daily workflow to fetch and score it — no separate stock symbol list exists.
+
 The CFD instrument master is a separate data source maintained in `data/cfd_instruments.csv`. It is refreshed by the weekly updater workflow and validated before the daily market analysis workflow runs.
 
 ## Source-of-truth boundary

--- a/data/mappings/canonical_instrument_mappings.csv
+++ b/data/mappings/canonical_instrument_mappings.csv
@@ -78,6 +78,6 @@ jpm,JPMorgan Chase & Co.,equity,楽天証券,JPモルガン・チェース,JPM,y
 unh,UnitedHealth Group Inc.,equity,GMOクリック証券,ユナイテッドヘルス・グループ （NYSE）,UNH,yfinance,UNH,d,true,GMO CFD tracks UnitedHealth Group common stock; Yahoo Finance UNH is the underlying equity
 xom,Exxon Mobil Corporation,equity,GMOクリック証券,エクソン・モービル （NYSE）,XOM,yfinance,XOM,d,true,GMO CFD tracks Exxon Mobil common stock; Yahoo Finance XOM is the underlying equity
 xom,Exxon Mobil Corporation,equity,楽天証券,エクソンモービル,XOM,yfinance,XOM,d,true,Rakuten CFD tracks Exxon Mobil common stock
-toyota,Toyota Motor Corporation,equity,,,,yfinance,7203.T,d,true,No CFD broker mapping available; Yahoo Finance 7203.T is the Tokyo Stock Exchange listing
-sony,Sony Group Corporation,equity,,,,yfinance,6758.T,d,true,No CFD broker mapping available; Yahoo Finance 6758.T is the Tokyo Stock Exchange listing
-mufg,Mitsubishi UFJ Financial Group Inc.,equity,,,,yfinance,8306.T,d,true,No CFD broker mapping available; Yahoo Finance 8306.T is the Tokyo Stock Exchange listing
+toyota,Toyota Motor Corporation,equity,,,,yfinance,7203.T,d,false,No broker CFD offering; not tradable at any mapped broker; Yahoo Finance 7203.T is the Tokyo Stock Exchange listing
+sony,Sony Group Corporation,equity,,,,yfinance,6758.T,d,false,No broker CFD offering; not tradable at any mapped broker; Yahoo Finance 6758.T is the Tokyo Stock Exchange listing
+mufg,Mitsubishi UFJ Financial Group Inc.,equity,,,,yfinance,8306.T,d,false,No broker CFD offering; not tradable at any mapped broker; Yahoo Finance 8306.T is the Tokyo Stock Exchange listing

--- a/data/mappings/canonical_instrument_mappings.csv
+++ b/data/mappings/canonical_instrument_mappings.csv
@@ -59,3 +59,25 @@ soybean,Soybeans,commodity,GMOクリック証券,大豆,ZS,yfinance,ZS=F,d,true,
 soybean,Soybeans,commodity,楽天証券,大豆,ZS,yfinance,ZS=F,d,true,Rakuten CFD tracks soybean futures (ZS/CBOT)
 wheat,Wheat,commodity,GMOクリック証券,小麦,ZW,yfinance,ZW=F,d,true,GMO CFD tracks wheat futures (ZW/CME)
 wheat,Wheat,commodity,楽天証券,小麦,ZW,yfinance,ZW=F,d,true,Rakuten CFD tracks wheat futures (ZW/CBOT)
+aapl,Apple Inc.,equity,GMOクリック証券,Apple （NASDAQ）,AAPL,yfinance,AAPL,d,true,GMO CFD tracks Apple common stock; Yahoo Finance AAPL is the underlying equity
+aapl,Apple Inc.,equity,楽天証券,アップル,AAPL,yfinance,AAPL,d,true,Rakuten CFD tracks Apple common stock
+msft,Microsoft Corporation,equity,GMOクリック証券,マイクロソフト （NASDAQ）,MSFT,yfinance,MSFT,d,true,GMO CFD tracks Microsoft common stock; Yahoo Finance MSFT is the underlying equity
+msft,Microsoft Corporation,equity,楽天証券,マイクロソフト,MSFT,yfinance,MSFT,d,true,Rakuten CFD tracks Microsoft common stock
+nvda,NVIDIA Corporation,equity,GMOクリック証券,NVIDIA （NASDAQ）,NVDA,yfinance,NVDA,d,true,GMO CFD tracks NVIDIA common stock; Yahoo Finance NVDA is the underlying equity
+nvda,NVIDIA Corporation,equity,楽天証券,エヌビディア,NVDA,yfinance,NVDA,d,true,Rakuten CFD tracks NVIDIA common stock
+amzn,Amazon.com Inc.,equity,GMOクリック証券,Amazon （NASDAQ）,AMZN,yfinance,AMZN,d,true,GMO CFD tracks Amazon common stock; Yahoo Finance AMZN is the underlying equity
+amzn,Amazon.com Inc.,equity,楽天証券,アマゾン・ドット・コム,AMZN,yfinance,AMZN,d,true,Rakuten CFD tracks Amazon common stock
+googl,Alphabet Inc. Class A,equity,GMOクリック証券,Alphabet（旧Google） （NASDAQ）,GOOGL,yfinance,GOOGL,d,true,GMO CFD tracks Alphabet Class A common stock; Yahoo Finance GOOGL is the underlying equity
+googl,Alphabet Inc. Class A,equity,楽天証券,アルファベット クラスA,GOOGL,yfinance,GOOGL,d,true,Rakuten CFD tracks Alphabet Class A common stock
+meta,Meta Platforms Inc.,equity,GMOクリック証券,Meta Platforms(旧Facebook) （NASDAQ）,META,yfinance,META,d,true,GMO CFD tracks Meta Platforms common stock; Yahoo Finance META is the underlying equity
+meta,Meta Platforms Inc.,equity,楽天証券,メタ・プラットフォームズ,META,yfinance,META,d,true,Rakuten CFD tracks Meta Platforms common stock
+tsla,Tesla Inc.,equity,GMOクリック証券,テスラ （NASDAQ）,TSLA,yfinance,TSLA,d,true,GMO CFD tracks Tesla common stock; Yahoo Finance TSLA is the underlying equity
+tsla,Tesla Inc.,equity,楽天証券,テスラ,TSLA,yfinance,TSLA,d,true,Rakuten CFD tracks Tesla common stock
+jpm,JPMorgan Chase & Co.,equity,GMOクリック証券,JPモルガン・チェース （NYSE）,JPM,yfinance,JPM,d,true,GMO CFD tracks JPMorgan Chase common stock; Yahoo Finance JPM is the underlying equity
+jpm,JPMorgan Chase & Co.,equity,楽天証券,JPモルガン・チェース,JPM,yfinance,JPM,d,true,Rakuten CFD tracks JPMorgan Chase common stock
+unh,UnitedHealth Group Inc.,equity,GMOクリック証券,ユナイテッドヘルス・グループ （NYSE）,UNH,yfinance,UNH,d,true,GMO CFD tracks UnitedHealth Group common stock; Yahoo Finance UNH is the underlying equity
+xom,Exxon Mobil Corporation,equity,GMOクリック証券,エクソン・モービル （NYSE）,XOM,yfinance,XOM,d,true,GMO CFD tracks Exxon Mobil common stock; Yahoo Finance XOM is the underlying equity
+xom,Exxon Mobil Corporation,equity,楽天証券,エクソンモービル,XOM,yfinance,XOM,d,true,Rakuten CFD tracks Exxon Mobil common stock
+toyota,Toyota Motor Corporation,equity,,,,yfinance,7203.T,d,true,No CFD broker mapping available; Yahoo Finance 7203.T is the Tokyo Stock Exchange listing
+sony,Sony Group Corporation,equity,,,,yfinance,6758.T,d,true,No CFD broker mapping available; Yahoo Finance 6758.T is the Tokyo Stock Exchange listing
+mufg,Mitsubishi UFJ Financial Group Inc.,equity,,,,yfinance,8306.T,d,true,No CFD broker mapping available; Yahoo Finance 8306.T is the Tokyo Stock Exchange listing

--- a/okf/concepts/data-sources.md
+++ b/okf/concepts/data-sources.md
@@ -19,6 +19,8 @@ Authoritative market and instrument data sources used by AIMS and the boundaries
 
 AIMS fetches daily OHLCV history from Yahoo Finance (`yfinance` library, default provider) with Stooq registered as a fallback/alternative provider. The daily workflow derives its symbol universe from `data/mappings/canonical_instrument_mappings.csv` for the configured provider and interval — there is no separate provider symbol list file.
 
+Individual stocks are configured the same way as equity indices and commodities: as rows in `canonical_instrument_mappings.csv` with `asset_class=equity`. Adding a stock row with `provider=yfinance` and `provider_interval=d` is sufficient for the daily workflow to fetch and score it — no separate stock symbol list exists.
+
 The CFD instrument master is a separate data source maintained in `data/cfd_instruments.csv`. It is refreshed by the weekly updater workflow and validated before the daily market analysis workflow runs.
 
 ## Source-of-truth boundary

--- a/tests/test_market_analysis.py
+++ b/tests/test_market_analysis.py
@@ -2389,6 +2389,23 @@ def test_canonical_mapping_contains_spx_dji_ndx(ma: ModuleType) -> None:
     assert "^NDX" in syms
 
 
+def test_canonical_mapping_yfinance_daily_includes_indices_and_stocks(
+    ma: ModuleType,
+) -> None:
+    mapping_path = Path("data/mappings/canonical_instrument_mappings.csv")
+    rows = ma.load_instrument_mappings(mapping_path)
+    syms = ma.symbols_from_mappings(rows, "yfinance", "d")
+
+    assert "^GSPC" in syms
+    assert "^DJI" in syms
+    assert "AAPL" in syms
+    assert "MSFT" in syms
+    assert "NVDA" in syms
+
+    dmap = ma.instrument_display_map(rows, "yfinance", "d")
+    assert dmap["AAPL"]["asset_class"] == "equity"
+
+
 # ── _resolve_symbols_for_generate ─────────────────────────────────────────────
 
 

--- a/tests/test_market_analysis.py
+++ b/tests/test_market_analysis.py
@@ -2190,6 +2190,24 @@ def test_symbols_from_mappings_deduplicates(ma: ModuleType, tmp_path: Path) -> N
     assert syms.count("^SPX") == 1
 
 
+def test_symbols_from_mappings_includes_brokerless_tradable_false(
+    ma: ModuleType, tmp_path: Path
+) -> None:
+    """Brokerless provider-only rows with tradable=false must still be returned."""
+    csv_text = (
+        "canonical_id,display_name,asset_class,broker,broker_instrument_name,"
+        "broker_ticker_symbol,provider,provider_symbol,provider_interval,tradable,notes\n"
+        "spx,S&P 500,equity_index,TestBroker,US500,ES,yfinance,^GSPC,d,true,Backed\n"
+        "toyota,Toyota Motor,equity,,,,yfinance,7203.T,d,false,No broker CFD offering\n"
+    )
+    p = tmp_path / "mixed.csv"
+    p.write_text(csv_text, encoding="utf-8")
+    rows = ma.load_instrument_mappings(p)
+    syms = ma.symbols_from_mappings(rows, "yfinance", "d")
+    assert "^GSPC" in syms, "broker-backed tradable=true row must be included"
+    assert "7203.T" in syms, "brokerless tradable=false row must still be included"
+
+
 def test_instrument_display_map_basic(ma: ModuleType, tmp_path: Path) -> None:
     rows = ma.load_instrument_mappings(_write_mini_mapping(tmp_path))
     dmap = ma.instrument_display_map(rows, "stooq", "d")
@@ -2404,6 +2422,36 @@ def test_canonical_mapping_yfinance_daily_includes_indices_and_stocks(
 
     dmap = ma.instrument_display_map(rows, "yfinance", "d")
     assert dmap["AAPL"]["asset_class"] == "equity"
+
+
+def test_canonical_mapping_brokerless_japanese_stocks_tradable_false_in_universe(
+    ma: ModuleType,
+) -> None:
+    # tradable=false must not exclude rows from symbols_from_mappings
+    mapping_path = Path("data/mappings/canonical_instrument_mappings.csv")
+    rows = ma.load_instrument_mappings(mapping_path)
+
+    brokerless = {
+        r.provider_symbol: r
+        for r in rows
+        if r.canonical_id in {"toyota", "sony", "mufg"}
+    }
+    for sym, row in brokerless.items():
+        assert row.broker == "", f"{sym}: expected blank broker, got {row.broker!r}"
+        assert row.tradable == "false", (
+            f"{sym}: expected tradable=false, got {row.tradable!r}"
+        )
+
+    syms = ma.symbols_from_mappings(rows, "yfinance", "d")
+    assert "7203.T" in syms, (
+        "toyota must remain in yfinance/d universe despite tradable=false"
+    )
+    assert "6758.T" in syms, (
+        "sony must remain in yfinance/d universe despite tradable=false"
+    )
+    assert "8306.T" in syms, (
+        "mufg must remain in yfinance/d universe despite tradable=false"
+    )
 
 
 # ── _resolve_symbols_for_generate ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- The daily workflow derives its symbol universe from \`data/mappings/canonical_instrument_mappings.csv\` via \`symbols_from_mappings(provider, interval)\`, but the mapping only contained equity indices and commodities, so individual stocks were never fetched, scored, or shown in the report.
- Add \`provider=yfinance\`/\`provider_interval=d\` mapping rows (\`asset_class=equity\`) for ten liquid US mega-caps (AAPL, MSFT, NVDA, AMZN, GOOGL, META, TSLA, JPM, UNH, XOM), each linked to its existing GMO Click Securities / Rakuten Securities CFD entry in \`data/cfd_instruments.csv\`, plus three Japanese large caps (Toyota 7203.T, Sony Group 6758.T, Mitsubishi UFJ 8306.T) with no broker link since those aren't offered as CFDs by either broker.
- No new symbol source, no scoring logic changes — the existing mapping-based loading path (\`load_instrument_mappings\` + \`symbols_from_mappings\`) picks these up automatically, matching how the daily workflow (\`.github/workflows/daily-market-analysis.yml\`) already works.
- Documented the stock configuration convention in \`OPERATIONS.md\` and the \`data-sources\` OKF concept (with regenerated Hugo shadow content).
- Fix \`tradable\` semantics: the three brokerless Japanese rows (toyota, sony, mufg) had \`tradable=true\` despite having no mapped broker. Per \`OPERATIONS.md\`, \`tradable\` means "tradable at the broker", so these are corrected to \`tradable=false\`. \`symbols_from_mappings()\` does not filter on \`tradable\`, so these symbols remain in the yfinance/d provider universe.

## Test plan
- [x] \`uv run ruff format .\`
- [x] \`uv run ruff check --fix .\`
- [x] \`uv run pyright .\`
- [x] \`uv run pytest\` (494 passed, 100% branch coverage)
- [x] \`uv run python .agents/skills/update-cfd-instruments/scripts/validate_cfd_instruments.py --input data/cfd_instruments.csv --schema data/schema/cfd_instruments.schema.json\`
- [x] \`uv run .agents/skills/market-analysis/scripts/validate_instrument_mappings.py --input data/mappings/canonical_instrument_mappings.csv --cfd-instruments data/cfd_instruments.csv\` (0 errors; 205 warnings)
- [x] \`uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge --clean\` then \`--check\`
- [x] \`hugo --gc --minify\`
- [x] New test \`test_symbols_from_mappings_includes_brokerless_tradable_false\` asserts brokerless \`tradable=false\` rows are still included by \`symbols_from_mappings()\`
- [x] New test \`test_canonical_mapping_brokerless_japanese_stocks_tradable_false_in_universe\` asserts real CSV rows for toyota/sony/mufg carry \`tradable=false\` and still appear in the yfinance/d symbol universe

🤖 Generated with [Claude Code](https://claude.com/claude-code)