### PR TITLE
feat(analysis): persist market regime as authoritative artifact metadata (#77)

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -213,6 +213,8 @@ The market regime label is derived from breadth: the share of reliable instrumen
 | Bearish     | ≤ 35%                                  |
 | Unavailable | No reliable instruments with MA20 data |
 
+The label is computed once, at artifact generation time, and stored as `metadata.market_regime` (`{label, positive_count, reliable_count, breadth, thresholds}`) — the authoritative, auditable source for the regime shown in reports and Slack notifications. Both consumers call `regime_from_artifact()` (`src/aims/reports.py`), which reads the stored value and only recomputes it from reliable-instrument MA20 breadth as a fallback for artifacts generated before this field existed (schema version < 1.1.0). This is informational only: it never modifies scores, ranks, or risk gates.
+
 ### Scoring version
 
 `SCORING_VERSION = "1.0.0"` in `src/aims/market_analysis.py`. Increment this when the feature set or scoring logic changes in a way that makes old and new scores incomparable.

--- a/data/schema/analysis.schema.json
+++ b/data/schema/analysis.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "AIMS analysis artifact",
   "description": "Schema reference for validate_analysis.py. Validation is implemented in Python rather than a JSON Schema library to avoid runtime dependencies.",
-  "artifact_version": "1.0.0",
+  "artifact_version": "1.1.0",
   "required_top_keys": ["version", "metadata", "instruments"],
   "required_metadata_keys": [
     "generated_at",
@@ -11,8 +11,17 @@
     "data_freshness",
     "scoring_version",
     "config",
-    "coverage"
+    "coverage",
+    "market_regime"
   ],
+  "required_market_regime_keys": [
+    "label",
+    "positive_count",
+    "reliable_count",
+    "breadth",
+    "thresholds"
+  ],
+  "market_regime_labels": ["Bullish", "Bearish", "Neutral", "Unavailable"],
   "required_config_keys": [
     "interval",
     "stale_days",
@@ -31,7 +40,8 @@
   "notes": {
     "data_source": "Sorted comma-separated provider names, e.g. 'stooq' or 'csv,stooq'.",
     "data_freshness": "Object mapping symbol to latest bar date (YYYY-MM-DD) or 'n/a' if no bars.",
-    "rank": "Display rank after reliability-aware ordering: reliable instruments (is_reliable=true) rank first by score descending; unreliable instruments follow."
+    "rank": "Display rank after reliability-aware ordering: reliable instruments (is_reliable=true) rank first by score descending; unreliable instruments follow.",
+    "market_regime": "Computed once at generation time from the share of reliable instruments trading above their 20-day moving average (breadth). 'breadth' is null and 'label' is 'Unavailable' when no reliable instrument has MA20 data. Reports and notifications read this field as the source of truth; artifacts predating schema 1.1.0 lack it and are labeled by on-the-fly recomputation for backward compatibility."
   },
   "required_instrument_keys": [
     "symbol",

--- a/src/aims/market_analysis.py
+++ b/src/aims/market_analysis.py
@@ -63,7 +63,10 @@ _FETCH_STATUS_FAILED: Final[str] = "failed"
 _FETCH_STATUS_PENDING: Final[str] = "pending"
 
 SCORING_VERSION: Final[str] = "1.0.0"
-ARTIFACT_VERSION: Final[str] = "1.0.0"
+ARTIFACT_VERSION: Final[str] = "1.1.0"
+
+_BULLISH_BREADTH: Final[float] = 0.65
+_BEARISH_BREADTH: Final[float] = 0.35
 
 RISK_GATE_STALE: Final[str] = "stale_data"
 RISK_GATE_HIGH_VOL: Final[str] = "high_volatility"
@@ -1037,6 +1040,37 @@ def _features_to_dict(feats: InstrumentFeatures) -> dict[str, float | None]:
     }
 
 
+def market_regime_metadata(scores: list[InstrumentScore]) -> dict[str, Any]:
+    """Label the market regime from MA20 breadth of reliable instruments.
+
+    Percentile-based composite scores are relative by construction, so their
+    median stays near 50 regardless of market direction. Breadth — the share
+    of reliable instruments trading above their 20-day moving average — is an
+    absolute measure that distinguishes broad rallies from broad declines.
+    Computed once at artifact generation so reports and notifications read a
+    single authoritative, auditable value instead of recomputing it.
+    """
+    reliable = [s for s in scores if s.is_reliable]
+    valid = [s for s in reliable if s.features.ma20_dist is not None]
+    positive = sum(1 for s in valid if (s.features.ma20_dist or 0) > 0)
+    breadth = positive / len(valid) if valid else None
+    if breadth is None:
+        label = "Unavailable"
+    elif breadth >= _BULLISH_BREADTH:
+        label = "Bullish"
+    elif breadth <= _BEARISH_BREADTH:
+        label = "Bearish"
+    else:
+        label = "Neutral"
+    return {
+        "label": label,
+        "positive_count": positive,
+        "reliable_count": len(valid),
+        "breadth": breadth,
+        "thresholds": {"bullish": _BULLISH_BREADTH, "bearish": _BEARISH_BREADTH},
+    }
+
+
 def generate_artifact(
     scores: list[InstrumentScore],
     data: dict[str, list[OhlcvBar]],
@@ -1115,6 +1149,7 @@ def generate_artifact(
         "data_freshness": freshness,
         "scoring_version": SCORING_VERSION,
         "config": config,
+        "market_regime": market_regime_metadata(scores),
     }
     if coverage is not None:
         artifact_metadata["coverage"] = coverage

--- a/src/aims/notifications.py
+++ b/src/aims/notifications.py
@@ -33,7 +33,7 @@ from aims.calendars import (
     load_calendar_events,
     upcoming_events,
 )
-from aims.reports import market_regime
+from aims.reports import regime_from_artifact
 
 _TIMEOUT: Final[int] = 15
 _MAX_EVENT_LINES: Final[int] = 3
@@ -131,7 +131,7 @@ def build_success_payload(
 
     instruments = artifact.get("instruments", [])
     reliable = [i for i in instruments if i.get("is_reliable")]
-    regime = market_regime(reliable)
+    regime, _, _ = regime_from_artifact(artifact, reliable)
 
     top3 = sorted(reliable, key=lambda i: float(i.get("score", 0)), reverse=True)[:3]
     signals = ", ".join(

--- a/src/aims/reports.py
+++ b/src/aims/reports.py
@@ -94,6 +94,10 @@ def market_regime(reliable: list[dict[str, Any]]) -> str:
     median stays near 50 regardless of market direction. Breadth — the share
     of reliable instruments trading above their 20-day moving average — is an
     absolute measure that distinguishes broad rallies from broad declines.
+
+    This recomputes the label from report-shaped instrument dicts; artifacts
+    generated after #77 carry the authoritative label in
+    ``metadata.market_regime`` instead — see :func:`regime_from_artifact`.
     """
     above, valid = _regime_breadth(reliable)
     if not valid:
@@ -104,6 +108,39 @@ def market_regime(reliable: list[dict[str, Any]]) -> str:
     if breadth <= _BEARISH_BREADTH:
         return "Bearish"
     return "Neutral"
+
+
+_REGIME_LABELS: Final[frozenset[str]] = frozenset({
+    "Bullish",
+    "Bearish",
+    "Neutral",
+    "Unavailable",
+})
+
+
+def regime_from_artifact(
+    artifact: dict[str, Any], reliable: list[dict[str, Any]]
+) -> tuple[str, int, int]:
+    """Return (label, above, valid), preferring the artifact's stored regime.
+
+    Artifacts generated before #77 (schema < 1.1.0) lack
+    ``metadata.market_regime``; fall back to recomputing it from breadth for
+    those so older committed artifacts keep rendering.
+    """
+    stored = artifact.get("metadata", {}).get("market_regime")
+    if (
+        isinstance(stored, dict)
+        and stored.get("label") in _REGIME_LABELS
+        and isinstance(stored.get("positive_count"), int)
+        and isinstance(stored.get("reliable_count"), int)
+    ):
+        return (
+            str(stored["label"]),
+            int(stored["positive_count"]),
+            int(stored["reliable_count"]),
+        )
+    above, valid = _regime_breadth(reliable)
+    return market_regime(reliable), above, valid
 
 
 def _build_front_matter(
@@ -124,7 +161,7 @@ def _build_front_matter(
 
     instruments = artifact.get("instruments", [])
     reliable = [i for i in instruments if i.get("is_reliable")]
-    regime = market_regime(reliable)
+    regime, _, _ = regime_from_artifact(artifact, reliable)
     n_reliable = len(reliable)
 
     all_symbols = sorted(str(i.get("symbol", "")) for i in instruments)
@@ -734,8 +771,7 @@ def generate_report(
     instruments = artifact.get("instruments", [])
     reliable = [i for i in instruments if i.get("is_reliable")]
     unreliable = [i for i in instruments if not i.get("is_reliable")]
-    regime = market_regime(reliable)
-    above, valid = _regime_breadth(reliable)
+    regime, above, valid = regime_from_artifact(artifact, reliable)
     total = len(instruments)
 
     # A qualitative artifact whose market narrative was withheld by the #93

--- a/src/aims/validate_analysis.py
+++ b/src/aims/validate_analysis.py
@@ -12,7 +12,7 @@ import json
 from pathlib import Path
 from typing import Any, Final
 
-ARTIFACT_VERSION: Final[str] = "1.0.0"
+ARTIFACT_VERSION: Final[str] = "1.1.0"
 DEFAULT_INPUT: Final[Path] = Path("data/analysis")
 
 _REQUIRED_TOP: Final[tuple[str, ...]] = ("version", "metadata", "instruments")
@@ -24,7 +24,21 @@ _REQUIRED_META: Final[tuple[str, ...]] = (
     "scoring_version",
     "config",
     "coverage",
+    "market_regime",
 )
+_REQUIRED_REGIME: Final[tuple[str, ...]] = (
+    "label",
+    "positive_count",
+    "reliable_count",
+    "breadth",
+    "thresholds",
+)
+_REGIME_LABELS: Final[frozenset[str]] = frozenset({
+    "Bullish",
+    "Bearish",
+    "Neutral",
+    "Unavailable",
+})
 _REQUIRED_CONFIG: Final[tuple[str, ...]] = (
     "interval",
     "stale_days",
@@ -121,6 +135,24 @@ def validate_artifact(data: dict[str, Any]) -> list[str]:
             passed = coverage.get("passed")
             if passed is not None and not isinstance(passed, bool):
                 errors.append("metadata.coverage.passed must be a boolean")
+
+        regime = metadata.get("market_regime")
+        if regime is None:
+            errors.append("metadata.market_regime must not be null")
+        elif not isinstance(regime, dict):
+            errors.append("metadata.market_regime must be a JSON object")
+        else:
+            errors.extend(
+                f"metadata.market_regime missing required key: {key!r}"
+                for key in _REQUIRED_REGIME
+                if key not in regime
+            )
+            label = regime.get("label")
+            if label is not None and label not in _REGIME_LABELS:
+                errors.append(
+                    f"metadata.market_regime.label {label!r} is not one of"
+                    f" {sorted(_REGIME_LABELS)}"
+                )
 
     instruments = data["instruments"]
     if not isinstance(instruments, list):

--- a/tests/test_generate_report.py
+++ b/tests/test_generate_report.py
@@ -504,6 +504,43 @@ def test_market_regime_zero_ma20_dist_not_above(gr: ModuleType) -> None:
     assert gr.market_regime([_reliable_inst(0.0)]) == "Bearish"
 
 
+# ── regime_from_artifact tests ──────────────────────────────────────────────────
+
+
+def test_regime_from_artifact_prefers_stored_metadata(gr: ModuleType) -> None:
+    artifact = {
+        "metadata": {
+            "market_regime": {
+                "label": "Bearish",
+                "positive_count": 1,
+                "reliable_count": 10,
+                "breadth": 0.1,
+                "thresholds": {"bullish": 0.65, "bearish": 0.35},
+            }
+        }
+    }
+    # Reliable instruments here would recompute as Bullish; the stored label
+    # must win so reports and notifications stay authoritative and auditable.
+    reliable = [_reliable_inst(0.05), _reliable_inst(0.05)]
+    assert gr.regime_from_artifact(artifact, reliable) == ("Bearish", 1, 10)
+
+
+def test_regime_from_artifact_falls_back_when_metadata_missing(
+    gr: ModuleType,
+) -> None:
+    # Artifacts generated before #77 lack metadata.market_regime.
+    reliable = [_reliable_inst(0.05)]
+    assert gr.regime_from_artifact({"metadata": {}}, reliable) == ("Bullish", 1, 1)
+
+
+def test_regime_from_artifact_falls_back_when_metadata_malformed(
+    gr: ModuleType,
+) -> None:
+    artifact = {"metadata": {"market_regime": {"label": "Bullish"}}}
+    reliable = [_reliable_inst(-0.05)]
+    assert gr.regime_from_artifact(artifact, reliable) == ("Bearish", 0, 1)
+
+
 # ── _format_pct tests ───────────────────────────────────────────────────────────
 
 

--- a/tests/test_market_analysis.py
+++ b/tests/test_market_analysis.py
@@ -807,7 +807,7 @@ def test_generate_artifact_structure(ma: ModuleType, mocker: MockerFixture) -> N
     ref = bars[-1].timestamp + timedelta(days=1)
     scores = ma.score_instruments({"A": bars}, reference_time=ref)
     artifact = ma.generate_artifact(scores, {"A": bars}, {"stale_days": 5})
-    assert artifact["version"] == "1.0.0"
+    assert artifact["version"] == "1.1.0"
     assert "metadata" in artifact
     assert "instruments" in artifact
     meta = artifact["metadata"]
@@ -855,6 +855,87 @@ def test_risk_gate_missing_data_constant(ma: ModuleType) -> None:
     assert ma.RISK_GATE_MISSING_DATA == "missing_data"
 
 
+def _score(
+    ma: ModuleType, symbol: str, *, ma20_dist: float | None, is_reliable: bool = True
+) -> object:
+    feats = ma.InstrumentFeatures(
+        ret_1d=None,
+        ret_5d=None,
+        ret_20d=None,
+        ret_60d=None,
+        ma20_dist=ma20_dist,
+        ma50_dist=None,
+        vol_20d=None,
+        mdd_60d=None,
+        rsi_14=None,
+        zscore_20d=None,
+    )
+    return ma.InstrumentScore(
+        symbol=symbol,
+        rank=1,
+        score=50.0,
+        features=feats,
+        risk_gates=[] if is_reliable else ["stale_data"],
+        is_reliable=is_reliable,
+        explanation="x",
+    )
+
+
+def test_market_regime_metadata_bullish(ma: ModuleType) -> None:
+    scores = [_score(ma, "A", ma20_dist=0.05), _score(ma, "B", ma20_dist=0.01)]
+    regime = ma.market_regime_metadata(scores)
+    assert regime == {
+        "label": "Bullish",
+        "positive_count": 2,
+        "reliable_count": 2,
+        "breadth": 1.0,
+        "thresholds": {"bullish": 0.65, "bearish": 0.35},
+    }
+
+
+def test_market_regime_metadata_bearish(ma: ModuleType) -> None:
+    scores = [_score(ma, "A", ma20_dist=-0.05), _score(ma, "B", ma20_dist=-0.01)]
+    regime = ma.market_regime_metadata(scores)
+    assert regime["label"] == "Bearish"
+    assert regime["breadth"] == 0.0
+
+
+def test_market_regime_metadata_neutral(ma: ModuleType) -> None:
+    scores = [_score(ma, "A", ma20_dist=0.05), _score(ma, "B", ma20_dist=-0.01)]
+    regime = ma.market_regime_metadata(scores)
+    assert regime["label"] == "Neutral"
+    assert regime["breadth"] == 0.5
+
+
+def test_market_regime_metadata_unavailable_without_ma20_data(ma: ModuleType) -> None:
+    scores = [_score(ma, "A", ma20_dist=None)]
+    regime = ma.market_regime_metadata(scores)
+    assert regime["label"] == "Unavailable"
+    assert regime["breadth"] is None
+    assert regime["reliable_count"] == 0
+
+
+def test_market_regime_metadata_ignores_unreliable_instruments(
+    ma: ModuleType,
+) -> None:
+    scores = [_score(ma, "A", ma20_dist=-0.05, is_reliable=False)]
+    regime = ma.market_regime_metadata(scores)
+    assert regime["label"] == "Unavailable"
+
+
+def test_generate_artifact_includes_market_regime(
+    ma: ModuleType, mocker: MockerFixture
+) -> None:
+    mocker.patch.object(ma, "_get_git_commit", return_value="abc")
+    bars = _make_bars(ma, "A", [float(100 + i) for i in range(80)])
+    ref = bars[-1].timestamp + timedelta(days=1)
+    scores = ma.score_instruments({"A": bars}, reference_time=ref)
+    artifact = ma.generate_artifact(scores, {"A": bars}, {})
+    regime = artifact["metadata"]["market_regime"]
+    assert regime["label"] in {"Bullish", "Bearish", "Neutral", "Unavailable"}
+    assert "thresholds" in regime
+
+
 def test_generate_artifact_empty_data_source(
     ma: ModuleType, mocker: MockerFixture
 ) -> None:
@@ -888,7 +969,7 @@ def test_save_artifact_path_contains_date(
     path = ma.save_artifact(artifact, tmp_path)
     assert path.suffix == ".json"
     loaded = json.loads(path.read_text())
-    assert loaded["version"] == "1.0.0"
+    assert loaded["version"] == "1.1.0"
 
 
 def test_save_artifact_no_generated_at(ma: ModuleType, tmp_path: Path) -> None:

--- a/tests/test_validate_analysis.py
+++ b/tests/test_validate_analysis.py
@@ -30,8 +30,16 @@ VALID_INSTRUMENT: dict[str, Any] = {
     "features": {"ret_1d": 0.01},
 }
 
+VALID_REGIME: dict[str, Any] = {
+    "label": "Bullish",
+    "positive_count": 1,
+    "reliable_count": 1,
+    "breadth": 1.0,
+    "thresholds": {"bullish": 0.65, "bearish": 0.35},
+}
+
 VALID_ARTIFACT: dict[str, Any] = {
-    "version": "1.0.0",
+    "version": "1.1.0",
     "metadata": {
         "generated_at": "2024-01-01T00:00:00+00:00",
         "git_commit": "abc1234",
@@ -56,6 +64,7 @@ VALID_ARTIFACT: dict[str, Any] = {
             "passed": True,
             "violations": [],
         },
+        "market_regime": VALID_REGIME,
     },
     "instruments": [VALID_INSTRUMENT],
 }
@@ -310,6 +319,46 @@ def test_validate_coverage_null_rejected(va: ModuleType) -> None:
     }
     errors = va.validate_artifact(data)
     assert any("metadata.coverage must not be null" in e for e in errors)
+
+
+def test_validate_market_regime_null_rejected(va: ModuleType) -> None:
+    data = {
+        **VALID_ARTIFACT,
+        "metadata": {**VALID_ARTIFACT["metadata"], "market_regime": None},
+    }
+    errors = va.validate_artifact(data)
+    assert any("metadata.market_regime must not be null" in e for e in errors)
+
+
+def test_validate_market_regime_must_be_object(va: ModuleType) -> None:
+    data = {
+        **VALID_ARTIFACT,
+        "metadata": {**VALID_ARTIFACT["metadata"], "market_regime": []},
+    }
+    errors = va.validate_artifact(data)
+    assert any("metadata.market_regime must be a JSON object" in e for e in errors)
+
+
+def test_validate_market_regime_missing_key(va: ModuleType) -> None:
+    bad_regime = {k: v for k, v in VALID_REGIME.items() if k != "breadth"}
+    data = {
+        **VALID_ARTIFACT,
+        "metadata": {**VALID_ARTIFACT["metadata"], "market_regime": bad_regime},
+    }
+    errors = va.validate_artifact(data)
+    assert any("market_regime missing required key: 'breadth'" in e for e in errors)
+
+
+def test_validate_market_regime_unknown_label(va: ModuleType) -> None:
+    data = {
+        **VALID_ARTIFACT,
+        "metadata": {
+            **VALID_ARTIFACT["metadata"],
+            "market_regime": {**VALID_REGIME, "label": "Sideways"},
+        },
+    }
+    errors = va.validate_artifact(data)
+    assert any("market_regime.label" in e for e in errors)
 
 
 def test_validate_data_freshness_valid(va: ModuleType) -> None:


### PR DESCRIPTION
## Summary

Closes #77 — the market regime label was recomputed downstream (in report generation and Slack notification) from MA20 breadth every time, with no persisted audit trail for the inputs behind the label.

- Added `market_regime_metadata(scores)` to `src/aims/market_analysis.py`, computed once during `generate_artifact` and stored as `metadata.market_regime`: `{label, positive_count, reliable_count, breadth, thresholds}`.
- Bumped `ARTIFACT_VERSION` to `1.1.0`; `validate_analysis.py` and `data/schema/analysis.schema.json` now require and structurally validate the field (label must be one of Bullish/Bearish/Neutral/Unavailable).
- `src/aims/reports.py` gained `regime_from_artifact(artifact, reliable)`, which prefers the stored metadata and falls back to on-the-fly recomputation (the old `market_regime`/`_regime_breadth` logic, kept intact) only for artifacts generated before this field existed (schema < 1.1.0) — so all previously committed reports/artifacts keep rendering identically.
- `src/aims/notifications.py` now reads the same authoritative source instead of recomputing.
- `OPERATIONS.md` §3 documents the new metadata shape and the fallback behavior.

## Validation

- `uv run pytest` — 954 passed, 100% branch coverage (new tests for `market_regime_metadata`'s four label branches, `regime_from_artifact`'s stored/fallback/malformed paths, and validator error paths for the new field)
- `ruff` / `pyright` — clean
- End-to-end: generated a real artifact via `market_analysis.py generate` (`{"label": "Bullish", "positive_count": 3, "reliable_count": 3, "breadth": 1.0, ...}`), validated it, rendered the report, and confirmed the "Market Regime" section reads the stored label
- Confirmed a pre-#77 committed artifact (`data/analysis/2026-07-04.json`, no `market_regime` key) still renders correctly via the fallback path

🤖 Generated with [Claude Code](https://claude.com/claude-code)