### PR TITLE
fix: resolve daily-analysis pipeline issues #100-#106

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
----
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,31 @@ jobs:
           extended: true
       - run: uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge --check
       - run: hugo --gc --minify
+  validate-market-data-config:
+    if: >
+      github.event_name == 'push'
+      || github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0   # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39   # v8.2.0
+      - run: uv sync
+      - name: Validate CFD instruments
+        run: |
+          uv run python \
+            .agents/skills/update-cfd-instruments/scripts/validate_cfd_instruments.py \
+            --input data/cfd_instruments.csv \
+            --schema data/schema/cfd_instruments.schema.json
+      - name: Validate instrument mappings
+        run: |
+          uv run python \
+            .agents/skills/market-analysis/scripts/validate_instrument_mappings.py \
+            --input data/mappings/canonical_instrument_mappings.csv \
+            --cfd-instruments data/cfd_instruments.csv
   hugo-deploy-to-gh-pages:
     if: >
       github.event_name == 'push'
@@ -88,6 +113,7 @@ jobs:
       - python-lint-and-scan
       - python-test
       - okf-hugo-build
+      - validate-market-data-config
     permissions:
       contents: read
       id-token: write
@@ -98,23 +124,3 @@ jobs:
       go-version: stable
       base-url: https://dceoy.github.io/aims/
       destination-dir: site
-  dependabot-auto-merge:
-    if: >
-      github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
-    needs:
-      - github-actions-lint-and-scan
-      - python-lint-and-scan
-      - python-test
-      - github-codeql-analysis
-      - okf-hugo-build
-    permissions:
-      contents: write
-      pull-requests: write
-      actions: read
-      checks: read
-      statuses: read
-    uses: dceoy/gh-actions-for-devops/.github/workflows/dependabot-auto-merge.yml@main  # zizmor: ignore[unpinned-uses]
-    with:
-      unconditional: true
-    secrets:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/daily-market-analysis.yml
+++ b/.github/workflows/daily-market-analysis.yml
@@ -71,14 +71,32 @@ jobs:
             .agents/skills/update-cfd-instruments/scripts/validate_cfd_instruments.py \
             --input data/cfd_instruments.csv \
             --schema data/schema/cfd_instruments.schema.json
+      - name: Validate instrument mappings
+        run: |
+          uv run python \
+            .agents/skills/market-analysis/scripts/validate_instrument_mappings.py \
+            --input data/mappings/canonical_instrument_mappings.csv \
+            --cfd-instruments data/cfd_instruments.csv
       - name: Set analysis date
         id: date
         run: |
           if [ -n "$ANALYSIS_DATE" ]; then
-            echo "date=$ANALYSIS_DATE" >> "$GITHUB_OUTPUT"
+            DATE="$ANALYSIS_DATE"
           else
-            echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+            DATE="$(date -u +%Y-%m-%d)"
           fi
+          echo "date=$DATE" >> "$GITHUB_OUTPUT"
+          # Interval-aware output stem: "d" (the default/scheduled interval)
+          # keeps the plain date for backward compatibility; "w"/"m" get a
+          # suffix so a manual dispatch cannot collide with the same date's
+          # daily artifact/history/report/PR branch. Mirrors
+          # aims.market_analysis.artifact_interval_suffix.
+          if [ "$INTERVAL" = "d" ]; then
+            STEM="$DATE"
+          else
+            STEM="${DATE}-${INTERVAL}"
+          fi
+          echo "stem=$STEM" >> "$GITHUB_OUTPUT"
       - name: Load symbols
         id: symbols
         env:
@@ -101,10 +119,12 @@ jobs:
           DATE: ${{ steps.date.outputs.date }}
           SYMBOLS: ${{ steps.symbols.outputs.symbols }}
         run: |
-          START=$(python3 -c "
+          START=$(uv run python -c "
           from datetime import datetime, timedelta
+          from aims.policy import fetch_window_days
           d = datetime.strptime('${DATE}', '%Y-%m-%d')
-          print((d - timedelta(days=365)).strftime('%Y-%m-%d'))
+          window = fetch_window_days('${INTERVAL}')
+          print((d - timedelta(days=window)).strftime('%Y-%m-%d'))
           ")
           FETCH_STATUS="data/prices/fetch_status_${INTERVAL}.json"
           uv run python .agents/skills/market-analysis/scripts/market_analysis.py \
@@ -141,34 +161,34 @@ jobs:
       - name: Validate artifact
         if: steps.symbols.outputs.symbols != ''
         env:
-          DATE: ${{ steps.date.outputs.date }}
+          STEM: ${{ steps.date.outputs.stem }}
         run: |
           uv run python .agents/skills/market-analysis/scripts/validate_analysis.py \
-            --input "data/analysis/${DATE}.json"
+            --input "data/analysis/${STEM}.json"
       - name: Generate score history
         if: steps.symbols.outputs.symbols != ''
         env:
-          DATE: ${{ steps.date.outputs.date }}
+          STEM: ${{ steps.date.outputs.stem }}
         run: |
           uv run python .agents/skills/market-analysis/scripts/generate_history.py \
-            --input "data/analysis/${DATE}.json" \
+            --input "data/analysis/${STEM}.json" \
             --analysis-dir data/analysis \
             --output data/history
       - name: Validate score history
         if: steps.symbols.outputs.symbols != ''
         env:
-          DATE: ${{ steps.date.outputs.date }}
+          STEM: ${{ steps.date.outputs.stem }}
         run: |
           uv run python .agents/skills/market-analysis/scripts/validate_history.py \
-            --input "data/history/${DATE}.json"
+            --input "data/history/${STEM}.json"
       - name: Generate Hugo report
         if: steps.symbols.outputs.symbols != ''
         env:
-          DATE: ${{ steps.date.outputs.date }}
+          STEM: ${{ steps.date.outputs.stem }}
         run: |
           uv run python .agents/skills/market-analysis/scripts/generate_report.py \
-            --input "data/analysis/${DATE}.json" \
-            --history "data/history/${DATE}.json" \
+            --input "data/analysis/${STEM}.json" \
+            --history "data/history/${STEM}.json" \
             --output content/results/
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
@@ -186,8 +206,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DATE: ${{ steps.date.outputs.date }}
+          STEM: ${{ steps.date.outputs.stem }}
         run: |
-          BRANCH="generated/analysis-${DATE}"
+          BRANCH="generated/analysis-${STEM}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           gh auth setup-git
@@ -216,30 +237,30 @@ jobs:
             echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
             echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
           fi
-      - name: Enable auto-merge for analysis pull request
+      - name: Merge analysis pull request
         if: steps.pr.outputs.pr_number != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
         run: |
-          # Merges automatically once required status checks (lint, type check,
-          # tests, Hugo build) pass. If branch protection requires review, the
-          # PR waits for that review instead of merging — no gate is bypassed.
-          # Requires "Allow auto-merge" enabled in repository settings; if it
-          # is not enabled, this warns and the PR falls back to manual merge.
-          gh pr merge "$PR_NUMBER" --auto --squash --delete-branch \
-            || echo "WARNING: could not enable auto-merge for PR #$PR_NUMBER;" \
-              "enable 'Allow auto-merge' in repository settings or merge manually."
+          # All validation (artifact/history schema checks, Hugo build) has
+          # already run earlier in this job, so merge immediately instead of
+          # requesting `--auto`: main has no branch protection or required
+          # status checks, and GitHub only allows auto-merge to be enabled on
+          # a PR whose merge is blocked by such requirements, so `--auto`
+          # fails outright here. A failed merge must fail this step (no
+          # `|| echo` masking) so it routes into "Notify Slack (failure)".
+          gh pr merge "$PR_NUMBER" --squash --delete-branch
       - name: Notify Slack (success)
         if: steps.symbols.outputs.symbols != '' && env.DRY_RUN != 'true' && env.SLACK_NOTIFICATIONS_ENABLED == 'true'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          DATE: ${{ steps.date.outputs.date }}
+          STEM: ${{ steps.date.outputs.stem }}
           PR_URL: ${{ steps.pr.outputs.pr_url }}
         run: |
           uv run python .agents/skills/market-analysis/scripts/notify_slack.py \
-            --artifact "data/analysis/${DATE}.json" \
-            --history "data/history/${DATE}.json" \
+            --artifact "data/analysis/${STEM}.json" \
+            --history "data/history/${STEM}.json" \
             --pr-url "${PR_URL}"
       - name: Notify Slack (failure)
         if: failure() && env.SLACK_NOTIFICATIONS_ENABLED == 'true'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ This repository combines a Python package, automation scripts, and a Hugo static
 
 ## Coding Style & Naming Conventions
 
-Python targets 3.11 through 3.13. Ruff enforces 88-character lines, Google-style docstrings, import sorting, and strict lint rules. Prefer typed functions and `pathlib` over string path manipulation. Apply KISS, DRY, and YAGNI: keep implementations simple, reuse existing helpers and patterns, and avoid abstractions or features before they are needed. Test files use `test_*.py`, and test names should describe behavior. Keep generated Hugo reports named like `YYYY-MM-DD-market-analysis.md` under `content/results/`.
+Python targets 3.13. Ruff enforces 88-character lines, Google-style docstrings, import sorting, and strict lint rules. Prefer typed functions and `pathlib` over string path manipulation. Apply KISS, DRY, and YAGNI: keep implementations simple, reuse existing helpers and patterns, and avoid abstractions or features before they are needed. Test files use `test_*.py`, and test names should describe behavior. Keep generated Hugo reports named like `YYYY-MM-DD-market-analysis.md` under `content/results/`.
 
 ## Testing Guidelines
 

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -197,6 +197,8 @@ Override coverage gates locally or in manual workflow runs via `market_analysis.
 
 **Current-run fetch status:** The daily workflow initializes `data/prices/fetch_status_<interval>.json` before fetching, records per-symbol success or failure during each `fetch` call, and passes that file to `generate --fetch-status`. Coverage gates use this fetch-status file as the source of truth, not merely the presence of pre-existing local price CSVs. A stale on-disk price file cannot mask a failed fetch in the current run. `generate` rejects fetch-status files whose `interval` or `analysis_date` do not match the current run.
 
+**Bar boundary policy:** `generate --analysis-date DATE` scores only bars strictly before `DATE`; any bar dated on or after `DATE` is dropped before scoring. This excludes in-progress intraday bars for markets still open when the scheduled run fires (e.g. `^N225`, `^HSI`, `*.T` — Tokyo/Hong Kong sessions are mid-day at the 01:00 UTC schedule), and rejects look-ahead when backfilling a past `analysis_date` against a `--data-dir` that holds newer bars. The tradeoff is one extra day of reporting lag for markets that had already closed by fetch time, in exchange for every instrument's `data_freshness` being computed the same way and a rerun of a past date reproducing the same artifact.
+
 ### Market regime
 
 The market regime label is derived from breadth: the share of reliable instruments whose latest close is above their 20-day moving average. Percentile-based composite scores are relative by construction — their median stays near 50 for any universe of meaningful size regardless of market direction — so breadth is used as an absolute directional measure instead. Reliable instruments without MA20 data are excluded from the ratio.
@@ -277,35 +279,38 @@ The generator is fully deterministic: identical input JSON always produces ident
 Pipeline order:
 
 1. Validate CFD instrument master
-2. Set analysis date (default: today UTC)
-3. Load symbols from `data/mappings/canonical_instrument_mappings.csv` for the configured `--provider`/`--interval` (the mapping file is the single source of truth; there is no separate `data/*_symbols.txt` file to keep in sync)
-4. Initialize `data/prices/fetch_status_<interval>.json` and fetch market data from the configured provider (1-year lookback), recording per-symbol outcomes in fetch status
-5. Generate JSON analysis artifact (`data/analysis/YYYY-MM-DD.json`) using `--mapping` and `--fetch-status`; fail if coverage gates are violated. Each instrument entry is enriched with `canonical_id`, `display_name`, and `asset_class` from the mapping.
-6. Validate artifact
-7. Generate score history (`data/history/YYYY-MM-DD.json`)
-8. Generate Hugo Markdown report (`content/results/YYYY-MM-DD-market-analysis.md`), grouped by asset class when the artifact carries more than one
-9. Build Hugo site (validation only — catches template or content errors before commit)
-10. Create (or update) a pull-request branch `generated/analysis-YYYY-MM-DD` with both artifacts and the report, then enable GitHub auto-merge (squash, delete branch on merge) on that PR
-11. A Slack notification summarizes new/persistent signals and risk-gate changes and links to the analysis PR.
+2. Validate instrument mappings (`validate_instrument_mappings.py`) — a typo'd `provider`/`provider_interval` value fails the run instead of silently shrinking the symbol universe
+3. Set analysis date (default: today UTC) and compute the interval-aware output stem (see below)
+4. Load symbols from `data/mappings/canonical_instrument_mappings.csv` for the configured `--provider`/`--interval` (the mapping file is the single source of truth; there is no separate `data/*_symbols.txt` file to keep in sync)
+5. Initialize `data/prices/fetch_status_<interval>.json` and fetch market data from the configured provider (lookback window scaled per interval by `aims.policy.fetch_window_days`), recording per-symbol outcomes in fetch status
+6. Generate JSON analysis artifact (`data/analysis/<stem>.json`) using `--mapping` and `--fetch-status`; fail if coverage gates are violated. Each instrument entry is enriched with `canonical_id`, `display_name`, and `asset_class` from the mapping. Bars dated on or after `--analysis-date` are dropped before scoring (see "Bar boundary policy" above).
+7. Validate artifact
+8. Generate score history (`data/history/<stem>.json`)
+9. Generate Hugo Markdown report (`content/results/<stem>-market-analysis.md`), grouped by asset class when the artifact carries more than one
+10. Build Hugo site (validation only — catches template or content errors before commit)
+11. Create (or update) a pull-request branch `generated/analysis-<stem>` with both artifacts and the report, then merge it directly (squash, delete branch)
+12. A Slack notification summarizes new/persistent signals and risk-gate changes and links to the analysis PR.
 
-### Auto-merge and CI approval
+**Interval-aware output stem:** `<stem>` is the analysis date (`YYYY-MM-DD`) for the default `d` interval, and `YYYY-MM-DD-<interval>` for `w`/`m` (see `aims.market_analysis.artifact_interval_suffix`). This keeps existing daily filenames unchanged while preventing a manual `w`/`m` dispatch from overwriting the same date's daily artifact, history, report, or PR branch.
 
-Step 10 calls `gh pr merge --auto --squash --delete-branch`, which merges the PR automatically once its required status checks pass — it does not bypass branch protection or required reviews. This requires **"Allow auto-merge"** to be enabled in **Settings → General → Pull Requests**; if it is not enabled, the step logs a warning and the PR falls back to manual merge exactly as before.
+### Merging the analysis PR
 
-**Known gotcha — PRs stuck in `action_required`:** pull-request-triggered `ci.yml` runs on `generated/analysis-*` branches can be gated with conclusion `action_required` and zero jobs executed, even though the PR was opened by `github-actions[bot]` pushing to a branch in the same repository (not a fork). When this happens, `gh pr merge --auto` waits indefinitely because the required checks never run. A repository maintainer must approve the pending workflow run (Actions tab → the run → **Approve and run**) or re-run it; only an authorized human/maintainer token can do this, the workflow's own `GITHUB_TOKEN` cannot self-approve. If this recurs daily, check **Settings → Actions → General** for an approval requirement (e.g. "Require approval for all outside collaborators") that is being applied to `github-actions[bot]`-authored pull requests, and relax it only if the operational risk is acceptable.
+Step 11 calls `gh pr merge --squash --delete-branch` directly rather than `--auto`: `main` has no branch protection or required status checks, and GitHub only allows `--auto` to be enabled on a PR whose merge is otherwise blocked by such requirements, so `--auto` fails outright here. All validation (artifact/history schema checks, Hugo build) has already run earlier in the same job, so merging immediately is safe. If the merge fails for any reason, the step fails the job (no error-masking) and the failure Slack notification fires.
+
+**Known gotcha — PRs stuck in `action_required`:** pull-request-triggered `ci.yml` runs on `generated/analysis-*` branches can be gated with conclusion `action_required` and zero jobs executed, even though the PR was opened by `github-actions[bot]` pushing to a branch in the same repository (not a fork). When this happens, the merge step above will fail (and notify) rather than merging. A repository maintainer must approve the pending workflow run (Actions tab → the run → **Approve and run**) or re-run it; only an authorized human/maintainer token can do this, the workflow's own `GITHUB_TOKEN` cannot self-approve. If this recurs daily, check **Settings → Actions → General** for an approval requirement (e.g. "Require approval for all outside collaborators") that is being applied to `github-actions[bot]`-authored pull requests, and relax it only if the operational risk is acceptable.
 
 ### Manual dispatch
 
 The workflow supports `workflow_dispatch` with optional inputs:
 
-| Input                 | Default    | Description                                                                                       |
-| --------------------- | ---------- | ------------------------------------------------------------------------------------------------- |
-| `analysis_date`       | Today UTC  | Override the analysis date (YYYY-MM-DD)                                                           |
-| `interval`            | `d`        | Price bar interval: `d` (daily), `w` (weekly), `m` (monthly)                                      |
-| `dry_run`             | `false`    | When `true`, skips PR creation, auto-merge, and Slack success notification                        |
-| `min_success_ratio`   | `0.8`      | Minimum symbol fetch success ratio for coverage gate                                              |
-| `max_missing_symbols` | `4`        | Maximum allowed missing symbols for coverage gate (scaled for the ~20-instrument mapped universe) |
-| `provider`            | `yfinance` | Market data provider: `yfinance` or `stooq`                                                       |
+| Input                 | Default    | Description                                                                                                                                                                                                                    |
+| --------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `analysis_date`       | Today UTC  | Override the analysis date (YYYY-MM-DD)                                                                                                                                                                                        |
+| `interval`            | `d`        | Price bar interval: `d` (daily), `w` (weekly), `m` (monthly). `w`/`m` currently only cover the mapping rows that exist for those intervals (the five original indices) and write to interval-suffixed output paths (see above) |
+| `dry_run`             | `false`    | When `true`, skips PR creation, merge, and Slack success notification                                                                                                                                                          |
+| `min_success_ratio`   | `0.8`      | Minimum symbol fetch success ratio for coverage gate                                                                                                                                                                           |
+| `max_missing_symbols` | `4`        | Maximum allowed missing symbols for coverage gate (scaled for the ~20-instrument mapped universe)                                                                                                                              |
+| `provider`            | `yfinance` | Market data provider: `yfinance` or `stooq`                                                                                                                                                                                    |
 
 ### Deployment gate
 

--- a/src/aims/history.py
+++ b/src/aims/history.py
@@ -7,6 +7,8 @@ import json
 from pathlib import Path
 from typing import Any, Final
 
+from aims.market_analysis import artifact_filename_stem
+
 HISTORY_VERSION: Final[str] = "1.0.0"
 DEFAULT_TOP_K: Final[int] = 5
 
@@ -147,7 +149,7 @@ def generate_history(
     artifacts.append(current)
     history = build_history(artifacts, top_k)
     output_dir.mkdir(parents=True, exist_ok=True)
-    output = output_dir / f"{current_date}.json"
+    output = output_dir / f"{artifact_filename_stem(current)}.json"
     output.write_text(
         json.dumps(history, indent=2, sort_keys=True) + "\n", encoding="utf-8"
     )

--- a/src/aims/mappings.py
+++ b/src/aims/mappings.py
@@ -87,8 +87,14 @@ def validate_mappings(
         return errors, warnings
 
     cfd_instruments: set[tuple[str, str]] = set()
-    if cfd_path is not None and cfd_path.exists():
-        cfd_instruments = _load_cfd_instruments(cfd_path)
+    if cfd_path is not None:
+        if cfd_path.exists():
+            cfd_instruments = _load_cfd_instruments(cfd_path)
+        else:
+            errors.append(
+                f"cfd-instruments file not found: {cfd_path};"
+                f" broker cross-checks cannot be performed"
+            )
 
     # canonical_id -> set of (provider, provider_symbol, provider_interval)
     canonical_provider_keys: dict[str, set[tuple[str, str, str]]] = {}

--- a/src/aims/market_analysis.py
+++ b/src/aims/market_analysis.py
@@ -26,8 +26,9 @@ import math
 import subprocess
 import sys
 from abc import ABC, abstractmethod
+from calendar import monthrange
 from dataclasses import dataclass, field
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 from typing import Any, Final
 from urllib.error import URLError
@@ -1331,19 +1332,36 @@ def _resolve_symbols_for_generate(args: argparse.Namespace) -> list[str] | None:
     return None
 
 
+def _bar_period_end_date(bar: OhlcvBar) -> date:
+    """Return the last calendar date covered by *bar*'s reporting period.
+
+    Weekly/monthly bars are timestamped at the period start, so a
+    same-day comparison against the raw timestamp would let an
+    in-progress week/month through. Advance to the period's last day
+    before comparing against the cutoff.
+    """
+    start = bar.timestamp.date()
+    if bar.interval == "w":
+        return start + timedelta(days=6)
+    if bar.interval == "m":
+        return date(start.year, start.month, monthrange(start.year, start.month)[1])
+    return start
+
+
 def _trim_bars_at_or_after(
     data: dict[str, list[OhlcvBar]], cutoff: datetime
 ) -> dict[str, list[OhlcvBar]]:
-    """Drop bars dated on/after *cutoff* from every symbol's bar list.
+    """Drop bars whose period ends on/after *cutoff* from every bar list.
 
-    Excludes in-progress intraday bars for markets still open at fetch time
-    (e.g. ``*.T``, ``^N225``, ``^HSI``) and closes the backfill look-ahead
-    where a data directory holds bars newer than the requested analysis
-    date.
+    Excludes in-progress intraday/weekly/monthly bars for periods still
+    open at fetch time (e.g. ``*.T``, ``^N225``, ``^HSI`` daily bars, or a
+    weekly/monthly bar covering the current, incomplete period) and closes
+    the backfill look-ahead where a data directory holds bars newer than
+    the requested analysis date.
     """
     cutoff_date = cutoff.date()
     return {
-        symbol: [bar for bar in bars if bar.timestamp.date() < cutoff_date]
+        symbol: [bar for bar in bars if _bar_period_end_date(bar) < cutoff_date]
         for symbol, bars in data.items()
     }
 

--- a/src/aims/market_analysis.py
+++ b/src/aims/market_analysis.py
@@ -1124,15 +1124,41 @@ def generate_artifact(
     }
 
 
+def artifact_interval_suffix(artifact: dict[str, Any]) -> str:
+    """Return ``"-{interval}"`` for non-daily artifacts, else ``""``.
+
+    Daily (``d``, the default and only interval the scheduled pipeline
+    uses) keeps plain ``YYYY-MM-DD`` filenames for backward compatibility.
+    Non-daily intervals get this suffix appended to artifact, history, and
+    report filenames so a manual ``w``/``m`` dispatch cannot silently
+    overwrite a same-date daily output.
+    """
+    meta = artifact.get("metadata")
+    if not isinstance(meta, dict):
+        return ""
+    config = meta.get("config")
+    if not isinstance(config, dict):
+        return ""
+    interval = config.get("interval")
+    if isinstance(interval, str) and interval and interval != "d":
+        return f"-{interval}"
+    return ""
+
+
+def artifact_filename_stem(artifact: dict[str, Any]) -> str:
+    """Return the date[-interval] filename stem for *artifact*."""
+    meta = artifact.get("metadata")
+    gen_at = str(meta.get("generated_at", "")) if isinstance(meta, dict) else ""
+    date_str = gen_at[:10] if gen_at else datetime.now(tz=UTC).date().isoformat()
+    return f"{date_str}{artifact_interval_suffix(artifact)}"
+
+
 def save_artifact(
     artifact: dict[str, Any],
     output_dir: Path = _DEFAULT_ANALYSIS_DIR,
 ) -> Path:
-    meta = artifact.get("metadata")
-    gen_at = str(meta.get("generated_at", "")) if isinstance(meta, dict) else ""
-    date_str = gen_at[:10] if gen_at else datetime.now(tz=UTC).date().isoformat()
     output_dir.mkdir(parents=True, exist_ok=True)
-    path = output_dir / f"{date_str}.json"
+    path = output_dir / f"{artifact_filename_stem(artifact)}.json"
     with path.open("w", encoding="utf-8") as fh:
         json.dump(artifact, fh, indent=2)
     return path
@@ -1305,6 +1331,23 @@ def _resolve_symbols_for_generate(args: argparse.Namespace) -> list[str] | None:
     return None
 
 
+def _trim_bars_at_or_after(
+    data: dict[str, list[OhlcvBar]], cutoff: datetime
+) -> dict[str, list[OhlcvBar]]:
+    """Drop bars dated on/after *cutoff* from every symbol's bar list.
+
+    Excludes in-progress intraday bars for markets still open at fetch time
+    (e.g. ``*.T``, ``^N225``, ``^HSI``) and closes the backfill look-ahead
+    where a data directory holds bars newer than the requested analysis
+    date.
+    """
+    cutoff_date = cutoff.date()
+    return {
+        symbol: [bar for bar in bars if bar.timestamp.date() < cutoff_date]
+        for symbol, bars in data.items()
+    }
+
+
 def _cmd_generate(args: argparse.Namespace) -> int:
     provider_name: str = (
         getattr(args, "provider", _DEFAULT_PROVIDER) or _DEFAULT_PROVIDER
@@ -1403,6 +1446,7 @@ def _cmd_generate(args: argparse.Namespace) -> int:
         reference_time = datetime.strptime(analysis_date, "%Y-%m-%d").replace(
             tzinfo=UTC
         )
+        data = _trim_bars_at_or_after(data, reference_time)
     results = score_instruments(
         data,
         reference_time=reference_time,

--- a/src/aims/notifications.py
+++ b/src/aims/notifications.py
@@ -160,7 +160,9 @@ def build_failure_payload(
             "type": "section",
             "text": {"type": "mrkdwn", "text": f"*{message}*"},
         },
-        {
+    ]
+    if run_url:
+        blocks.append({
             "type": "actions",
             "elements": [
                 {
@@ -170,8 +172,7 @@ def build_failure_payload(
                     "style": "danger",
                 }
             ],
-        },
-    ]
+        })
     return {"text": text, "blocks": blocks}
 
 

--- a/src/aims/policy.py
+++ b/src/aims/policy.py
@@ -54,6 +54,15 @@ _INTERVAL_THRESHOLDS: Final[dict[str, IntervalQualityThresholds]] = {
     "m": IntervalQualityThresholds(stale_days=62, max_gap_days=62, min_history=60),
 }
 
+# Calendar-day fetch lookback per interval, chosen so each interval clears
+# its min_history bar threshold above with a comfortable margin for
+# holidays, provider gaps, and the longest feature lookback (60 bars).
+_FETCH_WINDOW_DAYS: Final[dict[str, int]] = {
+    "d": 365,  # ~250 trading days
+    "w": 1460,  # ~4 years -> ~208 weekly bars
+    "m": 3650,  # ~10 years -> ~120 monthly bars
+}
+
 _DEFAULT_COVERAGE: Final[CoveragePolicy] = CoveragePolicy(
     min_success_ratio=0.8,
     max_missing_symbols=1,
@@ -70,6 +79,22 @@ def get_interval_thresholds(interval: str) -> IntervalQualityThresholds:
         )
         raise ValueError(msg)
     return _INTERVAL_THRESHOLDS[interval]
+
+
+def fetch_window_days(interval: str) -> int:
+    """Return the calendar-day fetch lookback window for *interval*.
+
+    A fixed 365-day window (enough for ~250 daily bars) is far too short
+    for weekly (~52 bars/year) or monthly (~12 bars/year) intervals to
+    clear ``min_history=60``; this scales the window per interval instead.
+    """
+    if interval not in _FETCH_WINDOW_DAYS:
+        msg = (
+            f"unsupported interval: {interval!r}"
+            f" (expected one of {_SUPPORTED_INTERVALS})"
+        )
+        raise ValueError(msg)
+    return _FETCH_WINDOW_DAYS[interval]
 
 
 def get_data_quality_policy(

--- a/src/aims/reports.py
+++ b/src/aims/reports.py
@@ -13,6 +13,8 @@ import json
 from pathlib import Path
 from typing import Any, Final, Literal
 
+from aims.market_analysis import artifact_interval_suffix
+
 _Alignment = Literal["left", "right", "center"]
 
 _DEFAULT_OUTPUT_DIR: Final[Path] = Path("content/results")
@@ -582,7 +584,7 @@ def report_filename(artifact: dict[str, Any]) -> str:
         date_str = "1970-01-01"
     else:
         date_str = generated_at[:10]
-    return f"{date_str}-market-analysis.md"
+    return f"{date_str}{artifact_interval_suffix(artifact)}-market-analysis.md"
 
 
 def generate_and_save(

--- a/src/aims/reports.py
+++ b/src/aims/reports.py
@@ -118,9 +118,10 @@ def _build_front_matter(
     all_symbols = sorted(str(i.get("symbol", "")) for i in instruments)
     symbols_toml = ", ".join(f'"{_toml_escape(s)}"' for s in all_symbols)
 
-    source_files = [f"data/analysis/{date_str}.json"]
+    stem = f"{date_str}{artifact_interval_suffix(artifact)}"
+    source_files = [f"data/analysis/{stem}.json"]
     if history is not None:
-        source_files.append(f"data/history/{date_str}.json")
+        source_files.append(f"data/history/{stem}.json")
     sources_toml = ", ".join(f'"{_toml_escape(path)}"' for path in source_files)
 
     if reliable:

--- a/tests/test_data_quality_policy.py
+++ b/tests/test_data_quality_policy.py
@@ -39,6 +39,29 @@ def test_unsupported_interval(policy: ModuleType) -> None:
         policy.get_interval_thresholds("h")
 
 
+def test_fetch_window_days_daily(policy: ModuleType) -> None:
+    assert policy.fetch_window_days("d") == 365
+
+
+def test_fetch_window_days_weekly_clears_min_history(policy: ModuleType) -> None:
+    thresholds = policy.get_interval_thresholds("w")
+    window = policy.fetch_window_days("w")
+    # ~7 calendar days per weekly bar; window must clear min_history bars.
+    assert window / 7 > thresholds.min_history
+
+
+def test_fetch_window_days_monthly_clears_min_history(policy: ModuleType) -> None:
+    thresholds = policy.get_interval_thresholds("m")
+    window = policy.fetch_window_days("m")
+    # ~30 calendar days per monthly bar; window must clear min_history bars.
+    assert window / 30 > thresholds.min_history
+
+
+def test_fetch_window_days_unsupported_interval(policy: ModuleType) -> None:
+    with pytest.raises(ValueError, match="unsupported interval"):
+        policy.fetch_window_days("h")
+
+
 def test_build_config_dict(policy: ModuleType) -> None:
     quality_policy = policy.get_data_quality_policy("d")
     config = policy.build_config_dict(quality_policy)

--- a/tests/test_generate_history.py
+++ b/tests/test_generate_history.py
@@ -162,6 +162,22 @@ def test_generate_history_and_main(gh: ModuleType, tmp_path: Path) -> None:
     assert gh.main(["--input", str(tmp_path / "missing.json")]) == 1
 
 
+def test_generate_history_weekly_output_has_interval_suffix(
+    gh: ModuleType, tmp_path: Path
+) -> None:
+    analysis = tmp_path / "analysis"
+    analysis.mkdir()
+    daily_path = analysis / "2024-01-03.json"
+    daily_path.write_text(json.dumps(_artifact("2024-01-03", [{"symbol": "A"}])))
+    current_path = analysis / "2024-01-03-w.json"
+    current = _artifact("2024-01-03", [{"symbol": "A"}])
+    current["metadata"]["config"]["interval"] = "w"
+    current_path.write_text(json.dumps(current))
+    output = tmp_path / "history"
+    result = gh.generate_history(current_path, analysis, output, 1)
+    assert result == output / "2024-01-03-w.json"
+
+
 def test_main_bad_json(gh: ModuleType, tmp_path: Path) -> None:
     bad = tmp_path / "bad.json"
     bad.write_text("{")

--- a/tests/test_generate_report.py
+++ b/tests/test_generate_report.py
@@ -324,6 +324,57 @@ def test_report_filename_weekly_interval_suffix(gr: ModuleType) -> None:
     assert gr.report_filename(artifact) == "2024-06-07-w-market-analysis.md"
 
 
+# ── _build_front_matter tests ───────────────────────────────────────────────────
+
+
+def test_build_front_matter_source_files_daily_has_no_suffix(
+    gr: ModuleType,
+) -> None:
+    artifact: dict[str, Any] = {
+        "metadata": {
+            "generated_at": "2024-01-01T00:00:00+00:00",
+            "config": {"interval": "d"},
+        }
+    }
+    front_matter = gr._build_front_matter(artifact, "2024-01-01")
+    assert 'source_files = ["data/analysis/2024-01-01.json"]' in front_matter
+
+
+def test_build_front_matter_source_files_match_suffixed_weekly_artifact(
+    gr: ModuleType,
+) -> None:
+    """A weekly report's source_files must point at the suffixed artifact.
+
+    ``report_filename`` writes ``2024-06-07-w-market-analysis.md`` for this
+    artifact, so ``source_files`` must reference ``2024-06-07-w.json``
+    rather than the unsuffixed daily filename.
+    """
+    artifact: dict[str, Any] = {
+        "metadata": {
+            "generated_at": "2024-06-07T00:00:00+00:00",
+            "config": {"interval": "w"},
+        }
+    }
+    front_matter = gr._build_front_matter(artifact, "2024-06-07")
+    assert 'source_files = ["data/analysis/2024-06-07-w.json"]' in front_matter
+
+
+def test_build_front_matter_source_files_with_history_include_suffix(
+    gr: ModuleType,
+) -> None:
+    artifact: dict[str, Any] = {
+        "metadata": {
+            "generated_at": "2024-06-07T00:00:00+00:00",
+            "config": {"interval": "m"},
+        }
+    }
+    front_matter = gr._build_front_matter(artifact, "2024-06-07", history={})
+    assert (
+        'source_files = ["data/analysis/2024-06-07-m.json",'
+        ' "data/history/2024-06-07-m.json"]' in front_matter
+    )
+
+
 # ── generate_and_save tests ─────────────────────────────────────────────────────
 
 

--- a/tests/test_generate_report.py
+++ b/tests/test_generate_report.py
@@ -314,6 +314,16 @@ def test_report_filename_non_string_generated_at(gr: ModuleType) -> None:
     assert gr.report_filename(artifact) == "1970-01-01-market-analysis.md"
 
 
+def test_report_filename_weekly_interval_suffix(gr: ModuleType) -> None:
+    artifact: dict[str, Any] = {
+        "metadata": {
+            "generated_at": "2024-06-07T00:00:00+00:00",
+            "config": {"interval": "w"},
+        }
+    }
+    assert gr.report_filename(artifact) == "2024-06-07-w-market-analysis.md"
+
+
 # ── generate_and_save tests ─────────────────────────────────────────────────────
 
 

--- a/tests/test_market_analysis.py
+++ b/tests/test_market_analysis.py
@@ -897,6 +897,59 @@ def test_save_artifact_no_generated_at(ma: ModuleType, tmp_path: Path) -> None:
     assert path.exists()
 
 
+# ── artifact_interval_suffix / artifact_filename_stem ──────────────────────────
+
+
+def test_artifact_interval_suffix_daily_is_empty(ma: ModuleType) -> None:
+    artifact = {"metadata": {"config": {"interval": "d"}}}
+    assert ma.artifact_interval_suffix(artifact) == ""
+
+
+def test_artifact_interval_suffix_weekly(ma: ModuleType) -> None:
+    artifact = {"metadata": {"config": {"interval": "w"}}}
+    assert ma.artifact_interval_suffix(artifact) == "-w"
+
+
+def test_artifact_interval_suffix_monthly(ma: ModuleType) -> None:
+    artifact = {"metadata": {"config": {"interval": "m"}}}
+    assert ma.artifact_interval_suffix(artifact) == "-m"
+
+
+def test_artifact_interval_suffix_missing_metadata(ma: ModuleType) -> None:
+    assert ma.artifact_interval_suffix({}) == ""
+
+
+def test_artifact_interval_suffix_missing_config(ma: ModuleType) -> None:
+    assert ma.artifact_interval_suffix({"metadata": {}}) == ""
+
+
+def test_artifact_filename_stem_weekly(ma: ModuleType) -> None:
+    artifact = {
+        "metadata": {
+            "generated_at": "2024-06-07T00:00:00+00:00",
+            "config": {"interval": "w"},
+        }
+    }
+    assert ma.artifact_filename_stem(artifact) == "2024-06-07-w"
+
+
+def test_save_artifact_weekly_filename_has_interval_suffix(
+    ma: ModuleType, mocker: MockerFixture, tmp_path: Path
+) -> None:
+    mocker.patch.object(ma, "_get_git_commit", return_value="abc")
+    bars = _make_bars(ma, "A", [float(100 + i) for i in range(70)])
+    ref = bars[-1].timestamp + timedelta(days=1)
+    scores = ma.score_instruments({"A": bars}, reference_time=ref)
+    artifact = ma.generate_artifact(
+        scores,
+        {"A": bars},
+        {"interval": "w"},
+        analysis_date="2024-06-07",
+    )
+    path = ma.save_artifact(artifact, tmp_path)
+    assert path.name == "2024-06-07-w.json"
+
+
 # ── CLI: _cmd_fetch ───────────────────────────────────────────────────────────
 
 
@@ -1448,6 +1501,39 @@ def test_cmd_generate_no_analysis_date_may_mark_stale(
     inst = next(i for i in artifact["instruments"] if i["symbol"] == "STALE")
     # Without reference_time fix, old bars stale relative to today
     assert ma.RISK_GATE_STALE in inst["risk_gates"]
+
+
+def test_cmd_generate_trims_bars_at_or_after_analysis_date(
+    ma: ModuleType, mocker: MockerFixture, tmp_path: Path
+) -> None:
+    """In-progress and look-ahead bars dated >= analysis_date are excluded.
+
+    Covers markets still open at run time (e.g. ``*.T``, ``^N225``, ``^HSI``)
+    whose "today" bar is a partial intraday snapshot, and closes the backfill
+    look-ahead where a data directory holds bars newer than the requested
+    analysis date.
+    """
+    mocker.patch.object(ma, "_get_git_commit", return_value="abc")
+    analysis_dt = datetime(2024, 1, 10, tzinfo=UTC)
+    base_dt = analysis_dt - timedelta(days=69)
+    # Index 69 lands exactly on analysis_date (in-progress bar); index 70
+    # lands one day after (look-ahead bar). Both must be trimmed.
+    bars = _make_bars(ma, "TRIM", [float(100 + i) for i in range(71)], start=base_dt)
+    ma.save_ohlcv(bars, tmp_path)
+
+    class Args:
+        symbols = "TRIM"
+        interval = "d"
+        data_dir = str(tmp_path)
+        output = str(tmp_path / "analysis")
+        analysis_date = "2024-01-10"
+        min_success_ratio = 0.8
+        max_missing_symbols = 1
+
+    result = ma._cmd_generate(Args())
+    assert result == 0
+    artifact = json.loads((tmp_path / "analysis" / "2024-01-10.json").read_text())
+    assert artifact["metadata"]["data_freshness"]["TRIM"] == "2024-01-09"
 
 
 # ── Coverage gates and artifact metadata ───────────────────────────────────────

--- a/tests/test_market_analysis.py
+++ b/tests/test_market_analysis.py
@@ -1536,6 +1536,46 @@ def test_cmd_generate_trims_bars_at_or_after_analysis_date(
     assert artifact["metadata"]["data_freshness"]["TRIM"] == "2024-01-09"
 
 
+def test_bar_period_end_date_daily_is_same_day(ma: ModuleType) -> None:
+    bar = _bar(ma, "X", 100.0, datetime(2024, 1, 10, tzinfo=UTC), interval="d")
+    assert ma._bar_period_end_date(bar) == datetime(2024, 1, 10, tzinfo=UTC).date()
+
+
+def test_bar_period_end_date_weekly_is_six_days_later(ma: ModuleType) -> None:
+    # Weekly bar timestamped at the Monday period start.
+    bar = _bar(ma, "X", 100.0, datetime(2024, 1, 8, tzinfo=UTC), interval="w")
+    assert ma._bar_period_end_date(bar) == datetime(2024, 1, 14, tzinfo=UTC).date()
+
+
+def test_bar_period_end_date_monthly_is_month_end(ma: ModuleType) -> None:
+    # Monthly bar timestamped at the period start; February 2024 is a leap month.
+    bar = _bar(ma, "X", 100.0, datetime(2024, 2, 1, tzinfo=UTC), interval="m")
+    assert ma._bar_period_end_date(bar) == datetime(2024, 2, 29, tzinfo=UTC).date()
+
+
+def test_trim_bars_at_or_after_excludes_in_progress_weekly_bar(
+    ma: ModuleType,
+) -> None:
+    """An in-progress weekly bar is trimmed despite its early Monday timestamp."""
+    # Week of 2024-01-08 (Mon) through 2024-01-14 (Sun); analysis runs
+    # mid-week on Wednesday, so this bar's period has not closed yet.
+    in_progress = _bar(ma, "X", 100.0, datetime(2024, 1, 8, tzinfo=UTC), interval="w")
+    closed = _bar(ma, "X", 99.0, datetime(2024, 1, 1, tzinfo=UTC), interval="w")
+    cutoff = datetime(2024, 1, 10, tzinfo=UTC)
+    trimmed = ma._trim_bars_at_or_after({"X": [closed, in_progress]}, cutoff)
+    assert trimmed["X"] == [closed]
+
+
+def test_trim_bars_at_or_after_excludes_in_progress_monthly_bar(
+    ma: ModuleType,
+) -> None:
+    in_progress = _bar(ma, "X", 100.0, datetime(2024, 2, 1, tzinfo=UTC), interval="m")
+    closed = _bar(ma, "X", 99.0, datetime(2024, 1, 1, tzinfo=UTC), interval="m")
+    cutoff = datetime(2024, 2, 15, tzinfo=UTC)
+    trimmed = ma._trim_bars_at_or_after({"X": [closed, in_progress]}, cutoff)
+    assert trimmed["X"] == [closed]
+
+
 # ── Coverage gates and artifact metadata ───────────────────────────────────────
 
 

--- a/tests/test_notify_slack.py
+++ b/tests/test_notify_slack.py
@@ -346,6 +346,13 @@ def test_build_failure_payload_custom_message(ns: ModuleType) -> None:
     assert "Custom failure message" in payload["text"]
 
 
+def test_build_failure_payload_no_run_url_omits_actions_block(
+    ns: ModuleType,
+) -> None:
+    payload = ns.build_failure_payload("")
+    assert all(block["type"] != "actions" for block in payload["blocks"])
+
+
 # ── send_notification tests ─────────────────────────────────────────────────────
 
 
@@ -518,12 +525,19 @@ def test_main_failure_mode_no_run_url(ns: ModuleType) -> None:
     mock_response.__enter__ = MagicMock(return_value=mock_response)
     mock_response.__exit__ = MagicMock(return_value=False)
 
+    captured_payload: dict[str, Any] = {}
+
+    def _capture_urlopen(req: Any, timeout: float) -> MagicMock:  # noqa: ARG001
+        captured_payload.update(json.loads(req.data.decode()))
+        return mock_response
+
     with (
         patch.dict("os.environ", {"SLACK_WEBHOOK_URL": "https://hooks.slack.com/test"}),
-        patch("urllib.request.urlopen", return_value=mock_response),
+        patch("urllib.request.urlopen", side_effect=_capture_urlopen),
     ):
         result = ns.main(["--failure"])
     assert result == 0
+    assert all(block["type"] != "actions" for block in captured_payload["blocks"])
 
 
 def test_build_success_payload_with_pr_url(

--- a/tests/test_validate_instrument_mappings.py
+++ b/tests/test_validate_instrument_mappings.py
@@ -143,11 +143,16 @@ def test_no_data_rows(vim: ModuleType, tmp_path: Path) -> None:
     assert any("no data rows" in e for e in errors)
 
 
-def test_cfd_path_not_exists_skips_broker_check(
-    vim: ModuleType, tmp_path: Path
-) -> None:
+def test_cfd_path_not_exists_is_error(vim: ModuleType, tmp_path: Path) -> None:
     mapping_path = _write_mapping(tmp_path, [_VALID_ROW])
-    errors, _ = vim.validate_mappings(mapping_path, tmp_path / "nonexistent.csv")
+    cfd_path = tmp_path / "nonexistent.csv"
+    errors, _ = vim.validate_mappings(mapping_path, cfd_path)
+    assert any("cfd-instruments file not found" in e for e in errors)
+
+
+def test_cfd_path_none_skips_broker_check(vim: ModuleType, tmp_path: Path) -> None:
+    mapping_path = _write_mapping(tmp_path, [_VALID_ROW])
+    errors, _ = vim.validate_mappings(mapping_path, None)
     assert errors == []
 
 
@@ -161,14 +166,27 @@ def test_row_with_empty_broker_skips_cfd_check(vim: ModuleType, tmp_path: Path) 
 
 def test_main_returns_0_on_valid(vim: ModuleType, tmp_path: Path) -> None:
     p = _write_mapping(tmp_path, [_VALID_ROW])
-    # Use a non-existent CFD path to skip broker reference checks
+    cfd_path = _write_cfd(tmp_path, ["TestBroker,US500"])
+    result = vim.main([
+        "--input",
+        str(p),
+        "--cfd-instruments",
+        str(cfd_path),
+    ])
+    assert result == 0
+
+
+def test_main_returns_1_on_missing_cfd_instruments_file(
+    vim: ModuleType, tmp_path: Path
+) -> None:
+    p = _write_mapping(tmp_path, [_VALID_ROW])
     result = vim.main([
         "--input",
         str(p),
         "--cfd-instruments",
         str(tmp_path / "no_cfd.csv"),
     ])
-    assert result == 0
+    assert result == 1
 
 
 def test_main_prints_warnings_and_returns_0(


### PR DESCRIPTION
## Summary

Fixes seven issues found via live analysis runs and workflow review, all in the daily market-analysis pipeline:

- **#100** — PR auto-merge never engages. `gh pr merge --auto` fails outright because `main` has no branch protection (GitHub only allows `--auto` when a PR's merge is otherwise blocked). Now merges directly (`gh pr merge --squash --delete-branch`) after in-run validation, and no longer masks failures with `|| echo` — a failed merge now fails the job and triggers the Slack failure notification.
- **#101** — Daily scoring used in-progress intraday bars for markets still open at run time (`^N225`, `^HSI`, `*.T`). Added `_trim_bars_at_or_after` in `market_analysis.py`, applied whenever `--analysis-date` is set, to drop bars dated on/after the analysis date. This also closes a backfill look-ahead gap.
- **#102** — Weekly/monthly dispatch was broken: a fixed 365-day fetch window can't clear `min_history=60` weekly/monthly bars, and outputs collided with daily artifacts on the same date. Added `fetch_window_days(interval)` to `policy.py` and interval-aware filename suffixing (`artifact_interval_suffix`/`artifact_filename_stem`) for artifacts, history, reports, and the PR branch. Daily behavior/filenames are unchanged.
- **#103** — Dependabot and Renovate both managed GitHub Actions updates with conflicting auto-merge policies (Dependabot auto-merged majors unconditionally, defeating Renovate's 7-day release-age gate). Removed the `github-actions` ecosystem from `.github/dependabot.yml` (its only entry) and dropped the `dependabot-auto-merge` CI job; Renovate is now the sole owner.
- **#104** — Instrument-mapping validation wasn't enforced in CI or the daily workflow, so typos could silently shrink the analysis universe. Added a "Validate instrument mappings" step to the daily workflow and a new `validate-market-data-config` CI job; `validate_mappings` now errors when `--cfd-instruments` points at a missing file instead of silently skipping cross-checks.
- **#105** — `notify_slack --failure` without `--run-url` built a Slack payload with an empty-URL button, which Slack rejects (losing the alert exactly when alerting matters). `build_failure_payload` now omits the actions block when `run_url` is empty, mirroring the success path.
- **#106** — `CLAUDE.md`/`AGENTS.md` claimed Python 3.11–3.13 support; `pyproject.toml` requires exactly 3.13. Docs corrected.

## Test plan

- [x] `uv run pytest` — 511 tests pass, 100% branch coverage on all `src/aims/` modules
- [x] `uv run ruff format .` / `uv run ruff check --fix .` — clean
- [x] `uv run pyright .` — 0 errors
- [x] `hugo --gc --minify` — builds successfully
- [x] `zizmor .github/workflows` — no findings
- [x] `actionlint` / `yamllint` on all workflow files — clean
- [x] `checkov --framework=all` — ran clean
- [x] Full `.agents/skills/local-qa/scripts/qa.sh` passes end-to-end

Related: #75, #85, #88, #99 (evidence sources for #100/#101), #39/#78 (related to #102), #18/#47 (related to #103)

🤖 Generated with [Claude Code](https://claude.com/claude-code)