### PR TITLE
feat(backtest): add costs, benchmark, significance, and regime breakdown (#80)

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -254,6 +254,16 @@ The composite score averages 10 feature percentile ranks, and 8 of the 10 are co
 
 No ML-fitted or optimizer-fitted weights — hand-set weights justified by measured ICs, keeping the engine deterministic and dependency-light.
 
+### Backtest cost model, benchmark, and significance
+
+`run_backtest` reports gross top-k forward returns only by default; costs, a benchmark, and a significance test are opt-in and additive — they never change `score_instruments` or the composite score.
+
+- **Cost model**: each top-k forward-return observation is treated as an independent round-trip (this backtest reports cross-sectional forward returns per date, not a single compounding equity curve), so the cost is `2 × spread_bps` (entry + exit) plus `financing_rate_annual × horizon / 365` (holding-period financing), deducted once per observation. Per-instrument overrides come from an optional `--cost-mapping` CSV (`symbol,spread_bps,financing_rate_annual`); symbols absent from it use conservative placeholders (`DEFAULT_SPREAD_BPS = 10.0`, `DEFAULT_FINANCING_RATE_ANNUAL = 0.05` in `src/aims/backtest.py`) until real broker spread/financing data is wired in. `metrics[h].top_k.average_return` stays gross; `net_average_return` is net of this cost.
+- **Benchmark**: `metrics[h].benchmark.average_return` is the equal-weight average forward return across the _entire_ reliable universe that date (all score buckets pooled), not just the top-k selection. `top_k.excess_return` / `net_excess_return` are the gross/net top-k average minus this benchmark, per horizon.
+- **Significance**: a deterministic moving-block bootstrap (`_moving_block_bootstrap_ci`, seeded, block-resampled to preserve short-range autocorrelation) on the mean daily net excess return, computed at the finest configured horizon (most daily observations to resample). Reported at `significance` with `{horizon, mean_net_excess_return, confidence, confidence_interval, block_size, iterations, seed, n}`; `confidence_interval` is `null` with fewer than two observations.
+- **Regime breakdown**: `regime_breakdown.regimes` buckets the same per-date net top-k and benchmark averages (at the significance horizon) by that date's breadth-based market regime label (`market_regime_metadata`, the same MA20-breadth measure persisted in daily analysis artifacts, #77) — showing whether the strategy's edge concentrates in a particular regime.
+- **Limitations**: overlapping forward horizons (e.g. daily observations at a 20-day horizon) overstate the effective independent sample size; the bootstrap partially compensates via block resampling but this is not a substitute for a longer out-of-sample window. The cost model has no order-book simulation, intraday slippage, or portfolio-level margin constraints.
+
 ### Assumptions and limitations
 
 - Scores are cross-sectional: they reflect relative, not absolute, performance. A score of 80 in a falling market still means that instrument fell less than most others.

--- a/data/schema/backtest.schema.json
+++ b/data/schema/backtest.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "AIMS walk-forward backtest artifact",
   "description": "Schema reference for validate_backtest.py. Validation is implemented in Python rather than a JSON Schema library to avoid runtime dependencies.",
-  "artifact_version": "1.1.0",
+  "artifact_version": "1.2.0",
   "required_top_keys": [
     "schema_version",
     "scoring_version",
@@ -12,7 +12,9 @@
     "metrics",
     "turnover",
     "max_drawdown",
-    "feature_diagnostics"
+    "feature_diagnostics",
+    "significance",
+    "regime_breakdown"
   ],
   "required_config_keys": [
     "symbols",
@@ -23,8 +25,11 @@
     "min_history"
   ],
   "notes": {
-    "metrics": "Object keyed by '{horizon}d' (e.g. '1d', '20d'); each value has score_buckets (bucket number -> {count, average_return}) and top_k ({count, average_return, hit_rate}).",
+    "metrics": "Object keyed by '{horizon}d' (e.g. '1d', '20d'); each value has score_buckets (bucket number -> {count, average_return}), benchmark (equal-weight universe average over the same date/horizon: {count, average_return}), and top_k ({count, average_return, net_average_return, hit_rate, excess_return, net_excess_return}). net_* and excess_return/net_excess_return were added in 1.2.0 (#80); average_return, hit_rate, and score_buckets predate them and stay gross/benchmark-agnostic.",
     "feature_diagnostics": "Added in 1.1.0 (#79): informational-only diagnostics, never used to adjust scores. 'features' lists the InstrumentFeatures field names in declaration order. 'information_coefficient' is keyed by '{horizon}d' -> feature -> {mean, n}, the mean daily cross-sectional Spearman rank correlation between that feature's value and the forward return at that horizon, averaged over the n dates with at least two valid (feature, forward-return) pairs; mean is null when n is 0. 'feature_correlation' is a symmetric feature x feature matrix of mean daily cross-sectional Spearman correlation between feature pairs (1.0 on the diagonal, null when never jointly observed).",
-    "scoring_version": "SCORING_VERSION is unaffected by feature_diagnostics; adopting a scoring v2 feature set based on measured ICs is a separate, evidence-gated decision (see OPERATIONS.md)."
+    "significance": "Added in 1.2.0 (#80): a deterministic moving-block bootstrap confidence interval on the mean daily net excess return (top_k net average minus benchmark average), computed at the finest configured horizon. {horizon, mean_net_excess_return, confidence, confidence_interval: {low, high} | null, block_size, iterations, seed, n}. confidence_interval is null with fewer than two daily observations.",
+    "regime_breakdown": "Added in 1.2.0 (#80): per-date net top_k and benchmark averages at the significance horizon, grouped by that date's breadth-based market_regime_metadata label (Bullish/Bearish/Neutral/Unavailable). {horizon, regimes: {label -> {count, top_k_net_average_return, benchmark_average_return, excess_return}}}.",
+    "cost_model": "top_k.net_* deduct a per-observation round-trip cost (2 x spread_bps + financing_rate_annual x horizon/365) using an optional --cost-mapping CSV (symbol, spread_bps, financing_rate_annual); symbols absent from it use DEFAULT_SPREAD_BPS/DEFAULT_FINANCING_RATE_ANNUAL placeholders in src/aims/backtest.py.",
+    "scoring_version": "SCORING_VERSION is unaffected by feature_diagnostics, significance, or regime_breakdown; adopting a scoring v2 feature set based on measured ICs is a separate, evidence-gated decision (see OPERATIONS.md)."
   }
 }

--- a/src/aims/backtest.py
+++ b/src/aims/backtest.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import argparse
+import csv
 import json
+import random
 from collections import defaultdict
-from dataclasses import fields
+from dataclasses import dataclass, fields
 from pathlib import Path
 from typing import Any, Final
 
@@ -14,13 +16,95 @@ from aims.market_analysis import (
     InstrumentFeatures,
     OhlcvBar,
     load_ohlcv,
+    market_regime_metadata,
     score_instruments,
 )
 
 DEFAULT_HORIZONS: Final[tuple[int, ...]] = (1, 5, 20, 60)
-BACKTEST_VERSION: Final[str] = "1.1.0"
+BACKTEST_VERSION: Final[str] = "1.2.0"
 
 _FEATURES: Final[tuple[str, ...]] = tuple(f.name for f in fields(InstrumentFeatures))
+
+# Conservative placeholders used for any symbol absent from a cost mapping;
+# real per-instrument costs should come from broker spread/financing data
+# once available (data/cfd_instruments.csv already records 金利調整 flags).
+DEFAULT_SPREAD_BPS: Final[float] = 10.0
+DEFAULT_FINANCING_RATE_ANNUAL: Final[float] = 0.05
+
+
+@dataclass(frozen=True)
+class InstrumentCost:
+    """Per-instrument trading cost inputs for net-of-cost backtest metrics."""
+
+    spread_bps: float
+    financing_rate_annual: float
+
+
+DEFAULT_COST: Final[InstrumentCost] = InstrumentCost(
+    DEFAULT_SPREAD_BPS, DEFAULT_FINANCING_RATE_ANNUAL
+)
+
+
+def load_instrument_costs(path: Path) -> dict[str, InstrumentCost]:
+    """Load optional per-symbol cost overrides from a small CSV table.
+
+    Columns: symbol, spread_bps, financing_rate_annual. Symbols absent from
+    the table fall back to DEFAULT_COST in run_backtest.
+    """
+    costs: dict[str, InstrumentCost] = {}
+    with path.open(encoding="utf-8", newline="") as fh:
+        for row in csv.DictReader(fh):
+            costs[row["symbol"]] = InstrumentCost(
+                spread_bps=float(row["spread_bps"]),
+                financing_rate_annual=float(row["financing_rate_annual"]),
+            )
+    return costs
+
+
+def _round_trip_cost(cost: InstrumentCost, horizon: int) -> float:
+    """Round-trip spread plus *horizon*-day holding financing, as a return fraction.
+
+    Each forward-return observation is treated as an independent entry and
+    exit (this backtest reports cross-sectional forward returns per date,
+    not a single compounding equity curve), so the cost applies once per
+    observation rather than accumulating with daily rebalance turnover.
+    """
+    return 2.0 * (cost.spread_bps / 10_000.0) + cost.financing_rate_annual * (
+        horizon / 365.0
+    )
+
+
+def _moving_block_bootstrap_ci(
+    values: list[float],
+    *,
+    block_size: int,
+    iterations: int,
+    seed: int,
+    confidence: float = 0.95,
+) -> dict[str, float] | None:
+    """Deterministic moving-block bootstrap confidence interval on the mean.
+
+    Resampling contiguous blocks (rather than i.i.d. points) preserves
+    short-range autocorrelation in the daily excess-return series.
+    """
+    n = len(values)
+    if n < 2:
+        return None
+    block_size = max(1, min(block_size, n))
+    n_blocks = -(-n // block_size)  # ceil division
+    rng = random.Random(seed)  # noqa: S311 - statistical resampling, not cryptographic
+    means: list[float] = []
+    for _ in range(iterations):
+        sample: list[float] = []
+        for _ in range(n_blocks):
+            start = rng.randrange(0, n - block_size + 1)
+            sample.extend(values[start : start + block_size])
+        means.append(sum(sample[:n]) / n)
+    means.sort()
+    tail = (1.0 - confidence) / 2.0
+    low_index = int(tail * iterations)
+    high_index = min(iterations - 1, int((1.0 - tail) * iterations))
+    return {"low": means[low_index], "high": means[high_index]}
 
 
 def _mean(values: list[float]) -> float | None:
@@ -82,6 +166,10 @@ def run_backtest(
     top_k: int = 3,
     buckets: int = 4,
     min_history: int = 60,
+    costs: dict[str, InstrumentCost] | None = None,
+    bootstrap_iterations: int = 1000,
+    bootstrap_block_size: int = 5,
+    bootstrap_seed: int = 0,
 ) -> dict[str, Any]:
     """Score each available date without look-ahead and aggregate forward returns."""
     if (
@@ -105,6 +193,7 @@ def run_backtest(
         lambda: defaultdict(list)
     )
     top_returns: dict[int, list[float]] = defaultdict(list)
+    top_net_returns: dict[int, list[float]] = defaultdict(list)
     top_hits: dict[int, list[bool]] = defaultdict(list)
     daily_top_returns: list[float] = []
     turnovers: list[float] = []
@@ -115,6 +204,14 @@ def run_backtest(
         lambda: defaultdict(list)
     )
     feature_corr: dict[tuple[str, str], list[float]] = defaultdict(list)
+
+    # Primary horizon for the significance test and regime breakdown: the
+    # finest-grained horizon gives the most daily observations to resample.
+    primary_horizon = min(horizons)
+    daily_net_excess: list[float] = []
+    regime_labels: list[str] = []
+    regime_top_net: dict[str, list[float]] = defaultdict(list)
+    regime_benchmark: dict[str, list[float]] = defaultdict(list)
 
     for date in dates:
         window = {
@@ -147,10 +244,13 @@ def run_backtest(
                     feature_corr[feat_a, feat_b].append(rho)
         selected = scores[:top_k]
         selected_symbols = {s.symbol for s in selected}
+        regime_label = market_regime_metadata(scores)["label"]
         date_observed = False
         top_k_observed = False
         for horizon in horizons:
             horizon_returns = []
+            horizon_net_returns = []
+            horizon_universe_returns: list[float] = []
             horizon_feature_pairs: dict[str, list[tuple[float, float]]] = defaultdict(
                 list
             )
@@ -163,14 +263,19 @@ def run_backtest(
                 close = data[score.symbol][index].close
                 forward = data[score.symbol][index + horizon].close / close - 1.0
                 bucket_returns[horizon][bucket].append(forward)
+                horizon_universe_returns.append(forward)
                 for feat in _FEATURES:
                     value = getattr(score.features, feat)
                     if value is not None:
                         horizon_feature_pairs[feat].append((value, forward))
                 if score in selected:
+                    cost = (costs or {}).get(score.symbol, DEFAULT_COST)
+                    net_forward = forward - _round_trip_cost(cost, horizon)
                     top_returns[horizon].append(forward)
+                    top_net_returns[horizon].append(net_forward)
                     top_hits[horizon].append(forward > 0)
                     horizon_returns.append(forward)
+                    horizon_net_returns.append(net_forward)
             for feat, pairs in horizon_feature_pairs.items():
                 if len(pairs) < 2:
                     continue
@@ -179,6 +284,19 @@ def run_backtest(
                     feature_ic[horizon][feat].append(rho)
             if horizon == 1 and horizon_returns:
                 daily_top_returns.append(sum(horizon_returns) / len(horizon_returns))
+            if (
+                horizon == primary_horizon
+                and horizon_net_returns
+                and horizon_universe_returns
+            ):
+                net_avg = sum(horizon_net_returns) / len(horizon_net_returns)
+                benchmark_avg = sum(horizon_universe_returns) / len(
+                    horizon_universe_returns
+                )
+                daily_net_excess.append(net_avg - benchmark_avg)
+                regime_labels.append(regime_label)
+                regime_top_net[regime_label].append(net_avg)
+                regime_benchmark[regime_label].append(benchmark_avg)
             top_k_observed = top_k_observed or bool(horizon_returns)
         if date_observed:
             observations += 1
@@ -194,6 +312,12 @@ def run_backtest(
 
     metrics = {}
     for horizon in horizons:
+        universe_returns = [
+            value for values in bucket_returns[horizon].values() for value in values
+        ]
+        benchmark_avg = _mean(universe_returns)
+        top_k_avg = _mean(top_returns[horizon])
+        top_k_net_avg = _mean(top_net_returns[horizon])
         metrics[f"{horizon}d"] = {
             "score_buckets": {
                 str(bucket): {
@@ -202,10 +326,25 @@ def run_backtest(
                 }
                 for bucket, values in sorted(bucket_returns[horizon].items())
             },
+            "benchmark": {
+                "count": len(universe_returns),
+                "average_return": benchmark_avg,
+            },
             "top_k": {
                 "count": len(top_returns[horizon]),
-                "average_return": _mean(top_returns[horizon]),
+                "average_return": top_k_avg,
+                "net_average_return": top_k_net_avg,
                 "hit_rate": _mean([float(hit) for hit in top_hits[horizon]]),
+                "excess_return": (
+                    None
+                    if top_k_avg is None or benchmark_avg is None
+                    else top_k_avg - benchmark_avg
+                ),
+                "net_excess_return": (
+                    None
+                    if top_k_net_avg is None or benchmark_avg is None
+                    else top_k_net_avg - benchmark_avg
+                ),
             },
         }
     feature_diagnostics = {
@@ -232,6 +371,44 @@ def run_backtest(
             for feat_a in _FEATURES
         },
     }
+    ci = _moving_block_bootstrap_ci(
+        daily_net_excess,
+        block_size=bootstrap_block_size,
+        iterations=bootstrap_iterations,
+        seed=bootstrap_seed,
+    )
+    significance = {
+        "horizon": primary_horizon,
+        "mean_net_excess_return": _mean(daily_net_excess),
+        "confidence": 0.95,
+        "confidence_interval": ci,
+        "block_size": bootstrap_block_size,
+        "iterations": bootstrap_iterations,
+        "seed": bootstrap_seed,
+        "n": len(daily_net_excess),
+    }
+
+    def _regime_stats(label: str) -> dict[str, Any]:
+        net_avg = _mean(regime_top_net[label])
+        benchmark_avg = _mean(regime_benchmark[label])
+        excess = (
+            None
+            if net_avg is None or benchmark_avg is None
+            else net_avg - benchmark_avg
+        )
+        return {
+            "count": len(regime_top_net[label]),
+            "top_k_net_average_return": net_avg,
+            "benchmark_average_return": benchmark_avg,
+            "excess_return": excess,
+        }
+
+    regime_breakdown = {
+        "horizon": primary_horizon,
+        "regimes": {
+            label: _regime_stats(label) for label in sorted(set(regime_labels))
+        },
+    }
     return {
         "observations": observations,
         "date_range": {
@@ -242,6 +419,8 @@ def run_backtest(
         "turnover": _mean(turnovers),
         "max_drawdown": _drawdown(daily_top_returns),
         "feature_diagnostics": feature_diagnostics,
+        "significance": significance,
+        "regime_breakdown": regime_breakdown,
     }
 
 
@@ -266,6 +445,20 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--top-k", type=int, default=3)
     parser.add_argument("--buckets", type=int, default=4)
     parser.add_argument("--min-history", type=int, default=60)
+    parser.add_argument(
+        "--cost-mapping",
+        type=Path,
+        default=None,
+        help=(
+            "Optional CSV (symbol, spread_bps, financing_rate_annual) of"
+            " per-instrument cost overrides; unlisted symbols use"
+            f" conservative defaults ({DEFAULT_SPREAD_BPS} bps,"
+            f" {DEFAULT_FINANCING_RATE_ANNUAL:.0%} annual financing)"
+        ),
+    )
+    parser.add_argument("--bootstrap-iterations", type=int, default=1000)
+    parser.add_argument("--bootstrap-block-size", type=int, default=5)
+    parser.add_argument("--bootstrap-seed", type=int, default=0)
     args = parser.parse_args(argv)
     symbols = tuple(item.strip() for item in args.symbols.split(",") if item.strip())
     if not symbols:
@@ -275,12 +468,17 @@ def main(argv: list[str] | None = None) -> int:
             symbol: load_ohlcv(symbol, args.interval, args.data_dir)
             for symbol in symbols
         }
+        costs = load_instrument_costs(args.cost_mapping) if args.cost_mapping else None
         result = run_backtest(
             data,
             horizons=args.horizons,
             top_k=args.top_k,
             buckets=args.buckets,
             min_history=args.min_history,
+            costs=costs,
+            bootstrap_iterations=args.bootstrap_iterations,
+            bootstrap_block_size=args.bootstrap_block_size,
+            bootstrap_seed=args.bootstrap_seed,
         )
     except (FileNotFoundError, ValueError) as exc:
         parser.error(str(exc))

--- a/src/aims/validate_backtest.py
+++ b/src/aims/validate_backtest.py
@@ -19,6 +19,8 @@ _REQUIRED_TOP: Final[tuple[str, ...]] = (
     "turnover",
     "max_drawdown",
     "feature_diagnostics",
+    "significance",
+    "regime_breakdown",
 )
 _REQUIRED_CONFIG: Final[tuple[str, ...]] = (
     "symbols",
@@ -61,6 +63,19 @@ def _validate_metrics(metrics: object) -> list[str]:
                     errors.append(
                         f"{bucket_prefix}.average_return must be a number or null"
                     )
+        benchmark = horizon_metrics.get("benchmark")
+        if not isinstance(benchmark, dict):
+            errors.append(f"{prefix}.benchmark must be an object")
+        else:
+            if not isinstance(benchmark.get("count"), int) or isinstance(
+                benchmark.get("count"), bool
+            ):
+                errors.append(f"{prefix}.benchmark.count must be an integer")
+            avg = benchmark.get("average_return")
+            if avg is not None and not _is_number(avg):
+                errors.append(
+                    f"{prefix}.benchmark.average_return must be a number or null"
+                )
         top_k = horizon_metrics.get("top_k")
         if not isinstance(top_k, dict):
             errors.append(f"{prefix}.top_k must be an object")
@@ -69,10 +84,77 @@ def _validate_metrics(metrics: object) -> list[str]:
                 top_k.get("count"), bool
             ):
                 errors.append(f"{prefix}.top_k.count must be an integer")
-            for field in ("average_return", "hit_rate"):
+            for field in (
+                "average_return",
+                "net_average_return",
+                "hit_rate",
+                "excess_return",
+                "net_excess_return",
+            ):
                 value = top_k.get(field)
                 if value is not None and not _is_number(value):
                     errors.append(f"{prefix}.top_k.{field} must be a number or null")
+    return errors
+
+
+def _validate_significance(significance: object) -> list[str]:
+    if not isinstance(significance, dict):
+        return ["significance must be an object"]
+    errors: list[str] = []
+    for field in ("horizon", "iterations", "block_size", "seed", "n"):
+        value = significance.get(field)
+        if not isinstance(value, int) or isinstance(value, bool):
+            errors.append(f"significance.{field} must be an integer")
+    mean = significance.get("mean_net_excess_return")
+    if mean is not None and not _is_number(mean):
+        errors.append("significance.mean_net_excess_return must be a number or null")
+    confidence = significance.get("confidence")
+    if not _is_number(confidence):
+        errors.append("significance.confidence must be a number")
+    ci = significance.get("confidence_interval")
+    if ci is not None:
+        if not isinstance(ci, dict) or not {"low", "high"} <= ci.keys():
+            errors.append(
+                "significance.confidence_interval must be an object with"
+                " 'low' and 'high', or null"
+            )
+        else:
+            errors.extend(
+                f"significance.confidence_interval.{bound} must be a number"
+                for bound in ("low", "high")
+                if not _is_number(ci.get(bound))
+            )
+    return errors
+
+
+def _validate_regime_breakdown(regime_breakdown: object) -> list[str]:
+    if not isinstance(regime_breakdown, dict):
+        return ["regime_breakdown must be an object"]
+    errors: list[str] = []
+    horizon = regime_breakdown.get("horizon")
+    if not isinstance(horizon, int) or isinstance(horizon, bool):
+        errors.append("regime_breakdown.horizon must be an integer")
+    regimes = regime_breakdown.get("regimes")
+    if not isinstance(regimes, dict):
+        errors.append("regime_breakdown.regimes must be an object")
+    else:
+        for label, stats in regimes.items():
+            prefix = f"regime_breakdown.regimes[{label!r}]"
+            if not isinstance(stats, dict):
+                errors.append(f"{prefix} must be an object")
+                continue
+            if not isinstance(stats.get("count"), int) or isinstance(
+                stats.get("count"), bool
+            ):
+                errors.append(f"{prefix}.count must be an integer")
+            for field in (
+                "top_k_net_average_return",
+                "benchmark_average_return",
+                "excess_return",
+            ):
+                value = stats.get(field)
+                if value is not None and not _is_number(value):
+                    errors.append(f"{prefix}.{field} must be a number or null")
     return errors
 
 
@@ -168,6 +250,8 @@ def validate_artifact(data: dict[str, Any]) -> list[str]:
 
     errors.extend(_validate_metrics(data["metrics"]))
     errors.extend(_validate_feature_diagnostics(data["feature_diagnostics"]))
+    errors.extend(_validate_significance(data["significance"]))
+    errors.extend(_validate_regime_breakdown(data["regime_breakdown"]))
     return errors
 
 

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -107,6 +107,73 @@ def test_corr_key_is_order_independent(
     )
 
 
+# ── cost model ───────────────────────────────────────────────────────────────────
+
+
+def test_load_instrument_costs(
+    modules: tuple[ModuleType, ModuleType], tmp_path: Path
+) -> None:
+    _, backtest = modules
+    path = tmp_path / "costs.csv"
+    path.write_text(
+        "symbol,spread_bps,financing_rate_annual\nAAPL,5,0.03\n", encoding="utf-8"
+    )
+    costs = backtest.load_instrument_costs(path)
+    assert costs == {"AAPL": backtest.InstrumentCost(5.0, 0.03)}
+
+
+def test_round_trip_cost(modules: tuple[ModuleType, ModuleType]) -> None:
+    _, backtest = modules
+    cost = backtest.InstrumentCost(spread_bps=10.0, financing_rate_annual=0.1)
+    # 2 * 10bps + 0.1 * (10/365)
+    assert backtest._round_trip_cost(cost, 10) == pytest.approx(
+        0.002 + 0.1 * (10 / 365)
+    )
+
+
+# ── moving-block bootstrap ───────────────────────────────────────────────────────
+
+
+def test_moving_block_bootstrap_ci_requires_two_values(
+    modules: tuple[ModuleType, ModuleType],
+) -> None:
+    _, backtest = modules
+    assert (
+        backtest._moving_block_bootstrap_ci([], block_size=5, iterations=100, seed=0)
+        is None
+    )
+    assert (
+        backtest._moving_block_bootstrap_ci([0.1], block_size=5, iterations=100, seed=0)
+        is None
+    )
+
+
+def test_moving_block_bootstrap_ci_deterministic_and_brackets_mean(
+    modules: tuple[ModuleType, ModuleType],
+) -> None:
+    _, backtest = modules
+    values = [0.01, 0.02, -0.01, 0.015, 0.005, 0.0, 0.03, -0.005, 0.01, 0.02]
+    ci_a = backtest._moving_block_bootstrap_ci(
+        values, block_size=3, iterations=200, seed=42
+    )
+    ci_b = backtest._moving_block_bootstrap_ci(
+        values, block_size=3, iterations=200, seed=42
+    )
+    assert ci_a == ci_b
+    assert ci_a is not None
+    assert ci_a["low"] <= ci_a["high"]
+
+
+def test_moving_block_bootstrap_ci_block_size_capped_at_n(
+    modules: tuple[ModuleType, ModuleType],
+) -> None:
+    _, backtest = modules
+    ci = backtest._moving_block_bootstrap_ci(
+        [0.1, 0.2], block_size=100, iterations=50, seed=0
+    )
+    assert ci is not None
+
+
 # ── run_backtest metrics ─────────────────────────────────────────────────────────
 
 
@@ -134,6 +201,94 @@ def test_run_backtest_metrics(modules: tuple[ModuleType, ModuleType]) -> None:
     }
     assert empty_diagnostics["feature_correlation"]["ret_1d"]["ret_1d"] == 1.0
     assert empty_diagnostics["feature_correlation"]["ret_1d"]["ret_5d"] is None
+
+
+# ── net-of-cost, benchmark, significance, regime breakdown ─────────────────────
+
+
+def test_run_backtest_benchmark_and_net_of_cost(
+    modules: tuple[ModuleType, ModuleType],
+) -> None:
+    ma, backtest = modules
+    data = {"UP": _bars(ma, "UP", 2.0), "DOWN": _bars(ma, "DOWN", -0.5)}
+    cost = backtest.InstrumentCost(spread_bps=10.0, financing_rate_annual=0.05)
+    result = backtest.run_backtest(
+        data,
+        horizons=(1,),
+        top_k=1,
+        min_history=60,
+        costs={"UP": cost, "DOWN": cost},
+    )
+    top_k = result["metrics"]["1d"]["top_k"]
+    benchmark = result["metrics"]["1d"]["benchmark"]
+    # UP is always selected (top_k=1); benchmark averages UP and DOWN.
+    assert benchmark["count"] == top_k["count"] * 2
+    assert top_k["average_return"] > benchmark["average_return"]
+    assert top_k["excess_return"] == pytest.approx(
+        top_k["average_return"] - benchmark["average_return"]
+    )
+    expected_cost = backtest._round_trip_cost(cost, 1)
+    assert top_k["net_average_return"] == pytest.approx(
+        top_k["average_return"] - expected_cost
+    )
+    assert top_k["net_excess_return"] == pytest.approx(
+        top_k["net_average_return"] - benchmark["average_return"]
+    )
+
+
+def test_run_backtest_uses_default_cost_when_unmapped(
+    modules: tuple[ModuleType, ModuleType],
+) -> None:
+    ma, backtest = modules
+    data = {"UP": _bars(ma, "UP", 2.0), "DOWN": _bars(ma, "DOWN", -0.5)}
+    result = backtest.run_backtest(data, horizons=(1,), top_k=1, min_history=60)
+    top_k = result["metrics"]["1d"]["top_k"]
+    default_cost_amount = backtest._round_trip_cost(backtest.DEFAULT_COST, 1)
+    assert top_k["net_average_return"] == pytest.approx(
+        top_k["average_return"] - default_cost_amount
+    )
+
+
+def test_run_backtest_significance_and_regime_breakdown(
+    modules: tuple[ModuleType, ModuleType],
+) -> None:
+    ma, backtest = modules
+    data = {"UP": _bars(ma, "UP", 2.0), "DOWN": _bars(ma, "DOWN", -0.5)}
+    result = backtest.run_backtest(
+        data,
+        horizons=(1, 5),
+        top_k=1,
+        min_history=60,
+        bootstrap_iterations=200,
+        bootstrap_seed=7,
+    )
+    significance = result["significance"]
+    assert significance["horizon"] == 1
+    assert significance["n"] == result["observations"]
+    assert significance["iterations"] == 200
+    assert significance["seed"] == 7
+    assert significance["confidence_interval"] is not None
+    assert (
+        significance["confidence_interval"]["low"]
+        <= significance["confidence_interval"]["high"]
+    )
+
+    regime_breakdown = result["regime_breakdown"]
+    assert regime_breakdown["horizon"] == 1
+    regimes = regime_breakdown["regimes"]
+    assert regimes
+    total_count = sum(r["count"] for r in regimes.values())
+    assert total_count == result["observations"]
+
+
+def test_run_backtest_significance_none_without_enough_observations(
+    modules: tuple[ModuleType, ModuleType],
+) -> None:
+    _, backtest = modules
+    empty = backtest.run_backtest({}, horizons=(1,))
+    assert empty["significance"]["confidence_interval"] is None
+    assert empty["significance"]["n"] == 0
+    assert empty["regime_breakdown"]["regimes"] == {}
 
 
 # ── feature_diagnostics ──────────────────────────────────────────────────────────
@@ -281,6 +436,48 @@ def test_main_writes_artifact(
         == 0
     )
     assert path.read_text() == content
+
+
+def test_main_with_cost_mapping_and_bootstrap_args(
+    modules: tuple[ModuleType, ModuleType], tmp_path: Path
+) -> None:
+    ma, backtest = modules
+    prices = tmp_path / "prices"
+    for symbol, slope in (("UP", 2.0), ("DOWN", -0.5)):
+        ma.save_ohlcv(_bars(ma, symbol, slope), prices)
+    cost_mapping = tmp_path / "costs.csv"
+    cost_mapping.write_text(
+        "symbol,spread_bps,financing_rate_annual\nUP,5,0.03\n", encoding="utf-8"
+    )
+    output = tmp_path / "backtests"
+    assert (
+        backtest.main([
+            "--symbols",
+            "UP,DOWN",
+            "--data-dir",
+            str(prices),
+            "--output-dir",
+            str(output),
+            "--horizons",
+            "1",
+            "--top-k",
+            "1",
+            "--cost-mapping",
+            str(cost_mapping),
+            "--bootstrap-iterations",
+            "50",
+            "--bootstrap-block-size",
+            "3",
+            "--bootstrap-seed",
+            "1",
+        ])
+        == 0
+    )
+    artifact = json.loads(next(output.glob("*.json")).read_text())
+    assert artifact["significance"]["iterations"] == 50
+    assert artifact["significance"]["block_size"] == 3
+    assert artifact["significance"]["seed"] == 1
+    assert validate_artifact(artifact) == []
 
 
 def test_main_rejects_no_observations(

--- a/tests/test_validate_backtest.py
+++ b/tests/test_validate_backtest.py
@@ -32,7 +32,7 @@ def vb() -> ModuleType:
 
 def _valid() -> dict[str, Any]:
     return {
-        "schema_version": "1.1.0",
+        "schema_version": "1.2.0",
         "scoring_version": "1.0.0",
         "config": {
             "symbols": ["A", "B"],
@@ -50,7 +50,15 @@ def _valid() -> dict[str, Any]:
                     "1": {"count": 5, "average_return": 0.01},
                     "2": {"count": 5, "average_return": -0.01},
                 },
-                "top_k": {"count": 10, "average_return": 0.01, "hit_rate": 0.9},
+                "benchmark": {"count": 10, "average_return": 0.0},
+                "top_k": {
+                    "count": 10,
+                    "average_return": 0.01,
+                    "net_average_return": 0.008,
+                    "hit_rate": 0.9,
+                    "excess_return": 0.01,
+                    "net_excess_return": 0.008,
+                },
             }
         },
         "turnover": 0.0,
@@ -65,6 +73,33 @@ def _valid() -> dict[str, Any]:
                     feat_b: 1.0 if feat_a == feat_b else 0.2 for feat_b in _FEATURES
                 }
                 for feat_a in _FEATURES
+            },
+        },
+        "significance": {
+            "horizon": 1,
+            "mean_net_excess_return": 0.008,
+            "confidence": 0.95,
+            "confidence_interval": {"low": 0.001, "high": 0.015},
+            "block_size": 5,
+            "iterations": 1000,
+            "seed": 0,
+            "n": 10,
+        },
+        "regime_breakdown": {
+            "horizon": 1,
+            "regimes": {
+                "Bullish": {
+                    "count": 6,
+                    "top_k_net_average_return": 0.01,
+                    "benchmark_average_return": 0.005,
+                    "excess_return": 0.005,
+                },
+                "Bearish": {
+                    "count": 4,
+                    "top_k_net_average_return": -0.01,
+                    "benchmark_average_return": -0.015,
+                    "excess_return": 0.005,
+                },
             },
         },
     }
@@ -269,6 +304,140 @@ def test_validate_feature_correlation_shape(vb: ModuleType) -> None:
     artifact = _valid()
     artifact["feature_diagnostics"]["feature_correlation"]["ret_1d"]["ret_5d"] = None
     assert vb.validate_artifact(artifact) == []
+
+
+def test_validate_metrics_benchmark_shape(vb: ModuleType) -> None:
+    artifact = _valid()
+    artifact["metrics"]["1d"]["benchmark"] = []
+    errors = vb.validate_artifact(artifact)
+    assert any("benchmark must be an object" in e for e in errors)
+
+    artifact = _valid()
+    artifact["metrics"]["1d"]["benchmark"]["count"] = 1.5
+    errors = vb.validate_artifact(artifact)
+    assert any("benchmark.count must be an integer" in e for e in errors)
+
+    artifact = _valid()
+    artifact["metrics"]["1d"]["benchmark"]["average_return"] = "bad"
+    errors = vb.validate_artifact(artifact)
+    assert any("benchmark.average_return must be a number or null" in e for e in errors)
+
+    artifact = _valid()
+    artifact["metrics"]["1d"]["benchmark"]["average_return"] = None
+    assert vb.validate_artifact(artifact) == []
+
+
+def test_validate_top_k_net_and_excess_fields(vb: ModuleType) -> None:
+    for field in ("net_average_return", "excess_return", "net_excess_return"):
+        artifact = _valid()
+        artifact["metrics"]["1d"]["top_k"][field] = "bad"
+        errors = vb.validate_artifact(artifact)
+        assert any(f"top_k.{field} must be a number or null" in e for e in errors)
+
+        artifact = _valid()
+        artifact["metrics"]["1d"]["top_k"][field] = None
+        assert vb.validate_artifact(artifact) == []
+
+
+def test_validate_significance_must_be_object(vb: ModuleType) -> None:
+    artifact = _valid()
+    artifact["significance"] = []
+    errors = vb.validate_artifact(artifact)
+    assert any("significance must be an object" in e for e in errors)
+
+
+def test_validate_significance_integer_fields(vb: ModuleType) -> None:
+    for field in ("horizon", "iterations", "block_size", "seed", "n"):
+        artifact = _valid()
+        artifact["significance"][field] = 1.5
+        errors = vb.validate_artifact(artifact)
+        assert any(f"significance.{field} must be an integer" in e for e in errors)
+
+
+def test_validate_significance_mean_and_confidence(vb: ModuleType) -> None:
+    artifact = _valid()
+    artifact["significance"]["mean_net_excess_return"] = "bad"
+    errors = vb.validate_artifact(artifact)
+    assert any(
+        "significance.mean_net_excess_return must be a number or null" in e
+        for e in errors
+    )
+
+    artifact = _valid()
+    artifact["significance"]["mean_net_excess_return"] = None
+    assert vb.validate_artifact(artifact) == []
+
+    artifact = _valid()
+    artifact["significance"]["confidence"] = "bad"
+    errors = vb.validate_artifact(artifact)
+    assert any("significance.confidence must be a number" in e for e in errors)
+
+
+def test_validate_significance_confidence_interval_shape(vb: ModuleType) -> None:
+    artifact = _valid()
+    artifact["significance"]["confidence_interval"] = "bad"
+    errors = vb.validate_artifact(artifact)
+    assert any(
+        "significance.confidence_interval must be an object" in e for e in errors
+    )
+
+    artifact = _valid()
+    artifact["significance"]["confidence_interval"] = {"low": "bad", "high": 0.01}
+    errors = vb.validate_artifact(artifact)
+    assert any(
+        "significance.confidence_interval.low must be a number" in e for e in errors
+    )
+
+    artifact = _valid()
+    artifact["significance"]["confidence_interval"] = None
+    assert vb.validate_artifact(artifact) == []
+
+
+def test_validate_regime_breakdown_must_be_object(vb: ModuleType) -> None:
+    artifact = _valid()
+    artifact["regime_breakdown"] = []
+    errors = vb.validate_artifact(artifact)
+    assert any("regime_breakdown must be an object" in e for e in errors)
+
+
+def test_validate_regime_breakdown_horizon(vb: ModuleType) -> None:
+    artifact = _valid()
+    artifact["regime_breakdown"]["horizon"] = 1.5
+    errors = vb.validate_artifact(artifact)
+    assert any("regime_breakdown.horizon must be an integer" in e for e in errors)
+
+
+def test_validate_regime_breakdown_regimes_shape(vb: ModuleType) -> None:
+    artifact = _valid()
+    artifact["regime_breakdown"]["regimes"] = []
+    errors = vb.validate_artifact(artifact)
+    assert any("regime_breakdown.regimes must be an object" in e for e in errors)
+
+    artifact = _valid()
+    artifact["regime_breakdown"]["regimes"]["Bullish"] = []
+    errors = vb.validate_artifact(artifact)
+    assert any("regimes['Bullish'] must be an object" in e for e in errors)
+
+    artifact = _valid()
+    artifact["regime_breakdown"]["regimes"]["Bullish"]["count"] = 1.5
+    errors = vb.validate_artifact(artifact)
+    assert any("regimes['Bullish'].count must be an integer" in e for e in errors)
+
+    for field in (
+        "top_k_net_average_return",
+        "benchmark_average_return",
+        "excess_return",
+    ):
+        artifact = _valid()
+        artifact["regime_breakdown"]["regimes"]["Bullish"][field] = "bad"
+        errors = vb.validate_artifact(artifact)
+        assert any(
+            f"regimes['Bullish'].{field} must be a number or null" in e for e in errors
+        )
+
+        artifact = _valid()
+        artifact["regime_breakdown"]["regimes"]["Bullish"][field] = None
+        assert vb.validate_artifact(artifact) == []
 
 
 def test_main_valid_file(


### PR DESCRIPTION
## Summary

Closes #80 — `run_backtest` reported gross forward returns only: no benchmark (top-k average return is uninterpretable without the universe return over the same window), no cost deduction despite turnover already being measured, and no way to tell if a result is distinguishable from noise given overlapping forward horizons.

- **Cost model**: `InstrumentCost` + `load_instrument_costs()` — an optional `--cost-mapping` CSV (`symbol,spread_bps,financing_rate_annual`) with conservative defaults for unlisted symbols. Each top-k forward-return observation is treated as an independent round-trip (this backtest reports cross-sectional forward returns per date, not a compounding equity curve), so `cost = 2×spread + horizon-scaled financing`, deducted once per observation into a new `top_k.net_average_return`.
- **Benchmark**: an equal-weight-universe average per horizon (`metrics[h].benchmark`) and gross/net top-k **excess return** over it.
- **Significance**: a deterministic moving-block bootstrap (`_moving_block_bootstrap_ci`, seeded) confidence interval on the mean daily net excess return at the finest configured horizon, reported at `significance`.
- **Regime breakdown**: `regime_breakdown` buckets the same daily net top-k/benchmark averages by that date's breadth-based `market_regime_metadata` label (#77's regime measure) — reusing the `InstrumentScore` list already in scope, no extra computation.
- `BACKTEST_VERSION` → `1.2.0`; schema doc and `validate_backtest.py` updated for the new fields.
- `OPERATIONS.md` documents the cost model, benchmark, significance methodology, and the overlapping-horizon limitation.

## Validation

- `uv run pytest` — 1048 passed, 100% branch coverage (deterministic fixtures for cost application, default-cost fallback, bootstrap determinism/degenerate cases, significance/regime-breakdown structure and empty-data paths, plus full `validate_backtest.py` coverage for every new field)
- `ruff` / `pyright` — clean
- **End-to-end against real data**: ran the backtest CLI with a real `--cost-mapping` against ~10 years of AAPL/MSFT daily bars from the persistent price store (#78). Net returns, benchmark, and excess return are all internally consistent (`net = gross − cost`; `excess = top_k − benchmark`); the bootstrap CI is reproducible for a fixed seed; and the regime-breakdown observation counts (567 Bearish + 1238 Bullish + 640 Neutral) sum exactly to the backtest's total observations (2445).

🤖 Generated with [Claude Code](https://claude.com/claude-code)