### PR TITLE
fix(ci): deploy Pages on bot merges with in-run retry and alerting (#115)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,21 @@ on:
       - opened
       - synchronize
       - reopened
+  # Daily analysis PRs are merged with GITHUB_TOKEN, which creates no push
+  # event (and therefore no deploy). Re-run CI/CD against main whenever the
+  # daily workflow finishes instead; deploys are idempotent snapshots of
+  # main, so an occasional redundant run (e.g. after a dry run) is harmless.
+  # Safe despite the zizmor audit: the triggering workflow runs only from
+  # this repository (schedule/dispatch, never forks), and no event-supplied
+  # data or head SHA is used — jobs always run against the head of main.
+  workflow_run:   # zizmor: ignore[dangerous-triggers]
+    workflows:
+      - Daily market analysis
+    types:
+      - completed
+  # Manual full CI + deploy of current main (e.g. to recover from a failed
+  # Pages deploy).
+  workflow_dispatch:
 permissions:
   contents: read
 jobs:
@@ -18,6 +33,9 @@ jobs:
     if: >
       github.event_name == 'push'
       || github.event_name == 'pull_request'
+      || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'workflow_run'
+      && github.event.workflow_run.conclusion == 'success')
     permissions:
       actions: read
       contents: read
@@ -31,6 +49,9 @@ jobs:
     if: >
       github.event_name == 'push'
       || github.event_name == 'pull_request'
+      || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'workflow_run'
+      && github.event.workflow_run.conclusion == 'success')
     permissions:
       contents: read
     uses: dceoy/gh-actions-for-devops/.github/workflows/python-package-lint-and-scan.yml@main   # zizmor: ignore[unpinned-uses]
@@ -40,6 +61,9 @@ jobs:
     if: >
       github.event_name == 'push'
       || github.event_name == 'pull_request'
+      || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'workflow_run'
+      && github.event.workflow_run.conclusion == 'success')
     permissions:
       contents: read
     uses: dceoy/gh-actions-for-devops/.github/workflows/python-package-test.yml@main  # zizmor: ignore[unpinned-uses]
@@ -49,6 +73,9 @@ jobs:
     if: >
       github.event_name == 'push'
       || github.event_name == 'pull_request'
+      || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'workflow_run'
+      && github.event.workflow_run.conclusion == 'success')
     permissions:
       contents: read
       security-events: write
@@ -61,6 +88,9 @@ jobs:
     if: >
       github.event_name == 'push'
       || github.event_name == 'pull_request'
+      || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'workflow_run'
+      && github.event.workflow_run.conclusion == 'success')
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -84,6 +114,9 @@ jobs:
     if: >
       github.event_name == 'push'
       || github.event_name == 'pull_request'
+      || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'workflow_run'
+      && github.event.workflow_run.conclusion == 'success')
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -108,6 +141,9 @@ jobs:
   hugo-deploy-to-gh-pages:
     if: >
       github.event_name == 'push'
+      || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'workflow_run'
+      && github.event.workflow_run.conclusion == 'success')
     needs:
       - github-actions-lint-and-scan
       - python-lint-and-scan
@@ -118,9 +154,55 @@ jobs:
       contents: read
       id-token: write
       pages: write
-    uses: dceoy/gh-actions-for-devops/.github/workflows/hugo-deploy-to-gh-pages.yml@main   # zizmor: ignore[unpinned-uses]
-    with:
-      site-path: .
-      go-version: stable
-      base-url: https://dceoy.github.io/aims/
-      destination-dir: site
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url || steps.deploy-retry.outputs.page_url }}
+    concurrency:
+      group: github-pages
+      cancel-in-progress: false
+    env:
+      SLACK_NOTIFICATIONS_ENABLED: ${{ secrets.SLACK_WEBHOOK_URL != '' }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0   # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: stable
+      - name: Install Hugo
+        uses: peaceiris/actions-hugo@2752ce1d29631191ea3f27c23495fa06139a5b78 # v3.2.1
+        with:
+          hugo-version: latest
+          extended: true
+      - name: Build site
+        run: hugo --gc --minify
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: site
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+        continue-on-error: true
+      # Pages deploys fail transiently ("Deployment failed, try again
+      # later."); one in-run retry absorbs that without a manual re-run.
+      - name: Retry deploy to GitHub Pages
+        id: deploy-retry
+        if: steps.deploy.outcome == 'failure'
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39   # v8.2.0
+        if: failure() && env.SLACK_NOTIFICATIONS_ENABLED == 'true'
+      - name: Sync dependencies
+        if: failure() && env.SLACK_NOTIFICATIONS_ENABLED == 'true'
+        run: uv sync
+      - name: Notify Slack (deploy failure)
+        if: failure() && env.SLACK_NOTIFICATIONS_ENABLED == 'true'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          uv run python .agents/skills/market-analysis/scripts/notify_slack.py \
+            --failure \
+            --run-url \
+            "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --message "Hugo Pages deploy failed"

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -319,6 +319,14 @@ The workflow supports `workflow_dispatch` with optional inputs:
 
 GitHub Pages deployment is handled by `ci.yml` (`hugo-deploy-to-gh-pages` job), which runs only after Python linting, type checking, and tests all pass. The daily analysis workflow commits only content files (JSON and Markdown), not Python source, so existing tests remain stable.
 
+`ci.yml` runs on three deploy-relevant triggers:
+
+- `push` to `main` (human merges).
+- `workflow_run` on "Daily market analysis" completion: bot merges performed with `GITHUB_TOKEN` create no push event, so the daily workflow finishing (successfully) re-runs CI/CD against the head of `main` and deploys it. Deploys are idempotent snapshots of `main`, so a redundant run after a dry run is harmless.
+- `workflow_dispatch` (`gh workflow run ci.yml`): manual full CI + deploy of current `main` — the recovery path when a deploy failed or the site is stale.
+
+The deploy job builds the site with Hugo, uploads it as a Pages artifact, and deploys via `actions/deploy-pages`. Pages deployments fail transiently ("Deployment failed, try again later."); the job retries the deploy once in-run. If the job still fails, a Slack failure notification fires when `SLACK_WEBHOOK_URL` is configured — otherwise check the run under the Actions tab and the deployment status via `gh api repos/<owner>/<repo>/deployments?environment=github-pages`.
+
 ### Rollback
 
 If a published report or artifact needs to be removed, see [Delete a published report](#delete-a-published-report) in Manual recovery. Reverting a bad _code_ change (as opposed to a bad daily _report_) is a normal `git revert` on `main`, gated by the same CI checks as any other change.


### PR DESCRIPTION
## Summary

Fixes #115 — daily analysis content never reached the published site.

**Structural fix:** bot merges via `gh pr merge` with `GITHUB_TOKEN` create no push event, so the push-only `hugo-deploy-to-gh-pages` job never ran for daily merges. `ci.yml` now also triggers on:
- `workflow_run` of "Daily market analysis" (completed, gated on `conclusion == 'success'`): re-runs the full CI suite against the head of `main` (which includes the just-merged analysis PR) and deploys. Deploys are idempotent snapshots of `main`, so a redundant run after a dry run is harmless. The trigger is safe despite zizmor's blanket `dangerous-triggers` audit (inline-ignored with justification): the triggering workflow runs only from this repository and no event-supplied data or head SHA is used.
- `workflow_dispatch`: manual full CI + deploy of current `main` — the recovery path for failed deploys.

**Operational fix:** the deploy job is now inlined (checkout → Hugo build → `actions/configure-pages` → `actions/upload-pages-artifact` → `actions/deploy-pages`, all SHA-pinned) instead of delegating to the external reusable workflow, so the transient `Deployment failed, try again later.` Pages error gets one in-run retry. If the job still fails, a Slack failure notification fires when `SLACK_WEBHOOK_URL` is configured (same pattern as the daily workflow). `concurrency: github-pages` serializes deploys.

OPERATIONS.md §5 documents the trigger paths, the retry, and recovery commands.

## Validation

- `zizmor .github/workflows` — no findings
- `actionlint` / `yamllint` (relaxed profile) on `ci.yml` — clean
- `checkov --framework github_actions` — 295 passed, 0 failed
- `npx prettier` on OPERATIONS.md — unchanged

## Post-merge operational steps

1. `gh workflow run ci.yml` to deploy current `main` and clear the staleness (reports 2026-07-04…07, evaluation page).
2. `gh api repos/dceoy/aims/deployments?environment=github-pages` → newest deployment succeeds.
3. After the next scheduled daily run: confirm a `workflow_run`-triggered CI/CD run deploys the merge commit and https://dceoy.github.io/aims/results/ shows the newest report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)