### PR TITLE
fix(calendars): add lxml dependency and fail loudly on total fetch failure (#117)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">= 3.13, < 3.14"
 dependencies = [
     "anthropic>=0.116.0",
+    "lxml>=6.1.1",
     "pyyaml>=6.0.0",
     "yfinance>=0.2.0",
 ]

--- a/src/aims/calendars.py
+++ b/src/aims/calendars.py
@@ -123,22 +123,23 @@ def build_earnings_calendar(
     horizon_days: int = DEFAULT_EARNINGS_HORIZON_DAYS,
     updated_at: str | None = None,
     fetch_fn: FetchEarnings = fetch_earnings_dates,
-) -> tuple[dict[str, Any], list[str]]:
+) -> tuple[dict[str, Any], list[tuple[str, str]]]:
     """Build the earnings calendar for (canonical_id, symbol) *equities*.
 
-    Returns the calendar dict and a list of symbols whose fetch failed.
+    Returns the calendar dict and a list of (symbol, error message) pairs
+    for fetches that failed, so callers can surface the root cause.
     Only dates within (start_date, start_date + horizon_days] are kept —
     the calendar records known future events, not history.
     """
     start = datetime.fromisoformat(f"{start_date}T00:00:00+00:00")
     end = start + timedelta(days=horizon_days)
     events: list[dict[str, Any]] = []
-    failed: list[str] = []
+    failed: list[tuple[str, str]] = []
     for canonical_id, symbol in sorted(equities):
         try:
             dates = fetch_fn(symbol)
-        except Exception:  # noqa: BLE001 - per-symbol failures are non-fatal
-            failed.append(symbol)
+        except Exception as exc:  # noqa: BLE001 - per-symbol failures are non-fatal
+            failed.append((symbol, f"{type(exc).__name__}: {exc}"))
             continue
         events.extend(
             {
@@ -241,8 +242,17 @@ def main(argv: list[str] | None = None) -> int:
         horizon_days=args.horizon_days,
         updated_at=args.updated_at,
     )
-    for symbol in failed:
-        print(f"WARNING: earnings fetch failed for {symbol}")
+    for symbol, message in failed:
+        print(f"WARNING: earnings fetch failed for {symbol}: {message}")
+    if len(failed) == len(equities):
+        # A calendar with zero fetched symbols means the fetch path itself is
+        # broken (e.g. a missing dependency); keep the committed calendar
+        # instead of silently overwriting it with an empty one.
+        print(
+            f"ERROR: all {len(equities)} earnings fetches failed;"
+            f" leaving {args.output} untouched"
+        )
+        return 1
     path = save_calendar(calendar, args.output)
     print(
         f"Earnings calendar written to {path}"

--- a/tests/test_calendars.py
+++ b/tests/test_calendars.py
@@ -170,7 +170,7 @@ def test_build_earnings_calendar_filters_horizon_and_records_failures() -> None:
         updated_at="2024-01-01",
         fetch_fn=fetch,
     )
-    assert failed == ["MSFT"]
+    assert failed == [("MSFT", "ConnectionError: no data")]
     assert [e["date"] for e in calendar["events"]] == ["2024-01-15"]
     assert calendar["events"][0]["canonical_ids"] == ["aapl"]
     assert calendar["metadata"]["updated_at"] == "2024-01-01"
@@ -226,31 +226,40 @@ def test_main_no_equities(tmp_path: Path, capsys: pytest.CaptureFixture[str]) ->
     assert "no equity instruments" in capsys.readouterr().out
 
 
-def test_main_success(
-    tmp_path: Path, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]
-) -> None:
+def _write_mapping(tmp_path: Path, *symbols: str) -> Path:
     mapping = tmp_path / "map.csv"
-    mapping.write_text(
+    header = (
         "canonical_id,display_name,asset_class,broker,broker_instrument_name,"
         "broker_ticker_symbol,provider,provider_symbol,provider_interval,tradable\n"
-        "aapl,Apple Inc.,equity,,,,yfinance,AAPL,d,true\n",
-        encoding="utf-8",
     )
+    rows = "".join(
+        f"{symbol.lower()},{symbol},equity,,,,yfinance,{symbol},d,true\n"
+        for symbol in symbols
+    )
+    mapping.write_text(header + rows, encoding="utf-8")
+    return mapping
+
+
+def _calendar_stub(events: list[dict[str, str]] | None = None) -> dict[str, object]:
+    return {
+        "version": cal.CALENDAR_VERSION,
+        "metadata": {
+            "calendar_id": "earnings",
+            "updated_at": "2024-01-01",
+            "source": "test",
+        },
+        "events": events or [],
+    }
+
+
+def test_main_success_with_partial_failure(
+    tmp_path: Path, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]
+) -> None:
+    mapping = _write_mapping(tmp_path, "AAPL", "MSFT")
     mocker.patch.object(
         cal,
         "build_earnings_calendar",
-        return_value=(
-            {
-                "version": cal.CALENDAR_VERSION,
-                "metadata": {
-                    "calendar_id": "earnings",
-                    "updated_at": "2024-01-01",
-                    "source": "test",
-                },
-                "events": [],
-            },
-            ["AAPL"],
-        ),
+        return_value=(_calendar_stub(), [("AAPL", "ImportError: lxml missing")]),
     )
     rc = cal.main([
         "--mapping",
@@ -262,5 +271,34 @@ def test_main_success(
     ])
     out = capsys.readouterr().out
     assert rc == 0
-    assert "WARNING: earnings fetch failed for AAPL" in out
+    assert "WARNING: earnings fetch failed for AAPL: ImportError: lxml missing" in out
     assert (tmp_path / "out.json").exists()
+
+
+def test_main_all_symbols_failed_exits_nonzero_without_writing(
+    tmp_path: Path, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]
+) -> None:
+    mapping = _write_mapping(tmp_path, "AAPL", "MSFT")
+    mocker.patch.object(
+        cal,
+        "build_earnings_calendar",
+        return_value=(
+            _calendar_stub(),
+            [
+                ("AAPL", "ImportError: lxml missing"),
+                ("MSFT", "ImportError: lxml missing"),
+            ],
+        ),
+    )
+    rc = cal.main([
+        "--mapping",
+        str(mapping),
+        "--start-date",
+        "2024-01-01",
+        "--output",
+        str(tmp_path / "out.json"),
+    ])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "ERROR: all 2 earnings fetches failed" in out
+    assert not (tmp_path / "out.json").exists()

--- a/uv.lock
+++ b/uv.lock
@@ -13,6 +13,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
+    { name = "lxml" },
     { name = "pyyaml" },
     { name = "yfinance" },
 ]
@@ -32,6 +33,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.116.0" },
+    { name = "lxml", specifier = ">=6.1.1" },
     { name = "pyyaml", specifier = ">=6.0.0" },
     { name = "yfinance", specifier = ">=0.2.0" },
 ]
@@ -397,6 +399,32 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/13/c5/2a467585a576594384e1d2c43e1224deaafc085f24e243529cf98beef8e1/jiter-0.16.0-cp313-cp313-win32.whl", hash = "sha256:c9c53be232c2e206ef9cdbad81a48bfa74c3d3f08bcf8124630a8a748aad993e", size = 202853, upload-time = "2026-06-29T13:03:53.015Z" },
     { url = "https://files.pythonhosted.org/packages/88/6a/de61d04b9eec69c71719968d2f716532a3bc121170c44a39e14979c6be81/jiter-0.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:baad945ed47f163ad833314f8e3288c396118934f94e7bbb9e243ce4b341a4fd", size = 196160, upload-time = "2026-06-29T13:03:54.447Z" },
     { url = "https://files.pythonhosted.org/packages/19/4b/b390ed59bafb3f31d008d1218578f10327714484b334439947f7e5b11e7f/jiter-0.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:3c1fd2dbe1b0af19e987f03fe66c5f5bd105a2229c1aff4ab14890b24f41d21a", size = 189862, upload-time = "2026-06-29T13:03:55.754Z" },
+]
+
+[[package]]
+name = "lxml"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/3b/aab6728cae887456f409b4d75e8a01856e4f04bd510de38052a47768b680/lxml-6.1.1.tar.gz", hash = "sha256:ba96ae44888e0185281e937633a743ea90d5a196c6000f82565ebb0580012d40", size = 4197430, upload-time = "2026-05-18T19:19:06.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/eb/7e6f37c5584ccbb2ff267f56fd0339016938c1c8684cfefab9b33ffc2f36/lxml-6.1.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:68a9198d0fc122d14bb76837de9aa80cf84caed990b5b237f532ed87d3706736", size = 8559780, upload-time = "2026-05-18T19:17:57.661Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/36/587c2521cf23a2cd6c9c22108aa7528f683a1f195ed7ccd23a4b1786ad36/lxml-6.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7d47866cb32fb503450b6edc9df355d10dc49836af2e89901bd6ac6b0896d9d9", size = 4618006, upload-time = "2026-05-18T19:18:04.452Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ca/ab7bfe2bf4c972af5e7878262845ead3a24a929a9b04bc11c7c1ece6c82a/lxml-6.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb7c9811bfaa8b1ed5ed319f5d370dfbcaa59d52ea64be2a5a85e18195930354", size = 4924139, upload-time = "2026-05-18T19:19:04.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/55/a0c72851dfee5ecc689f949723a73dea457758912542cb955b108eaf0d8f/lxml-6.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:762ff394d5bd56da0cf034a23dcce4e13923f15321a2adfa2ac00201dc6d3fca", size = 5082329, upload-time = "2026-05-18T19:19:09.728Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b6/0608f7d61a3b96cc67e5648a3d906e31a5082093e10e7be65b3886289938/lxml-6.1.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a088f287f7d8275a33c07f2cac6c50b9319309a0200a39e7e75d80c707723099", size = 4993564, upload-time = "2026-05-18T19:19:13.608Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/66/ae227524b066d29d55bf0b453d93d2d793c40218657d643dcbbca13b8faf/lxml-6.1.1-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e902da4b04e6b52e5893900d4b8ab46068f75f3561f01bf1080957f9fd932ed6", size = 5613467, upload-time = "2026-05-18T19:19:16.228Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/76/dbe4a00b50385e40194231dcfe5a12c059de7cf90e89c83407d2b085b719/lxml-6.1.1-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1d4962d4c66bf830a7e59ed6cfc17d148149898a3aefa8ec6e59763e6e3ed085", size = 5228304, upload-time = "2026-05-18T19:19:19.354Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/01/00b1b8442ed2041793336868ba0b9ea4b13d7da7c085c6404c207a63bf79/lxml-6.1.1-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:581d4c8ae690a6609e64862dd6b7c2489635c2d13907fc2b20f2bc200ff1d21e", size = 5341607, upload-time = "2026-05-18T19:19:22.297Z" },
+    { url = "https://files.pythonhosted.org/packages/63/36/1ad29931e9a4638bb707869f01d423a6c815f82152138d1a40dfcfde2b95/lxml-6.1.1-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:876e1ff5930ed8bf295ec5ef9a8155e9b6b1876bbf1deed8b3a8069311875a8f", size = 4700168, upload-time = "2026-05-18T19:19:25.133Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d1/a9536cecf9be18a0dc72d32bead283a2332d1ffebd2dd3ac70ce444686e5/lxml-6.1.1-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9eb9b5a968f6e0f6d640092a567e14529ff8cea2e29d00da6f78a79fa49f013c", size = 5232487, upload-time = "2026-05-18T19:19:28.603Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/77/b4fb1e03bf5d130e879214d3100092e386418807fb74dd0adc4b0a48f351/lxml-6.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:aa49e06d94aba782c6a02eecb7e507969e7e7a41b267f1b359bb35585f295d5b", size = 5044231, upload-time = "2026-05-18T19:18:42.246Z" },
+    { url = "https://files.pythonhosted.org/packages/26/4c/d00daeeb0a5530c4028a9232aa1b93db3ef4ed2158c116ea73c79a9765b3/lxml-6.1.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:70cdfd80589d59e43e18005dd7244e8895e93db8ab6a620b7e23df5445a4e3d2", size = 4769450, upload-time = "2026-05-18T19:18:48.013Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/6a/715a3a8d156ce42f29cf014706f5410c2ff3b02267774110fc23266409fe/lxml-6.1.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:aad9aa39483ed8ec44d6d2e59e5b98a0d80676ef0d92f44bfc374836111f62f5", size = 5635874, upload-time = "2026-05-18T19:18:51.914Z" },
+    { url = "https://files.pythonhosted.org/packages/45/37/0544bc21dde2a88f3a17b504e6fc79c0e01d25a33c2f6079724e9e72b9c7/lxml-6.1.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:d49514be2f28d895c38cf9d2b72d7b9a07d00314519f456c0b50b53cfcf4c785", size = 5223987, upload-time = "2026-05-18T19:18:59.715Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f8/f6a5e8185bcb28c2befae3d31f8e3df3b811cb0f47746517a81279fcafe1/lxml-6.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:47402e62c52ff5988c1e8c6c63177f5708bccf48e366dea4e3dcf1e645e04947", size = 5250276, upload-time = "2026-05-18T19:19:03.834Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f2/1a2b9f1b7a49d45495369be7ef9ad05b262930f2eab3e3145706fca8083f/lxml-6.1.1-cp313-cp313-win32.whl", hash = "sha256:3483644525531e1d5762b0c44a8e18b6efba321b6dcf8a8952de10b037618bca", size = 3596903, upload-time = "2026-05-18T19:17:29.863Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/99/f4ffb024f238eec2131aaa09f3278fb6129cf892741bf68e1fc1afb8c100/lxml-6.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:a10bd2fd62e8ce916ececb342f348f190724a098c1faa056fdfb2a22ad5e8660", size = 3995869, upload-time = "2026-05-18T19:18:02.596Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/53/70eb8c5c6037f27448f1e3c54ebede9545a801ae63f0a7254afca4fe8e45/lxml-6.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:424aa57aca0897eb922aef34395bd1289b3b6f04e6bae20ea123c0c7e333cffc", size = 3658490, upload-time = "2026-05-19T19:22:53.846Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes #117 — the weekly earnings-calendar refresh always wrote an empty calendar.

- **Root cause 1:** `yfinance.Ticker.get_earnings_dates()` requires `lxml` (via `pandas.read_html`), which was not a project dependency — every per-symbol fetch raised `ImportError` before any network call. `lxml` is now a runtime dependency (`uv add lxml`, lockfile updated).
- **Root cause 2:** per-symbol failures were swallowed without detail and `main()` returned 0 unconditionally, overwriting the committed calendar with an empty one. Now:
  - `build_earnings_calendar` returns `(symbol, "ExceptionType: message")` pairs and the CLI prints `WARNING: earnings fetch failed for AAPL: ImportError: ...`, so the next root cause is diagnosable from the log.
  - When **all** fetches fail, the CLI prints an ERROR, leaves the committed calendar untouched, and exits 1 (turning the workflow run red). Partial failures still write and warn.

## Validation

- `uv run python .agents/skills/qualitative-analysis/scripts/update_calendars.py --mapping data/mappings/canonical_instrument_mappings.csv --output <scratch>/earnings.json` → **12 real events** (JPM 07-14, TSLA 07-22, GOOGL 07-23, META/MSFT 07-29, …), 1 partial failure (UNH: `KeyError: ['Earnings Date']`) surfaced with its cause; previously 0 events / 13 failed symbols.
- `validate_calendar.py` on the generated file → OK
- `uv run pytest` — 941 passed, 100% branch coverage (new tests: all-failed → exit 1 without writing; partial failure → exit 0 with detailed warning)
- `ruff` / `pyright` — clean

## Post-merge

Re-run the "Update event calendars" workflow via `workflow_dispatch` and confirm the resulting PR contains real events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)