### PR TITLE
feat(pipeline): add provider failover and cross-provider price checks (#81)

### DIFF
--- a/.github/workflows/daily-market-analysis.yml
+++ b/.github/workflows/daily-market-analysis.yml
@@ -71,6 +71,10 @@ jobs:
       MIN_SUCCESS_RATIO: ${{ inputs.min_success_ratio || '0.8' }}
       MAX_MISSING_SYMBOLS: ${{ inputs.max_missing_symbols || '4' }}
       PROVIDER: ${{ inputs.provider || 'yfinance' }}
+      # Retried when the primary provider's coverage gate fails (#81); the
+      # other of the two registered providers with a daily symbol universe.
+      FALLBACK_PROVIDER: >-
+        ${{ (inputs.provider || 'yfinance') == 'stooq' && 'yfinance' || 'stooq' }}
       SLACK_NOTIFICATIONS_ENABLED: ${{ secrets.SLACK_WEBHOOK_URL != '' }}
       # Qualitative steps run only when the optional ANTHROPIC_API_KEY secret
       # exists (mirroring SLACK_NOTIFICATIONS_ENABLED); without it the run is
@@ -120,6 +124,10 @@ jobs:
             STEM="${DATE}-${INTERVAL}"
           fi
           echo "stem=$STEM" >> "$GITHUB_OUTPUT"
+          # Cross-provider consistency check runs weekly (Monday) rather than
+          # daily to avoid doubling fetch volume every run.
+          echo "is_monday=$([ "$(date -u -d "$DATE" +%u)" = 1 ] && echo true || echo false)" \
+            >> "$GITHUB_OUTPUT"
       - name: Load symbols
         id: symbols
         env:
@@ -166,8 +174,107 @@ jobs:
               --fetch-status "${FETCH_STATUS}" \
               || echo "WARNING: fetch failed for $SYM; symbol will be marked missing in artifact"
           done
+      - name: Fetch market data (secondary provider, weekly consistency check)
+        if: steps.symbols.outputs.symbols != '' && steps.date.outputs.is_monday == 'true'
+        env:
+          DATE: ${{ steps.date.outputs.date }}
+        run: |
+          START=$(uv run python -c "
+          from datetime import datetime, timedelta
+          from aims.policy import fetch_window_days
+          d = datetime.strptime('${DATE}', '%Y-%m-%d')
+          window = fetch_window_days('${INTERVAL}')
+          print((d - timedelta(days=window)).strftime('%Y-%m-%d'))
+          ")
+          SECONDARY_SYMBOLS=$(uv run python -c "
+          from pathlib import Path
+          from aims.market_analysis import load_instrument_mappings, symbols_from_mappings
+          rows = load_instrument_mappings(Path('data/mappings/canonical_instrument_mappings.csv'))
+          print(','.join(symbols_from_mappings(rows, '${FALLBACK_PROVIDER}', '${INTERVAL}')))
+          ")
+          IFS=',' read -ra SYMS <<< "${SECONDARY_SYMBOLS}"
+          for SYM in "${SYMS[@]}"; do
+            uv run python .agents/skills/market-analysis/scripts/market_analysis.py \
+              fetch --symbol "$SYM" --start "$START" --end "$DATE" \
+              --interval "$INTERVAL" \
+              --provider "$FALLBACK_PROVIDER" \
+              --output "data/prices-secondary" \
+              || echo "WARNING: secondary-provider fetch failed for $SYM; excluded from consistency check"
+          done
+      - name: Cross-provider consistency check
+        if: steps.symbols.outputs.symbols != '' && steps.date.outputs.is_monday == 'true'
+        run: |
+          uv run python .agents/skills/market-analysis/scripts/market_analysis.py \
+            consistency \
+            --mapping data/mappings/canonical_instrument_mappings.csv \
+            --interval "$INTERVAL" \
+            --primary-provider "$PROVIDER" \
+            --secondary-provider "$FALLBACK_PROVIDER" \
+            --primary-data-dir data/prices \
+            --secondary-data-dir data/prices-secondary \
+            --output "data/prices/consistency_${INTERVAL}.json"
       - name: Generate analysis artifact
+        id: generate_primary
         if: steps.symbols.outputs.symbols != ''
+        continue-on-error: true
+        env:
+          DATE: ${{ steps.date.outputs.date }}
+        run: |
+          ARGS=(
+            --mapping data/mappings/canonical_instrument_mappings.csv
+            --interval "$INTERVAL"
+            --analysis-date "${DATE}"
+            --provider "$PROVIDER"
+            --fetch-status "data/prices/fetch_status_${INTERVAL}.json"
+            --min-success-ratio "${MIN_SUCCESS_RATIO}"
+            --max-missing-symbols "${MAX_MISSING_SYMBOLS}"
+            --output data/analysis/
+          )
+          if [ -f "data/prices/consistency_${INTERVAL}.json" ]; then
+            ARGS+=(--price-consistency "data/prices/consistency_${INTERVAL}.json")
+          fi
+          uv run python .agents/skills/market-analysis/scripts/market_analysis.py \
+            generate "${ARGS[@]}"
+      - name: Fetch market data (fallback provider)
+        if: steps.symbols.outputs.symbols != '' && steps.generate_primary.outcome == 'failure'
+        env:
+          DATE: ${{ steps.date.outputs.date }}
+        run: |
+          START=$(uv run python -c "
+          from datetime import datetime, timedelta
+          from aims.policy import fetch_window_days
+          d = datetime.strptime('${DATE}', '%Y-%m-%d')
+          window = fetch_window_days('${INTERVAL}')
+          print((d - timedelta(days=window)).strftime('%Y-%m-%d'))
+          ")
+          FALLBACK_SYMBOLS=$(uv run python -c "
+          from pathlib import Path
+          from aims.market_analysis import load_instrument_mappings, symbols_from_mappings
+          rows = load_instrument_mappings(Path('data/mappings/canonical_instrument_mappings.csv'))
+          print(','.join(symbols_from_mappings(rows, '${FALLBACK_PROVIDER}', '${INTERVAL}')))
+          ")
+          FETCH_STATUS="data/prices-fallback/fetch_status_${INTERVAL}.json"
+          uv run python .agents/skills/market-analysis/scripts/market_analysis.py \
+            init-fetch-status \
+            --symbols "${FALLBACK_SYMBOLS}" \
+            --interval "$INTERVAL" \
+            --analysis-date "${DATE}" \
+            --provider "$FALLBACK_PROVIDER" \
+            --output "${FETCH_STATUS}"
+          IFS=',' read -ra SYMS <<< "${FALLBACK_SYMBOLS}"
+          for SYM in "${SYMS[@]}"; do
+            uv run python .agents/skills/market-analysis/scripts/market_analysis.py \
+              fetch --symbol "$SYM" --start "$START" --end "$DATE" \
+              --interval "$INTERVAL" \
+              --provider "$FALLBACK_PROVIDER" \
+              --fetch-status "${FETCH_STATUS}" \
+              --output "data/prices-fallback" \
+              || echo "WARNING: fallback fetch failed for $SYM; symbol will be marked missing"
+          done
+      - name: Generate analysis artifact (fallback provider)
+        id: generate_fallback
+        if: steps.symbols.outputs.symbols != '' && steps.generate_primary.outcome == 'failure'
+        continue-on-error: true
         env:
           DATE: ${{ steps.date.outputs.date }}
         run: |
@@ -176,11 +283,21 @@ jobs:
             --mapping data/mappings/canonical_instrument_mappings.csv \
             --interval "$INTERVAL" \
             --analysis-date "${DATE}" \
-            --provider "$PROVIDER" \
-            --fetch-status "data/prices/fetch_status_${INTERVAL}.json" \
+            --provider "$FALLBACK_PROVIDER" \
+            --data-dir data/prices-fallback \
+            --fetch-status "data/prices-fallback/fetch_status_${INTERVAL}.json" \
             --min-success-ratio "${MIN_SUCCESS_RATIO}" \
             --max-missing-symbols "${MAX_MISSING_SYMBOLS}" \
             --output data/analysis/
+      - name: Fail if both providers failed to generate a valid artifact
+        if: >
+          steps.symbols.outputs.symbols != ''
+          && steps.generate_primary.outcome == 'failure'
+          && steps.generate_fallback.outcome == 'failure'
+        run: |
+          echo "::error::Both primary ($PROVIDER) and fallback" \
+            "($FALLBACK_PROVIDER) providers failed the coverage gate."
+          exit 1
       - name: Validate artifact
         if: steps.symbols.outputs.symbols != ''
         env:

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -54,6 +54,14 @@ Pass `--provider <name>` to `init-fetch-status`, `fetch`, or `generate`. The def
 
 **Adding a future provider:** Subclass `MarketDataProvider` in `src/aims/market_analysis.py`, register it in `_PROVIDER_REGISTRY` with a `ProviderMetadata` entry listing its supported intervals and any known limitations, and mirror the entry in `src/aims/mappings.py`'s `_KNOWN_PROVIDERS` and `_PROVIDER_INTERVALS`. Update the `provider` input choices in `.github/workflows/daily-market-analysis.yml`. Add the new provider to the test suite to maintain 100% coverage.
 
+### Provider failover
+
+If the primary provider's fetch fails the coverage gate (`generate` returns non-zero), the daily workflow retries the full fetch-and-generate cycle with the other registered provider (`FALLBACK_PROVIDER`: `stooq` when the primary is `yfinance`, and vice versa) before failing the run. The fallback fetch writes into a separate `data/prices-fallback/` directory so it never mixes with the primary provider's local cache. If both providers fail the coverage gate, the job fails explicitly and the failure Slack notification fires. One provider's data always fills the whole artifact — the two are never mixed for a single run.
+
+### Cross-provider price consistency
+
+Every Monday, the daily workflow additionally fetches the secondary provider's data (into `data/prices-secondary/`, not committed) and runs `market_analysis.py consistency`, which compares closes for canonical instruments available from both providers over their last 5 common bars. Divergence above 0.5% is recorded as a warning; divergence above 2% is escalated. The report feeds into `generate --price-consistency`, which stores it at `metadata.price_consistency` and adds a `provider_divergence` risk gate (marking the instrument unreliable) to any escalated instrument. Escalated instruments are also called out in the Slack success notification. This check is weekly rather than daily to avoid doubling fetch volume on every run.
+
 ### CFD instrument master
 
 The canonical list of CFD products available at supported brokers is maintained in `data/cfd_instruments.csv`. It is refreshed weekly by the `update-cfd-instruments` workflow. The daily analysis workflow validates this file before running but does not modify it.

--- a/src/aims/market_analysis.py
+++ b/src/aims/market_analysis.py
@@ -74,6 +74,11 @@ RISK_GATE_INSUFFICIENT: Final[str] = "insufficient_history"
 RISK_GATE_MISSING_BARS: Final[str] = "missing_bars"
 RISK_GATE_MALFORMED: Final[str] = "malformed_input"
 RISK_GATE_MISSING_DATA: Final[str] = "missing_data"
+RISK_GATE_PROVIDER_DIVERGENCE: Final[str] = "provider_divergence"
+
+_CONSISTENCY_BARS: Final[int] = 5
+_CONSISTENCY_WARN_THRESHOLD: Final[float] = 0.005
+_CONSISTENCY_ESCALATE_THRESHOLD: Final[float] = 0.02
 
 _OHLCV_FIELDS: Final[tuple[str, ...]] = (
     "symbol",
@@ -925,6 +930,58 @@ def _build_explanation(
     return "; ".join(parts)
 
 
+def check_price_consistency(
+    primary: dict[str, list[OhlcvBar]],
+    secondary: dict[str, list[OhlcvBar]],
+    *,
+    bars: int = _CONSISTENCY_BARS,
+    warn_threshold: float = _CONSISTENCY_WARN_THRESHOLD,
+    escalate_threshold: float = _CONSISTENCY_ESCALATE_THRESHOLD,
+) -> list[dict[str, Any]]:
+    """Compare closes between two providers' data, keyed by canonical_id.
+
+    Callers remap each provider's provider_symbol-keyed OHLCV to
+    canonical_id first (e.g. via ``instrument_display_map``), since the two
+    providers generally use different symbol conventions for the same
+    instrument. Only canonical_ids present in both series are compared, on
+    up to the last *bars* dates common to both. A bad adjusted close from
+    either source should not silently flow into scoring, so this flags
+    divergence rather than picking a "correct" value.
+    """
+    results: list[dict[str, Any]] = []
+    for canonical_id in sorted(set(primary) & set(secondary)):
+        primary_by_date = {b.timestamp.date(): b.close for b in primary[canonical_id]}
+        secondary_by_date = {
+            b.timestamp.date(): b.close for b in secondary[canonical_id]
+        }
+        common_dates = sorted(set(primary_by_date) & set(secondary_by_date))[-bars:]
+        if not common_dates:
+            results.append({
+                "canonical_id": canonical_id,
+                "bars_compared": 0,
+                "max_divergence": None,
+                "warned": False,
+                "escalated": False,
+            })
+            continue
+        divergences = [
+            abs(primary_by_date[d] - secondary_by_date[d]) / secondary_by_date[d]
+            for d in common_dates
+            if secondary_by_date[d]
+        ]
+        max_divergence = max(divergences) if divergences else None
+        results.append({
+            "canonical_id": canonical_id,
+            "bars_compared": len(common_dates),
+            "max_divergence": max_divergence,
+            "warned": max_divergence is not None and max_divergence > warn_threshold,
+            "escalated": (
+                max_divergence is not None and max_divergence > escalate_threshold
+            ),
+        })
+    return results
+
+
 def score_instruments(
     data: dict[str, list[OhlcvBar]],
     *,
@@ -932,6 +989,7 @@ def score_instruments(
     stale_days: int = _STALE_DAYS,
     min_history: int = _MIN_HISTORY,
     max_gap_days: int = _MAX_GAP_DAYS,
+    extra_risk_gates: dict[str, list[str]] | None = None,
 ) -> list[InstrumentScore]:
     if not data:
         return []
@@ -954,6 +1012,9 @@ def score_instruments(
     for idx, symbol in enumerate(symbols):
         feats = features_map[symbol]
         gates = _collect_risk_gates(reports[symbol], feats)
+        for gate in (extra_risk_gates or {}).get(symbol, []):
+            if gate not in gates:
+                gates.append(gate)
         rank_values = _compute_rank_values(feature_cols, idx)
         combined = sum(rank_values) / len(rank_values)
         scores.append(
@@ -1080,6 +1141,7 @@ def generate_artifact(
     missing_symbols: list[str] | None = None,
     coverage: dict[str, Any] | None = None,
     instrument_metadata: dict[str, dict[str, str]] | None = None,
+    price_consistency: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     now = datetime.now(tz=UTC)
     generated_at = (
@@ -1153,6 +1215,8 @@ def generate_artifact(
     }
     if coverage is not None:
         artifact_metadata["coverage"] = coverage
+    if price_consistency is not None:
+        artifact_metadata["price_consistency"] = price_consistency
     return {
         "version": ARTIFACT_VERSION,
         "metadata": artifact_metadata,
@@ -1401,6 +1465,29 @@ def _trim_bars_at_or_after(
     }
 
 
+def _load_price_consistency(
+    path: Path, display_meta: dict[str, dict[str, str]] | None
+) -> tuple[dict[str, Any], dict[str, list[str]]]:
+    """Load a consistency report and derive per-symbol escalation gates.
+
+    Returns (report, extra_risk_gates); *extra_risk_gates* maps a provider
+    symbol to ``[RISK_GATE_PROVIDER_DIVERGENCE]`` when its canonical_id was
+    flagged as escalated and *display_meta* can resolve it back to a
+    provider symbol used in this run's data.
+    """
+    with path.open(encoding="utf-8") as fh:
+        report: dict[str, Any] = json.load(fh)
+    escalated_ids = {
+        r["canonical_id"] for r in report.get("results", []) if r.get("escalated")
+    }
+    extra_risk_gates: dict[str, list[str]] = {}
+    if escalated_ids and display_meta:
+        for symbol, meta in display_meta.items():
+            if meta.get("canonical_id") in escalated_ids:
+                extra_risk_gates[symbol] = [RISK_GATE_PROVIDER_DIVERGENCE]
+    return report, extra_risk_gates
+
+
 def _cmd_generate(args: argparse.Namespace) -> int:
     provider_name: str = (
         getattr(args, "provider", _DEFAULT_PROVIDER) or _DEFAULT_PROVIDER
@@ -1428,6 +1515,17 @@ def _cmd_generate(args: argparse.Namespace) -> int:
             display_meta = instrument_display_map(rows, provider_name, args.interval)
         except (OSError, csv.Error):
             display_meta = None
+
+    price_consistency_report: dict[str, Any] | None = None
+    extra_risk_gates: dict[str, list[str]] = {}
+    price_consistency_arg: str | None = getattr(args, "price_consistency", None)
+    if price_consistency_arg:
+        try:
+            price_consistency_report, extra_risk_gates = _load_price_consistency(
+                Path(price_consistency_arg), display_meta
+            )
+        except (FileNotFoundError, json.JSONDecodeError) as exc:
+            print(f"WARNING: failed to load price consistency report: {exc}")
 
     coverage_policy = CoveragePolicy(
         min_success_ratio=args.min_success_ratio,
@@ -1506,6 +1604,7 @@ def _cmd_generate(args: argparse.Namespace) -> int:
         stale_days=thresholds.stale_days,
         min_history=thresholds.min_history,
         max_gap_days=thresholds.max_gap_days,
+        extra_risk_gates=extra_risk_gates or None,
     )
     artifact = generate_artifact(
         results,
@@ -1515,6 +1614,7 @@ def _cmd_generate(args: argparse.Namespace) -> int:
         missing_symbols=missing or None,
         coverage=coverage_metadata,
         instrument_metadata=display_meta,
+        price_consistency=price_consistency_report,
     )
     path = save_artifact(artifact, Path(args.output))
     print(f"artifact saved to {path}")
@@ -1525,6 +1625,59 @@ def _cmd_generate(args: argparse.Namespace) -> int:
         for violation in coverage_result.violations:
             print(f"ERROR: coverage gate failed: {violation}")
         return 1
+    return 0
+
+
+def _cmd_consistency(args: argparse.Namespace) -> int:
+    try:
+        rows = load_instrument_mappings(Path(args.mapping))
+    except (FileNotFoundError, csv.Error) as exc:
+        print(f"ERROR: {exc}")
+        return 1
+
+    primary_meta = instrument_display_map(rows, args.primary_provider, args.interval)
+    secondary_meta = instrument_display_map(
+        rows, args.secondary_provider, args.interval
+    )
+
+    def _load_by_canonical_id(
+        meta: dict[str, dict[str, str]], data_dir: str
+    ) -> dict[str, list[OhlcvBar]]:
+        loaded: dict[str, list[OhlcvBar]] = {}
+        for symbol, info in meta.items():
+            canonical_id = info.get("canonical_id")
+            if not canonical_id:
+                continue
+            try:
+                loaded[canonical_id] = load_ohlcv(symbol, args.interval, Path(data_dir))
+            except FileNotFoundError:
+                continue
+        return loaded
+
+    primary_data = _load_by_canonical_id(primary_meta, args.primary_data_dir)
+    secondary_data = _load_by_canonical_id(secondary_meta, args.secondary_data_dir)
+    results = check_price_consistency(primary_data, secondary_data)
+    report = {
+        "primary_provider": args.primary_provider,
+        "secondary_provider": args.secondary_provider,
+        "tolerance": {
+            "warn": _CONSISTENCY_WARN_THRESHOLD,
+            "escalate": _CONSISTENCY_ESCALATE_THRESHOLD,
+        },
+        "bars_checked": _CONSISTENCY_BARS,
+        "results": results,
+    }
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    warned = sum(1 for r in results if r["warned"] and not r["escalated"])
+    escalated = sum(1 for r in results if r["escalated"])
+    print(
+        f"consistency report written to {output_path}"
+        f" ({len(results)} compared, {warned} warned, {escalated} escalated)"
+    )
     return 0
 
 
@@ -1642,6 +1795,40 @@ def main(argv: list[str] | None = None) -> int:
         dest="fetch_status",
         help="Path to fetch-status JSON from the current fetch run",
     )
+    p_gen.add_argument(
+        "--price-consistency",
+        default=None,
+        dest="price_consistency",
+        help="Path to a consistency report from the 'consistency' subcommand",
+    )
+
+    p_cons = sub.add_parser(
+        "consistency",
+        help="Compare closes between two providers for the same instruments",
+    )
+    p_cons.add_argument(
+        "--mapping",
+        required=True,
+        help="Path to canonical_instrument_mappings.csv",
+    )
+    p_cons.add_argument("--interval", default=_DEFAULT_INTERVAL)
+    p_cons.add_argument(
+        "--primary-provider",
+        required=True,
+        dest="primary_provider",
+        choices=sorted(KNOWN_PROVIDERS),
+    )
+    p_cons.add_argument(
+        "--secondary-provider",
+        required=True,
+        dest="secondary_provider",
+        choices=sorted(KNOWN_PROVIDERS),
+    )
+    p_cons.add_argument("--primary-data-dir", required=True, dest="primary_data_dir")
+    p_cons.add_argument(
+        "--secondary-data-dir", required=True, dest="secondary_data_dir"
+    )
+    p_cons.add_argument("--output", required=True)
 
     args = parser.parse_args(argv)
 
@@ -1653,6 +1840,8 @@ def main(argv: list[str] | None = None) -> int:
         return _cmd_score(args)
     if args.command == "init-fetch-status":
         return _cmd_init_fetch_status(args)
+    if args.command == "consistency":
+        return _cmd_consistency(args)
     return _cmd_generate(args)
 
 

--- a/src/aims/notifications.py
+++ b/src/aims/notifications.py
@@ -222,6 +222,19 @@ def build_success_payload(
                 ),
             })
 
+    consistency_raw = meta.get("price_consistency")
+    if isinstance(consistency_raw, dict):
+        escalated = sorted(
+            str(r.get("canonical_id"))
+            for r in consistency_raw.get("results", [])
+            if isinstance(r, dict) and r.get("escalated")
+        )
+        if escalated:
+            fields.append({
+                "type": "mrkdwn",
+                "text": f"*⚠️ Provider divergence:* {', '.join(escalated)}",
+            })
+
     if pr_url is not None:
         text = f"AIMS Market Analysis {date_str}: {regime} market. Analysis PR created."
         button_text = "View PR"

--- a/tests/test_market_analysis.py
+++ b/tests/test_market_analysis.py
@@ -798,6 +798,111 @@ def test_get_git_commit_oserror(ma: ModuleType, mocker: MockerFixture) -> None:
     assert ma._get_git_commit() == "unknown"
 
 
+# ── check_price_consistency ─────────────────────────────────────────────────────
+
+
+def test_check_price_consistency_no_divergence(ma: ModuleType) -> None:
+    primary = {"spx": _make_bars(ma, "^GSPC", [100.0, 101.0, 102.0])}
+    secondary = {"spx": _make_bars(ma, "^SPX", [100.0, 101.0, 102.0])}
+    results = ma.check_price_consistency(primary, secondary)
+    assert results == [
+        {
+            "canonical_id": "spx",
+            "bars_compared": 3,
+            "max_divergence": 0.0,
+            "warned": False,
+            "escalated": False,
+        }
+    ]
+
+
+def test_check_price_consistency_warns_below_escalation(ma: ModuleType) -> None:
+    primary = {"spx": _make_bars(ma, "^GSPC", [100.0])}
+    secondary = {"spx": _make_bars(ma, "^SPX", [99.0])}
+    results = ma.check_price_consistency(primary, secondary)
+    assert results[0]["warned"] is True
+    assert results[0]["escalated"] is False
+
+
+def test_check_price_consistency_escalates_large_divergence(ma: ModuleType) -> None:
+    primary = {"spx": _make_bars(ma, "^GSPC", [110.0])}
+    secondary = {"spx": _make_bars(ma, "^SPX", [100.0])}
+    results = ma.check_price_consistency(primary, secondary)
+    assert results[0]["escalated"] is True
+    assert results[0]["warned"] is True
+
+
+def test_check_price_consistency_limits_to_last_n_bars(ma: ModuleType) -> None:
+    primary = {
+        "spx": _make_bars(ma, "^GSPC", [100.0, 100.0, 100.0, 100.0, 100.0, 200.0])
+    }
+    secondary = {"spx": _make_bars(ma, "^SPX", [100.0, 100.0, 100.0, 100.0, 100.0])}
+    # The divergent bar (index 5) has no counterpart in secondary, and only
+    # the last 5 bars are compared, so no divergence should be flagged.
+    results = ma.check_price_consistency(primary, secondary, bars=5)
+    assert results[0]["max_divergence"] == 0.0
+
+
+def test_check_price_consistency_no_common_canonical_ids(ma: ModuleType) -> None:
+    primary = {"spx": _make_bars(ma, "^GSPC", [100.0])}
+    secondary = {"ndx": _make_bars(ma, "^NDX", [100.0])}
+    assert ma.check_price_consistency(primary, secondary) == []
+
+
+def test_check_price_consistency_no_common_dates(ma: ModuleType) -> None:
+    primary = {
+        "spx": _make_bars(ma, "^GSPC", [100.0], start=datetime(2023, 1, 2, tzinfo=UTC))
+    }
+    secondary = {
+        "spx": _make_bars(ma, "^SPX", [100.0], start=datetime(2023, 2, 2, tzinfo=UTC))
+    }
+    results = ma.check_price_consistency(primary, secondary)
+    assert results == [
+        {
+            "canonical_id": "spx",
+            "bars_compared": 0,
+            "max_divergence": None,
+            "warned": False,
+            "escalated": False,
+        }
+    ]
+
+
+def test_check_price_consistency_ignores_zero_secondary_close(ma: ModuleType) -> None:
+    primary = {"spx": _make_bars(ma, "^GSPC", [100.0])}
+    secondary = {"spx": _make_bars(ma, "^SPX", [0.0])}
+    results = ma.check_price_consistency(primary, secondary)
+    assert results[0]["max_divergence"] is None
+    assert results[0]["warned"] is False
+
+
+# ── score_instruments extra_risk_gates ──────────────────────────────────────────
+
+
+def test_score_instruments_applies_extra_risk_gates(ma: ModuleType) -> None:
+    bars = _make_bars(ma, "A", [float(100 + i) for i in range(80)])
+    ref = bars[-1].timestamp + timedelta(days=1)
+    scores = ma.score_instruments(
+        {"A": bars},
+        reference_time=ref,
+        extra_risk_gates={"A": [ma.RISK_GATE_PROVIDER_DIVERGENCE]},
+    )
+    assert ma.RISK_GATE_PROVIDER_DIVERGENCE in scores[0].risk_gates
+    assert scores[0].is_reliable is False
+
+
+def test_score_instruments_extra_risk_gates_deduplicates(ma: ModuleType) -> None:
+    bars = _make_bars(ma, "A", [float(100 + i) for i in range(80)])
+    ref = bars[-1].timestamp + timedelta(days=1)
+    scores = ma.score_instruments(
+        {"A": bars},
+        reference_time=ref,
+        stale_days=0,
+        extra_risk_gates={"A": [ma.RISK_GATE_STALE]},
+    )
+    assert scores[0].risk_gates.count(ma.RISK_GATE_STALE) == 1
+
+
 # ── generate_artifact / save_artifact ─────────────────────────────────────────
 
 
@@ -934,6 +1039,29 @@ def test_generate_artifact_includes_market_regime(
     regime = artifact["metadata"]["market_regime"]
     assert regime["label"] in {"Bullish", "Bearish", "Neutral", "Unavailable"}
     assert "thresholds" in regime
+
+
+def test_generate_artifact_includes_price_consistency_when_given(
+    ma: ModuleType, mocker: MockerFixture
+) -> None:
+    mocker.patch.object(ma, "_get_git_commit", return_value="abc")
+    bars = _make_bars(ma, "A", [float(100 + i) for i in range(80)])
+    ref = bars[-1].timestamp + timedelta(days=1)
+    scores = ma.score_instruments({"A": bars}, reference_time=ref)
+    report = {"primary_provider": "yfinance", "results": []}
+    artifact = ma.generate_artifact(scores, {"A": bars}, {}, price_consistency=report)
+    assert artifact["metadata"]["price_consistency"] == report
+
+
+def test_generate_artifact_omits_price_consistency_by_default(
+    ma: ModuleType, mocker: MockerFixture
+) -> None:
+    mocker.patch.object(ma, "_get_git_commit", return_value="abc")
+    bars = _make_bars(ma, "A", [float(100 + i) for i in range(80)])
+    ref = bars[-1].timestamp + timedelta(days=1)
+    scores = ma.score_instruments({"A": bars}, reference_time=ref)
+    artifact = ma.generate_artifact(scores, {"A": bars}, {})
+    assert "price_consistency" not in artifact["metadata"]
 
 
 def test_generate_artifact_empty_data_source(
@@ -2906,3 +3034,234 @@ def test_cmd_generate_mapping_display_meta_load_error(
 
     # display_meta falls back to None; generate still succeeds
     assert ma._cmd_generate(Args()) == 0
+
+
+# ── _load_price_consistency / --price-consistency wiring ───────────────────────
+
+
+def test_load_price_consistency_derives_extra_risk_gates(
+    ma: ModuleType, tmp_path: Path
+) -> None:
+    report = {
+        "results": [
+            {"canonical_id": "spx", "escalated": True},
+            {"canonical_id": "dji", "escalated": False},
+        ]
+    }
+    path = tmp_path / "consistency.json"
+    path.write_text(json.dumps(report), encoding="utf-8")
+    display_meta = {"^SPX": {"canonical_id": "spx"}, "^DJI": {"canonical_id": "dji"}}
+    loaded, extra_gates = ma._load_price_consistency(path, display_meta)
+    assert loaded == report
+    assert extra_gates == {"^SPX": [ma.RISK_GATE_PROVIDER_DIVERGENCE]}
+
+
+def test_load_price_consistency_no_escalation_yields_no_gates(
+    ma: ModuleType, tmp_path: Path
+) -> None:
+    report = {"results": [{"canonical_id": "spx", "escalated": False}]}
+    path = tmp_path / "consistency.json"
+    path.write_text(json.dumps(report), encoding="utf-8")
+    loaded, extra_gates = ma._load_price_consistency(
+        path, {"^SPX": {"canonical_id": "spx"}}
+    )
+    assert loaded == report
+    assert extra_gates == {}
+
+
+def test_load_price_consistency_without_display_meta(
+    ma: ModuleType, tmp_path: Path
+) -> None:
+    report = {"results": [{"canonical_id": "spx", "escalated": True}]}
+    path = tmp_path / "consistency.json"
+    path.write_text(json.dumps(report), encoding="utf-8")
+    loaded, extra_gates = ma._load_price_consistency(path, None)
+    assert loaded == report
+    assert extra_gates == {}
+
+
+def test_cmd_generate_applies_price_consistency_escalation(
+    ma: ModuleType, mocker: MockerFixture, tmp_path: Path
+) -> None:
+    mocker.patch.object(ma, "_get_git_commit", return_value="abc")
+    mapping_path = _write_mini_mapping(tmp_path)
+    for sym in ("^SPX", "^DJI"):
+        bars = _make_bars(ma, sym, [float(100 + i) for i in range(70)])
+        ma.save_ohlcv(bars, tmp_path)
+    consistency_path = tmp_path / "consistency.json"
+    consistency_path.write_text(
+        json.dumps({"results": [{"canonical_id": "spx", "escalated": True}]}),
+        encoding="utf-8",
+    )
+
+    class Args:
+        symbols = None
+        mapping = str(mapping_path)
+        interval = "d"
+        provider = "stooq"
+        data_dir = str(tmp_path)
+        output = str(tmp_path / "analysis")
+        analysis_date = "2024-07-01"
+        min_success_ratio = 0.8
+        max_missing_symbols = 1
+        fetch_status = None
+        price_consistency = str(consistency_path)
+
+    assert ma._cmd_generate(Args()) == 0
+    artifact = json.loads((tmp_path / "analysis" / "2024-07-01.json").read_text())
+    assert "price_consistency" in artifact["metadata"]
+    spx_inst = next(i for i in artifact["instruments"] if i["symbol"] == "^SPX")
+    assert ma.RISK_GATE_PROVIDER_DIVERGENCE in spx_inst["risk_gates"]
+    assert spx_inst["is_reliable"] is False
+    dji_inst = next(i for i in artifact["instruments"] if i["symbol"] == "^DJI")
+    assert ma.RISK_GATE_PROVIDER_DIVERGENCE not in dji_inst["risk_gates"]
+
+
+def test_cmd_generate_missing_price_consistency_file_warns_and_continues(
+    ma: ModuleType,
+    mocker: MockerFixture,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    mocker.patch.object(ma, "_get_git_commit", return_value="abc")
+    bars = _make_bars(ma, "E", [float(100 + i) for i in range(70)])
+    ma.save_ohlcv(bars, tmp_path)
+
+    class Args:
+        symbols = "E"
+        interval = "d"
+        data_dir = str(tmp_path)
+        output = str(tmp_path / "analysis")
+        analysis_date = None
+        min_success_ratio = 0.8
+        max_missing_symbols = 1
+        price_consistency = str(tmp_path / "missing.json")
+
+    result = ma._cmd_generate(Args())
+    assert result == 0
+    assert "WARNING: failed to load price consistency report" in capsys.readouterr().out
+
+
+# ── consistency subcommand ───────────────────────────────────────────────────────
+
+
+def test_cmd_consistency_writes_report(
+    ma: ModuleType, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    mapping_path = _write_mini_mapping(tmp_path)
+    primary_dir = tmp_path / "primary"
+    secondary_dir = tmp_path / "secondary"
+    ma.save_ohlcv(_make_bars(ma, "^SPX", [100.0, 101.0]), primary_dir)
+    ma.save_ohlcv(_make_bars(ma, "^SPX", [110.0, 111.0]), secondary_dir)
+    output_path = tmp_path / "out" / "consistency.json"
+
+    class Args:
+        mapping = str(mapping_path)
+        interval = "d"
+        primary_provider = "stooq"
+        secondary_provider = "stooq"
+        primary_data_dir = str(primary_dir)
+        secondary_data_dir = str(secondary_dir)
+        output = str(output_path)
+
+    assert ma._cmd_consistency(Args()) == 0
+    report = json.loads(output_path.read_text())
+    assert report["primary_provider"] == "stooq"
+    assert report["results"][0]["canonical_id"] == "spx"
+    assert report["results"][0]["escalated"] is True
+    out = capsys.readouterr().out
+    assert "1 compared" in out
+    assert "1 escalated" in out
+
+
+def test_cmd_consistency_skips_symbols_without_local_data(
+    ma: ModuleType, tmp_path: Path
+) -> None:
+    mapping_path = _write_mini_mapping(tmp_path)
+    primary_dir = tmp_path / "primary"
+    secondary_dir = tmp_path / "secondary"
+    ma.save_ohlcv(_make_bars(ma, "^SPX", [100.0]), primary_dir)
+    # secondary_dir has no data at all for any symbol.
+
+    class Args:
+        mapping = str(mapping_path)
+        interval = "d"
+        primary_provider = "stooq"
+        secondary_provider = "stooq"
+        primary_data_dir = str(primary_dir)
+        secondary_data_dir = str(secondary_dir)
+        output = str(tmp_path / "out.json")
+
+    assert ma._cmd_consistency(Args()) == 0
+    report = json.loads((tmp_path / "out.json").read_text())
+    assert report["results"] == []
+
+
+def test_cmd_consistency_skips_rows_with_blank_canonical_id(
+    ma: ModuleType, tmp_path: Path
+) -> None:
+    mapping_path = tmp_path / "mappings.csv"
+    mapping_path.write_text(
+        "canonical_id,display_name,asset_class,broker,broker_instrument_name,"
+        "broker_ticker_symbol,provider,provider_symbol,provider_interval,"
+        "tradable,notes\n"
+        ",Unlabeled,equity_index,,,,stooq,^UNLABELED,d,true,\n",
+        encoding="utf-8",
+    )
+    primary_dir = tmp_path / "primary"
+    ma.save_ohlcv(_make_bars(ma, "^UNLABELED", [100.0]), primary_dir)
+
+    class Args:
+        mapping = str(mapping_path)
+        interval = "d"
+        primary_provider = "stooq"
+        secondary_provider = "stooq"
+        primary_data_dir = str(primary_dir)
+        secondary_data_dir = str(primary_dir)
+        output = str(tmp_path / "out.json")
+
+    assert ma._cmd_consistency(Args()) == 0
+    report = json.loads((tmp_path / "out.json").read_text())
+    assert report["results"] == []
+
+
+def test_cmd_consistency_mapping_load_error(
+    ma: ModuleType, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    class Args:
+        mapping = str(tmp_path / "missing.csv")
+        interval = "d"
+        primary_provider = "stooq"
+        secondary_provider = "yfinance"
+        primary_data_dir = str(tmp_path)
+        secondary_data_dir = str(tmp_path)
+        output = str(tmp_path / "out.json")
+
+    assert ma._cmd_consistency(Args()) == 1
+    assert "ERROR" in capsys.readouterr().out
+
+
+def test_main_consistency_subcommand(ma: ModuleType, tmp_path: Path) -> None:
+    mapping_path = _write_mini_mapping(tmp_path)
+    primary_dir = tmp_path / "primary"
+    secondary_dir = tmp_path / "secondary"
+    ma.save_ohlcv(_make_bars(ma, "^SPX", [100.0]), primary_dir)
+    ma.save_ohlcv(_make_bars(ma, "^SPX", [100.0]), secondary_dir)
+    output_path = tmp_path / "consistency.json"
+    exit_code = ma.main([
+        "consistency",
+        "--mapping",
+        str(mapping_path),
+        "--primary-provider",
+        "stooq",
+        "--secondary-provider",
+        "stooq",
+        "--primary-data-dir",
+        str(primary_dir),
+        "--secondary-data-dir",
+        str(secondary_dir),
+        "--output",
+        str(output_path),
+    ])
+    assert exit_code == 0
+    assert output_path.exists()

--- a/tests/test_notify_slack.py
+++ b/tests/test_notify_slack.py
@@ -166,6 +166,45 @@ def test_build_success_payload_coverage_summary(
     assert "3/3" in fields_text
 
 
+def test_build_success_payload_price_consistency_escalated(
+    ns: ModuleType, fixture_artifact: dict[str, Any]
+) -> None:
+    artifact = {
+        **fixture_artifact,
+        "metadata": {
+            **fixture_artifact["metadata"],
+            "price_consistency": {
+                "results": [
+                    {"canonical_id": "spx", "escalated": True},
+                    {"canonical_id": "dji", "escalated": False},
+                ]
+            },
+        },
+    }
+    payload = ns.build_success_payload(artifact, "https://example.com/")
+    fields_text = json.dumps(payload["blocks"], ensure_ascii=False)
+    assert "Provider divergence:" in fields_text
+    assert "spx" in fields_text
+    assert "dji" not in fields_text
+
+
+def test_build_success_payload_price_consistency_no_escalation(
+    ns: ModuleType, fixture_artifact: dict[str, Any]
+) -> None:
+    artifact = {
+        **fixture_artifact,
+        "metadata": {
+            **fixture_artifact["metadata"],
+            "price_consistency": {
+                "results": [{"canonical_id": "spx", "escalated": False}]
+            },
+        },
+    }
+    payload = ns.build_success_payload(artifact, "https://example.com/")
+    fields_text = json.dumps(payload["blocks"], ensure_ascii=False)
+    assert "Provider divergence:" not in fields_text
+
+
 def test_build_success_payload_no_reliable(ns: ModuleType) -> None:
     artifact: dict[str, Any] = {
         "version": "1.0.0",


### PR DESCRIPTION
## Summary

Closes #81 — the daily run had no failover when its primary provider's coverage gate failed (the run simply stopped with no published analysis), and no check that the two registered providers agree on price.

- **`check_price_consistency`** (`src/aims/market_analysis.py`): compares closes between two providers' data (remapped to `canonical_id` first, since providers use different symbol conventions) over their last 5 common bars. Divergence > 0.5% is a warning; > 2% is escalated.
- **`score_instruments(..., extra_risk_gates=...)`**: new optional param merging externally-supplied risk gates before ranking, reusing the existing is_reliable/explanation machinery. New `RISK_GATE_PROVIDER_DIVERGENCE` gate.
- **`consistency` CLI subcommand** + **`generate --price-consistency`**: the subcommand writes a consistency report JSON; `generate` loads it, derives per-symbol escalation gates via the mapping layer, and records the full report at `metadata.price_consistency` (optional field — existing artifacts unaffected).
- **Workflow wiring** (`daily-market-analysis.yml`):
  - Provider failover: if the primary provider's `generate` step fails its coverage gate (`continue-on-error` + `steps.*.outcome` check, the same pattern already used for the qualitative step), retry the full fetch-and-generate cycle with the other registered provider (`FALLBACK_PROVIDER`) into a separate `data/prices-fallback/` directory before failing the job.
  - Cross-provider consistency check runs weekly (Monday only, via a computed `is_monday` step output) to avoid doubling daily fetch volume; the report feeds into the same-run `generate` call.
  - Slack success notification now calls out any escalated canonical_ids under "⚠️ Provider divergence".
- `OPERATIONS.md` documents the failover order and the divergence policy/thresholds.

## Validation

- `uv run pytest` — 978 passed, 100% branch coverage (new deterministic fixtures for no-divergence/warn/escalate/no-common-dates/zero-close cases, `extra_risk_gates` dedup, `_load_price_consistency`, the `consistency` subcommand incl. mapping-load-error and blank-canonical_id branches, `--price-consistency` wiring through `_cmd_generate`, and the Slack payload's divergence field)
- `ruff` / `pyright` — clean
- `zizmor` / `actionlint` / `yamllint` / `checkov` on `.github/workflows/daily-market-analysis.yml` — clean
- **End-to-end against real data**: ran `market_analysis.py consistency` against the actual `data/mappings/canonical_instrument_mappings.csv` with real yfinance `^GSPC` data and a synthetic stooq-style `^SPX` copy — correctly identified `spx` as the one canonical instrument covered by both providers locally and computed a 0.1% divergence. Then fed an escalated report into `generate --price-consistency` and confirmed the `provider_divergence` gate landed on exactly `^GSPC` (not other instruments), with `metadata.price_consistency` persisted.

## Post-merge

No manual step required; the failover and weekly consistency check activate on the next scheduled run. To dry-run failover, dispatch the workflow with `provider: stooq` against symbols only mapped for `yfinance`, or vice versa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)