### PR TITLE
fix(data): map GMO JPY-denominated spot metal CFDs to tickers (#118)

### DIFF
--- a/data/mappings/cfd_ticker_mappings.csv
+++ b/data/mappings/cfd_ticker_mappings.csv
@@ -60,6 +60,9 @@ instrument,,,オーストラリア株価指数ETF,,EWA
 instrument,,,金スポット,,XAU
 instrument,,,銀スポット,,XAG
 instrument,,,プラチナスポット,,XPT
+instrument,,,金/JPY,,XAUJPY
+instrument,,,銀/JPY,,XAGJPY
+instrument,,,プラチナ/JPY,,XPTJPY
 instrument,,,銅先物,,HG
 instrument,,,鉄鉱石,,FEF
 instrument,,,WTI原油,,CL

--- a/tests/test_update_cfd_instruments.py
+++ b/tests/test_update_cfd_instruments.py
@@ -385,6 +385,18 @@ def test_load_mappings_loads_all_types(updater: ModuleType, tmp_path: Path) -> N
     assert result.click_stock_base_symbols == {"Apple": "AAPL"}
 
 
+def test_committed_mappings_resolve_gmo_jpy_spot_metals(updater: ModuleType) -> None:
+    # Regression guard for the GMO JPY-denominated spot metals that broke the
+    # weekly refresh when they appeared in the lineup without mappings (#118).
+    committed = Path(__file__).resolve().parent.parent / (
+        "data/mappings/cfd_ticker_mappings.csv"
+    )
+    result = updater.load_mappings(committed)
+    assert result.instrument_symbols["金/JPY"] == "XAUJPY"
+    assert result.instrument_symbols["銀/JPY"] == "XAGJPY"
+    assert result.instrument_symbols["プラチナ/JPY"] == "XPTJPY"
+
+
 def test_load_mappings_fails_on_missing_file(
     updater: ModuleType, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes #118 — the weekly "Update CFD instruments" workflow fails on missing ticker mappings for GMO's new JPY-denominated spot metal CFDs, leaving `data/cfd_instruments.csv` stale since 2026-06-22.

- Add three `instrument`-type rows to `data/mappings/cfd_ticker_mappings.csv`: `金/JPY → XAUJPY`, `銀/JPY → XAGJPY`, `プラチナ/JPY → XPTJPY` (FX-pair style codes, consistent with the existing USD spot rows `金スポット → XAU` etc.; conform to the `^[A-Z][A-Z0-9 .;]{0,49}$` ticker pattern).
- Add a regression test that loads the committed mapping file and asserts the three names resolve.
- `canonical_instrument_mappings.csv` entries are intentionally **not** added: the reverse-reference check in `mappings.py` only warns (does not fail) for CFD instruments without canonical mappings, and picking a yfinance symbol for JPY-quoted spot metals can be deferred until they should join the analysis universe.

## Validation

- `uv run pytest` — 941 passed, 100% branch coverage
- `ruff` / `pyright` — clean

## Post-merge

Re-run the "Update CFD instruments" workflow (`gh workflow run update-cfd-instruments.yml`) and confirm the updater exits 0 and opens a catalog-refresh PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)