### PR TITLE
fix(tests): derive newest performance artifact and dedup warnings (#116)

### DIFF
--- a/src/aims/performance.py
+++ b/src/aims/performance.py
@@ -331,12 +331,12 @@ def build_artifact(
 
     *extra_warnings* carries warnings from outside the join itself — e.g. a
     same-run qualitative artifact excluded by the caller's trust boundary —
-    merged in sorted alongside the evaluation's own warnings.
+    merged in deduplicated and sorted alongside the evaluation's own warnings.
     """
     stance_evaluation, warnings = evaluate_stances(
         qualitative_artifacts, analyses, horizons
     )
-    all_warnings = sorted([*warnings, *extra_warnings])
+    all_warnings = sorted({*warnings, *extra_warnings})
     return {
         "version": PERFORMANCE_VERSION,
         "metadata": {

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -312,7 +312,11 @@ def test_render_page_is_stable_across_json_round_trip() -> None:
 
 
 def test_committed_evaluation_page_is_regenerated_from_artifact() -> None:
-    committed = json.loads((REPO_ROOT / "data/performance/2026-07-04.json").read_text())
+    # Daily automation rewrites the page from the newest daily artifact, so
+    # derive it instead of pinning a date (weekly/monthly stems like
+    # 2026-07-04-w.json do not match the daily glob).
+    newest = max((REPO_ROOT / "data/performance").glob("????-??-??.json"))
+    committed = json.loads(newest.read_text())
     expected = (REPO_ROOT / "content/evaluation/_index.md").read_text()
     assert performance.render_page(committed) == expected
 
@@ -339,6 +343,27 @@ def test_build_artifact_merges_and_sorts_extra_warnings() -> None:
     assert "zzz-extra" in artifact["warnings"]
     assert "aaa-extra" in artifact["warnings"]
     assert artifact["warnings"] == sorted(artifact["warnings"])
+
+
+def test_build_artifact_deduplicates_repeated_conflict_warnings() -> None:
+    # Two later artifacts each revising the same bar emit the same conflict
+    # warning; the artifact must carry it once.
+    analyses = [
+        _analysis("2024-01-01", {"AAA": ("2024-01-01", 0.01, None)}),
+        _analysis("2024-01-02", {"AAA": ("2024-01-01", 0.05, None)}),
+        _analysis("2024-01-03", {"AAA": ("2024-01-01", 0.09, None)}),
+    ]
+    qualitative = [_qualitative("2024-01-01", [("AAA", "supportive", "high", [])])]
+    _, warnings = performance.build_bar_series(analyses)
+    assert len(warnings) == 2
+    artifact = performance.build_artifact(
+        qualitative, analyses, as_of="2024-01-03", interval="d"
+    )
+    conflict = (
+        "AAA: conflicting ret_1d for bar 2024-01-01 across analysis"
+        " artifacts; keeping the latest value"
+    )
+    assert artifact["warnings"].count(conflict) == 1
 
 
 def test_build_artifact_default_extra_warnings_is_empty() -> None:

--- a/tests/test_validate_performance.py
+++ b/tests/test_validate_performance.py
@@ -11,7 +11,9 @@ import pytest
 from aims.validate_performance import main, validate_artifact
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-COMMITTED = REPO_ROOT / "data/performance/2026-07-04.json"
+# Newest committed daily artifact; daily automation adds one per run, so the
+# validator must accept whatever is current rather than a pinned date.
+COMMITTED = max((REPO_ROOT / "data/performance").glob("????-??-??.json"))
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Fixes #116 — `python-test` is permanently red on `main`.

- `tests/test_performance.py::test_committed_evaluation_page_is_regenerated_from_artifact` pinned `data/performance/2026-07-04.json`, but the daily workflow regenerates `content/evaluation/_index.md` from the **newest** artifact on every run. The test now derives the newest committed daily artifact via `glob("????-??-??.json")` (weekly/monthly stems like `*-w.json` do not match; `prompt_regressions.json` does not match), so daily automation can no longer outdate it.
- `tests/test_validate_performance.py` uses the same derivation for its committed-artifact fixture instead of a pinned date.
- `build_artifact` (`src/aims/performance.py`) now deduplicates warnings (`sorted({...})`): `build_bar_series` emits one identical "conflicting ret_1d" warning per later-artifact revision of the same bar, which rendered duplicate lines (e.g. 6 duplicates of 7 warnings) on the published evaluation page. Committed artifacts are not regenerated here; the next daily run rewrites the page without duplicates.

## Validation

- `uv run pytest` — 940 passed, 100% branch coverage (was 1 failed / 938 passed on main)
- `uv run ruff format .` / `uv run ruff check --fix .` — clean
- `uv run pyright .` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)