### PR TITLE
feat(performance): #82 top-5 実現リターン追跡

### DIFF
--- a/.agents/skills/market-analysis/scripts/track_signal_performance.py
+++ b/.agents/skills/market-analysis/scripts/track_signal_performance.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+"""Thin wrapper: track realized forward returns of published top-5 signals."""
+
+from __future__ import annotations
+
+from aims.signal_performance import build_artifact, evaluate_signals, main, render_page
+
+__all__ = ["build_artifact", "evaluate_signals", "main", "render_page"]
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/market-analysis/scripts/validate_signal_performance.py
+++ b/.agents/skills/market-analysis/scripts/validate_signal_performance.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+"""Thin wrapper: validate an AIMS cumulative signal-performance artifact."""
+
+from __future__ import annotations
+
+from aims.validate_signal_performance import main, validate_artifact
+
+__all__ = ["main", "validate_artifact"]
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/daily-market-analysis.yml
+++ b/.github/workflows/daily-market-analysis.yml
@@ -407,6 +407,21 @@ jobs:
           uv run python \
             .agents/skills/qualitative-analysis/scripts/validate_performance.py \
             --input "data/performance/${STEM}.json"
+      # Realized top-5 signal performance (#82): rebuilt in full from every
+      # committed daily analysis artifact, including today's, which is
+      # already on disk at this point in the job. Independent of the
+      # qualitative steps above, so it always runs for daily intervals.
+      - name: Track signal performance
+        if: steps.symbols.outputs.symbols != '' && env.INTERVAL == 'd'
+        run: |
+          uv run python \
+            .agents/skills/market-analysis/scripts/track_signal_performance.py \
+            --analysis-dir data/analysis \
+            --output data/performance/signals.json \
+            --page-output content/performance/_index.md
+          uv run python \
+            .agents/skills/market-analysis/scripts/validate_signal_performance.py \
+            --input data/performance/signals.json
       # Citation-validity sampling (#97): probes a bounded, deterministic
       # sample of recent evidence citation URLs so link rot surfaces in the
       # workflow log. Warning only — the script always exits 0 and nothing
@@ -476,7 +491,7 @@ jobs:
           git fetch origin "$BRANCH" 2>/dev/null || true
           git checkout -B "$BRANCH"
           git add data/analysis/ data/history/ data/performance/ \
-            content/results/ content/evaluation/
+            content/results/ content/evaluation/ content/performance/
           # Evidence and qualitative artifacts (shadow mode) travel in the
           # same analysis PR; the directories exist only when the
           # qualitative steps ran.
@@ -547,6 +562,9 @@ jobs:
           fi
           if [ -f "data/performance/${STEM}.json" ]; then
             ARGS+=(--performance "data/performance/${STEM}.json")
+          fi
+          if [ -f "data/performance/signals.json" ]; then
+            ARGS+=(--signal-performance "data/performance/signals.json")
           fi
           uv run python .agents/skills/market-analysis/scripts/notify_slack.py \
             "${ARGS[@]}"

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -289,6 +289,16 @@ print(','.join(symbols_from_mappings(rows, 'yfinance', 'd')))
 
 Re-run after material changes to the feature set, scoring logic, or once #78's deep store has accumulated materially more history; a stale artifact is a documentation problem, not a correctness one (the daily pipeline never reads `data/backtests/`).
 
+### Signal performance tracking (#82)
+
+Where the backtest above measures the scoring engine against history offline, `track_signal_performance.py` (delegating to `src/aims/signal_performance.py`) measures the top-5 quantitative signals actually published each day, using only committed `data/analysis/*.json` artifacts — no live price fetch. It runs in the daily workflow after score history (daily interval only) and rewrites a single cumulative artifact, `data/performance/signals.json`, plus the public `content/performance/_index.md` page, each run.
+
+- **What's measured.** Each daily artifact's top-5 reliable, tradable instruments (same eligibility as the report's "Top opportunities" section, #76) become individually tagged "slot observations" — one per instrument per horizon, carrying that instrument's asset class and the artifact's market regime label (#77) — paired with the equal-weight average forward return of the _entire_ reliable universe that date as a benchmark. Grouping the flat pool of slot observations by tag yields the by-asset-class and by-regime breakdowns without requiring every date to have complete coverage in every group. Default horizons: 1d/5d/20d.
+- **Reused machinery.** Forward returns are reconstructed by chaining `ret_1d` across consecutive artifacts (`aims.performance.build_bar_series`/`forward_return`, the same #97 stance-evaluation bar-chaining), self-checked against `ret_5d` and invalidating the affected link on mismatch rather than producing a wrong return.
+- **Pending vs. incomplete.** A slot is `pending` when the forward window hasn't matured yet (not enough later artifacts chained) and `incomplete` when it matured but the chain is broken or unmatched — this distinction lets the artifact and page distinguish "wait for more data" from "this observation is permanently unusable."
+- **Slack.** When present, `notify_slack.py --signal-performance` appends a trailing `20d top-5 excess ...` line (trailing 20-day top-5 vs. benchmark excess return and hit rate); omitted until matured observations exist at that horizon.
+- **Same informational caveat as backtesting.** Excludes fees, slippage, financing, and order timing; rests on small overlapping samples early in accumulation; not an investable or executable track record. Format reference: `data/schema/signal_performance.schema.json`.
+
 ### Assumptions and limitations
 
 - Scores are cross-sectional: they reflect relative, not absolute, performance. A score of 80 in a falling market still means that instrument fell less than most others.
@@ -616,6 +626,19 @@ uv run .agents/skills/qualitative-analysis/scripts/evaluate_stances.py \
     --page-output content/evaluation/_index.md
 uv run .agents/skills/qualitative-analysis/scripts/validate_performance.py \
     --input data/performance/YYYY-MM-DD.json
+```
+
+### Regenerate the signal-performance artifact and page
+
+Deterministic; rebuilt in full from every committed daily analysis artifact each run (no API key, no price fetch). See [§3](#3-scoring-methodology).
+
+```sh
+uv run .agents/skills/market-analysis/scripts/track_signal_performance.py \
+    --analysis-dir data/analysis \
+    --output data/performance/signals.json \
+    --page-output content/performance/_index.md
+uv run .agents/skills/market-analysis/scripts/validate_signal_performance.py \
+    --input data/performance/signals.json
 ```
 
 ### Run the OKF theme curation pass

--- a/data/schema/signal_performance.schema.json
+++ b/data/schema/signal_performance.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AIMS signal-performance artifact",
+  "description": "Schema reference for validate_signal_performance.py. Validation is implemented in Python rather than a JSON Schema library to avoid runtime dependencies. Cumulative accountability artifact for the quantitative pipeline (#82): realized forward returns of each daily analysis artifact's top-5 reliable, tradable instruments vs. an equal-weight benchmark over the same artifact's reliable universe.",
+  "artifact_version": "1.0.0",
+  "required_top_keys": ["version", "metadata", "signal_evaluation", "warnings"],
+  "required_metadata_keys": [
+    "generated_at",
+    "as_of",
+    "git_commit",
+    "config",
+    "inputs",
+    "disclaimer"
+  ],
+  "required_config_keys": ["top_k", "horizons", "return_consistency_tolerance"],
+  "required_inputs_keys": ["analysis_dates"],
+  "required_signal_evaluation_keys": ["dates_evaluated", "horizons"],
+  "required_horizon_keys": [
+    "count",
+    "top5_average_return",
+    "benchmark_average_return",
+    "excess_return",
+    "hit_rate",
+    "pending",
+    "incomplete",
+    "by_asset_class",
+    "by_regime"
+  ],
+  "required_bucket_keys": [
+    "count",
+    "top5_average_return",
+    "benchmark_average_return",
+    "excess_return",
+    "hit_rate"
+  ],
+  "notes": {
+    "single_cumulative_file": "Unlike the dated data/performance/<date>.json stance-evaluation artifacts (#97), this is one file (data/performance/signals.json) rebuilt in full from every committed daily data/analysis/ artifact on each run.",
+    "determinism": "Derived exclusively from committed data/analysis/ files — no live price fetches. Rebuilding from the same inputs is byte-identical.",
+    "slot_observations": "Each of a date's top-5 (rank order by score among is_reliable && tradable != false instruments) is one 'slot observation': its own realized forward return, tagged with its asset_class and that date's metadata.market_regime.label (or 'Unavailable'), paired with that date's equal-weight benchmark average over the full reliable universe (best-effort: symbols whose forward return is not yet resolvable are simply excluded from the benchmark average, not the whole date). by_asset_class and by_regime group the flat pool of slot observations across all dates, so a breakdown bucket's average never depends on every top-5 slot that date already being resolved in that same group.",
+    "top5_definition": "tradable=false instruments (#76) are informational-only and excluded from top-5 selection here, matching the report's Top Opportunities section and Slack's top-signal lines.",
+    "forward_returns": "Per-symbol forward returns are compounded from the trailing ret_1d feature chained across analysis artifacts (aims.performance.build_bar_series/forward_return, shared with the #97 stance-evaluation loop), keyed by the per-symbol bar date in metadata.data_freshness. Wherever a later artifact carries ret_5d, the compounded product of the trailing five chained ret_1d values must reproduce it within config.return_consistency_tolerance; a mismatch marks the affected links broken.",
+    "pending_vs_incomplete": "pending counts top-5 slots whose forward horizon has not matured yet (not enough subsequent committed bars); incomplete counts slots dropped for any other reason (no chained bar for the artifact's bar date, a broken bar chain, or no benchmark average available that date/horizon).",
+    "hit_definition": "A slot 'hits' when its realized return exceeds that date's benchmark average return.",
+    "empty_state": "With no daily analysis artifacts, generate() raises rather than writing an empty artifact — data/analysis/ always has at least one committed artifact once the daily pipeline has run.",
+    "disclaimer": "Embedded verbatim in every artifact and rendered prominently on the signal-performance page: results measure informational association only, never an investable or executable track record."
+  }
+}

--- a/src/aims/notifications.py
+++ b/src/aims/notifications.py
@@ -117,6 +117,32 @@ def _performance_summary(performance: dict[str, Any]) -> str | None:
     return "; ".join(parts)
 
 
+def _signal_performance_summary(
+    signal_performance: dict[str, Any], *, horizon: int = 20
+) -> str | None:
+    """One-line trailing top-5 excess-return summary, or None with no matured data.
+
+    Informational association only — never presented as a track record; the
+    signal-performance page carries the full disclaimer.
+    """
+    horizons = signal_performance.get("signal_evaluation", {}).get("horizons", {})
+    bucket = horizons.get(f"{horizon}d")
+    if not isinstance(bucket, dict):
+        return None
+    excess = bucket.get("excess_return")
+    count = bucket.get("count", 0)
+    if not isinstance(excess, (int, float)) or not count:
+        return None
+    hit_rate = bucket.get("hit_rate")
+    hit_str = (
+        f", hit rate {float(hit_rate):.0%}"
+        if isinstance(hit_rate, (int, float))
+        else ""
+    )
+    sign = "+" if excess >= 0 else ""
+    return f"{horizon}d top-5 excess {sign}{excess * 100:.2f}% (n={count}){hit_str}"
+
+
 def build_success_payload(
     artifact: dict[str, Any],
     report_url: str = "",
@@ -127,6 +153,7 @@ def build_success_payload(
     qualitative: dict[str, Any] | None = None,
     qualitative_failed: bool = False,
     performance: dict[str, Any] | None = None,
+    signal_performance: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     meta = artifact.get("metadata", {})
     generated_at = meta.get("generated_at", "")
@@ -213,6 +240,14 @@ def build_success_payload(
             fields.append({
                 "type": "mrkdwn",
                 "text": f"*AI stance hit rate:* {hit_rates}",
+            })
+
+    if signal_performance is not None:
+        signal_summary = _signal_performance_summary(signal_performance)
+        if signal_summary is not None:
+            fields.append({
+                "type": "mrkdwn",
+                "text": f"*Signal performance:* {signal_summary}",
             })
 
     coverage_raw = meta.get("coverage")
@@ -391,6 +426,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=None,
         help="Stance-evaluation artifact for the trailing hit-rate line",
     )
+    parser.add_argument(
+        "--signal-performance",
+        type=str,
+        default=None,
+        help="Cumulative signal-performance artifact for the trailing excess-return"
+        " line",
+    )
     return parser.parse_args(argv)
 
 
@@ -451,6 +493,14 @@ def main(argv: list[str] | None = None) -> int:
             except (FileNotFoundError, json.JSONDecodeError) as exc:
                 print(f"ERROR: invalid performance artifact: {exc}")
                 return 1
+        signal_performance = None
+        if args.signal_performance:
+            try:
+                with open(args.signal_performance, encoding="utf-8") as fh:  # noqa: PTH123
+                    signal_performance = json.load(fh)
+            except (FileNotFoundError, json.JSONDecodeError) as exc:
+                print(f"ERROR: invalid signal-performance artifact: {exc}")
+                return 1
         payload = build_success_payload(
             artifact,
             report_url,
@@ -460,6 +510,7 @@ def main(argv: list[str] | None = None) -> int:
             qualitative=qualitative,
             qualitative_failed=args.qualitative_failed,
             performance=performance,
+            signal_performance=signal_performance,
         )
 
     try:

--- a/src/aims/signal_performance.py
+++ b/src/aims/signal_performance.py
@@ -1,0 +1,468 @@
+r"""Track realized forward returns of published top-5 quantitative signals.
+
+Deterministic accountability loop for the quantitative pipeline (#82): each
+committed ``data/analysis/`` artifact's top-5 reliable, tradable instruments
+are joined with realized forward returns reconstructed purely from committed
+analysis artifacts — no live price fetches — against an equal-weight
+benchmark over the same artifact's reliable universe. This measures whether
+the published top-5 outperformed a naive equal-weight basket, not an
+investable or executable track record.
+
+Reuses the bar-chaining and forward-return machinery from ``aims.performance``
+(#97's stance-evaluation loop): per-symbol ``ret_1d`` values are chained
+across artifacts, self-checked against ``ret_5d`` where available, and a
+mismatch invalidates the affected links instead of producing wrong returns.
+
+The artifact is a single cumulative file (``data/performance/signals.json``),
+rebuilt in full from every committed daily analysis artifact on each run —
+unlike the dated stance-evaluation artifacts, there is one growing record.
+
+Usage:
+    uv run .agents/skills/market-analysis/scripts/track_signal_performance.py \
+        --analysis-dir data/analysis \
+        --output data/performance/signals.json \
+        --page-output content/performance/_index.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Final, NamedTuple
+
+from aims.evidence import git_commit
+from aims.performance import (
+    RETURN_CONSISTENCY_TOLERANCE,
+    Bar,
+    build_bar_series,
+    chain_breaks,
+    forward_return,
+)
+from aims.reports import MarkdownAlignment, format_markdown_table
+
+SIGNAL_PERFORMANCE_VERSION: Final[str] = "1.0.0"
+DEFAULT_HORIZONS: Final[tuple[int, ...]] = (1, 5, 20)
+TOP_K: Final[int] = 5
+_ROUND_DIGITS: Final[int] = 6
+_MAX_PAGE_WARNINGS: Final[int] = 20
+
+_DEFAULT_ANALYSIS_DIR: Final[Path] = Path("data/analysis")
+_DEFAULT_OUTPUT: Final[Path] = Path("data/performance/signals.json")
+
+DISCLAIMER: Final[str] = (
+    "Informational association only. These figures measure whether the"
+    " published top-5 quantitative signals outperformed a naive equal-weight"
+    " basket of the same day's reliable universe in committed data; they are"
+    " not an investable or executable track record, exclude fees, slippage,"
+    " financing, and order timing, rest on small overlapping samples, and are"
+    " not investment advice."
+)
+
+
+class _SlotObservation(NamedTuple):
+    """One realized top-5 slot: its return, that date's benchmark, and tags."""
+
+    realized: float
+    benchmark: float
+    asset_class: str
+    regime: str
+
+
+def _artifact_date(artifact: dict[str, Any]) -> str:
+    generated_at = artifact.get("metadata", {}).get("generated_at")
+    if not isinstance(generated_at, str) or len(generated_at) < 10:
+        msg = "analysis artifact has no valid metadata.generated_at"
+        raise ValueError(msg)
+    return generated_at[:10]
+
+
+def _analysis_interval(artifact: dict[str, Any]) -> str:
+    return str(artifact.get("metadata", {}).get("config", {}).get("interval", ""))
+
+
+def _mean(values: list[float]) -> float | None:
+    return sum(values) / len(values) if values else None
+
+
+def _round_or_none(value: float | None) -> float | None:
+    return None if value is None else round(value, _ROUND_DIGITS)
+
+
+def _resolve_return(
+    symbol: str,
+    freshness: dict[str, Any],
+    series: dict[str, list[Bar]],
+    broken: dict[str, set[int]],
+    index_of: dict[str, dict[str, int]],
+    horizon: int,
+) -> tuple[float | None, str]:
+    """Resolve *symbol*'s realized forward return, or the reason it can't yet.
+
+    Status is one of "ok", "unmatched" (no chained bar for this artifact's
+    bar date), "pending" (not enough future bars chained yet), or "broken"
+    (a bar is missing inside the forward window).
+    """
+    bar_date = freshness.get(symbol)
+    if not isinstance(bar_date, str):
+        return None, "unmatched"
+    index = index_of.get(symbol, {}).get(bar_date)
+    if index is None:
+        return None, "unmatched"
+    bars = series[symbol]
+    if index + horizon >= len(bars):
+        return None, "pending"
+    realized = forward_return(bars, broken[symbol], index, horizon)
+    if realized is None:
+        return None, "broken"
+    return realized, "ok"
+
+
+def evaluate_signals(
+    analyses: list[dict[str, Any]],
+    horizons: tuple[int, ...] = DEFAULT_HORIZONS,
+) -> tuple[dict[str, Any], list[str]]:
+    """Join each artifact's top-5 with realized forward returns and a benchmark.
+
+    Each of a date's top-5 instruments becomes one "slot observation" tagged
+    with its asset class and that date's market regime label, paired with the
+    equal-weight benchmark return over the full reliable universe that date.
+    Grouping the flat pool of slot observations by tag yields the
+    per-asset-class and per-regime breakdowns without needing a date-level
+    top-5 average to already be complete in every asset class or regime.
+    """
+    if (
+        not horizons
+        or any(h < 1 for h in horizons)
+        or len(set(horizons)) != len(horizons)
+    ):
+        msg = "horizons must be unique positive integers"
+        raise ValueError(msg)
+    series, warnings = build_bar_series(analyses)
+    broken = {symbol: chain_breaks(bars) for symbol, bars in series.items()}
+    index_of = {
+        symbol: {bar.date: i for i, bar in enumerate(bars)}
+        for symbol, bars in series.items()
+    }
+
+    slots: dict[int, list[_SlotObservation]] = {h: [] for h in horizons}
+    pending = dict.fromkeys(horizons, 0)
+    incomplete = dict.fromkeys(horizons, 0)
+    dates_evaluated = 0
+
+    for analysis in sorted(analyses, key=_artifact_date):
+        date = _artifact_date(analysis)
+        freshness = analysis.get("metadata", {}).get("data_freshness", {})
+        instruments = analysis.get("instruments", [])
+        reliable = [
+            inst
+            for inst in instruments
+            if inst.get("is_reliable") and inst.get("tradable") is not False
+        ]
+        if not reliable:
+            continue
+        top5 = sorted(
+            reliable, key=lambda inst: float(inst.get("score", 0)), reverse=True
+        )[:TOP_K]
+        regime = str(
+            (analysis.get("metadata", {}).get("market_regime") or {}).get("label")
+            or "Unavailable"
+        )
+        dates_evaluated += 1
+        for horizon in horizons:
+            benchmark_values: list[float] = []
+            for inst in reliable:
+                realized, status = _resolve_return(
+                    str(inst.get("symbol", "")),
+                    freshness,
+                    series,
+                    broken,
+                    index_of,
+                    horizon,
+                )
+                if status == "ok" and realized is not None:
+                    benchmark_values.append(realized)
+            benchmark_avg = _mean(benchmark_values)
+            for inst in top5:
+                symbol = str(inst.get("symbol", ""))
+                realized, status = _resolve_return(
+                    symbol, freshness, series, broken, index_of, horizon
+                )
+                if status == "pending":
+                    pending[horizon] += 1
+                    continue
+                if status != "ok" or realized is None or benchmark_avg is None:
+                    incomplete[horizon] += 1
+                    if status == "broken":
+                        warnings.append(
+                            f"{date}: {symbol}: broken bar chain within"
+                            f" {horizon}d forward window"
+                        )
+                    continue
+                slots[horizon].append(
+                    _SlotObservation(
+                        realized,
+                        benchmark_avg,
+                        str(inst.get("asset_class") or "unknown"),
+                        regime,
+                    )
+                )
+
+    def _bucket_summary(observations: list[_SlotObservation]) -> dict[str, Any]:
+        top5_avg = _mean([o.realized for o in observations])
+        benchmark_avg = _mean([o.benchmark for o in observations])
+        excess = (
+            None
+            if top5_avg is None or benchmark_avg is None
+            else top5_avg - benchmark_avg
+        )
+        hits = [o.realized > o.benchmark for o in observations]
+        return {
+            "count": len(observations),
+            "top5_average_return": _round_or_none(top5_avg),
+            "benchmark_average_return": _round_or_none(benchmark_avg),
+            "excess_return": _round_or_none(excess),
+            "hit_rate": _round_or_none(
+                _mean([float(h) for h in hits]) if hits else None
+            ),
+        }
+
+    horizons_out: dict[str, Any] = {}
+    for horizon in horizons:
+        observations = slots[horizon]
+        by_asset_class: dict[str, list[_SlotObservation]] = defaultdict(list)
+        by_regime: dict[str, list[_SlotObservation]] = defaultdict(list)
+        for obs in observations:
+            by_asset_class[obs.asset_class].append(obs)
+            by_regime[obs.regime].append(obs)
+        summary = _bucket_summary(observations)
+        summary["pending"] = pending[horizon]
+        summary["incomplete"] = incomplete[horizon]
+        summary["by_asset_class"] = {
+            key: _bucket_summary(values)
+            for key, values in sorted(by_asset_class.items())
+        }
+        summary["by_regime"] = {
+            key: _bucket_summary(values) for key, values in sorted(by_regime.items())
+        }
+        horizons_out[f"{horizon}d"] = summary
+
+    return {
+        "dates_evaluated": dates_evaluated,
+        "horizons": horizons_out,
+    }, sorted(set(warnings))
+
+
+def build_artifact(
+    analyses: list[dict[str, Any]],
+    *,
+    as_of: str,
+    horizons: tuple[int, ...] = DEFAULT_HORIZONS,
+) -> dict[str, Any]:
+    """Assemble the versioned, schema-validated signal-performance artifact."""
+    signal_evaluation, warnings = evaluate_signals(analyses, horizons)
+    return {
+        "version": SIGNAL_PERFORMANCE_VERSION,
+        "metadata": {
+            "generated_at": f"{as_of}T00:00:00+00:00",
+            "as_of": as_of,
+            "git_commit": git_commit(),
+            "config": {
+                "top_k": TOP_K,
+                "horizons": list(horizons),
+                "return_consistency_tolerance": RETURN_CONSISTENCY_TOLERANCE,
+            },
+            "inputs": {"analysis_dates": sorted(_artifact_date(a) for a in analyses)},
+            "disclaimer": DISCLAIMER,
+        },
+        "signal_evaluation": signal_evaluation,
+        "warnings": warnings,
+    }
+
+
+def _pct(value: float | None, *, signed: bool = False) -> str:
+    if value is None:
+        return "n/a"
+    if signed:
+        return f"{value * 100:+.2f}%"
+    return f"{value * 100:.0f}%"
+
+
+def _horizon_names(horizons: dict[str, Any]) -> list[str]:
+    return sorted(horizons, key=lambda name: int(name.removesuffix("d")))
+
+
+def _overview_table(horizons: dict[str, Any]) -> str:
+    rows = [
+        [
+            name,
+            str(horizons[name]["count"]),
+            _pct(horizons[name]["top5_average_return"], signed=True),
+            _pct(horizons[name]["benchmark_average_return"], signed=True),
+            _pct(horizons[name]["excess_return"], signed=True),
+            _pct(horizons[name]["hit_rate"]),
+        ]
+        for name in _horizon_names(horizons)
+    ]
+    alignments: list[MarkdownAlignment] = [
+        "left",
+        "right",
+        "right",
+        "right",
+        "right",
+        "right",
+    ]
+    return format_markdown_table(
+        ["Horizon", "Count", "Top-5", "Benchmark", "Excess", "Hit rate"],
+        rows,
+        alignments,
+    )
+
+
+def _breakdown_section(title: str, key: str, horizons: dict[str, Any]) -> str:
+    rows = [
+        [
+            f"{name} / {label}",
+            str(bucket["count"]),
+            _pct(bucket["excess_return"], signed=True),
+            _pct(bucket["hit_rate"]),
+        ]
+        for name in _horizon_names(horizons)
+        for label, bucket in sorted(horizons[name][key].items())
+    ]
+    if not rows:
+        return f"### {title}\n\n_No matured observations yet._"
+    alignments: list[MarkdownAlignment] = ["left", "right", "right", "right"]
+    table = format_markdown_table(
+        ["Horizon / Group", "Count", "Excess", "Hit rate"], rows, alignments
+    )
+    return f"### {title}\n\n{table}"
+
+
+def render_page(artifact: dict[str, Any]) -> str:
+    """Render the deterministic Hugo signal-performance page from the artifact."""
+    meta = artifact["metadata"]
+    as_of = str(meta["as_of"])
+    evaluation = artifact["signal_evaluation"]
+    horizons = evaluation["horizons"]
+    warnings = artifact["warnings"]
+
+    front_matter = "\n".join([
+        "+++",
+        'title = "Signal Performance"',
+        f'date = "{meta["generated_at"]}"',
+        "draft = false",
+        (
+            f'summary = "Realized forward returns of the published top-{TOP_K}'
+            ' signals vs. an equal-weight benchmark."'
+        ),
+        'source_files = ["data/performance/signals.json"]',
+        "+++",
+    ])
+
+    intro = (
+        f"As of **{as_of}**, {evaluation['dates_evaluated']} daily analysis"
+        f" artifact(s) evaluated.\n\n> {artifact['metadata']['disclaimer']}"
+    )
+
+    sections = [
+        front_matter,
+        "## Signal Performance",
+        intro,
+        "## Cumulative Overview",
+        _overview_table(horizons),
+        _breakdown_section("By Asset Class", "by_asset_class", horizons),
+        _breakdown_section("By Market Regime", "by_regime", horizons),
+    ]
+
+    if warnings:
+        shown = warnings[:_MAX_PAGE_WARNINGS]
+        lines = "\n".join(f"- {w}" for w in shown)
+        more = len(warnings) - len(shown)
+        if more > 0:
+            lines += f"\n- … and {more} more"
+        sections.append(f"## Warnings ({len(warnings)})\n\n{lines}")
+
+    return "\n\n".join(sections) + "\n"
+
+
+def _load(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as stream:
+        value: dict[str, Any] = json.load(stream)
+    return value
+
+
+def generate(
+    analysis_dir: Path,
+    output: Path,
+    *,
+    horizons: tuple[int, ...] = DEFAULT_HORIZONS,
+    page_output: Path | None = None,
+) -> Path:
+    """Build, write, and optionally render the signal-performance artifact."""
+    analyses = [
+        artifact
+        for path in sorted(analysis_dir.glob("*.json"))
+        if _analysis_interval(artifact := _load(path)) == "d"
+    ]
+    if not analyses:
+        msg = f"no daily analysis artifacts found under {analysis_dir}"
+        raise ValueError(msg)
+    as_of = max(_artifact_date(a) for a in analyses)
+    artifact = build_artifact(analyses, as_of=as_of, horizons=horizons)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(f"Signal performance written to {output}")
+    if page_output is not None:
+        page_output.parent.mkdir(parents=True, exist_ok=True)
+        page_output.write_text(render_page(artifact), encoding="utf-8")
+        print(f"Signal performance page written to {page_output}")
+    return output
+
+
+def _parse_horizons(value: str) -> tuple[int, ...]:
+    try:
+        horizons = tuple(int(item) for item in value.split(","))
+    except ValueError as exc:
+        msg = "horizons must be comma-separated positive integers"
+        raise argparse.ArgumentTypeError(msg) from exc
+    if not horizons or any(h < 1 for h in horizons):
+        msg = "horizons must be comma-separated positive integers"
+        raise argparse.ArgumentTypeError(msg)
+    return horizons
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--analysis-dir", default=_DEFAULT_ANALYSIS_DIR, type=Path)
+    parser.add_argument("--output", default=_DEFAULT_OUTPUT, type=Path)
+    parser.add_argument("--horizons", default=DEFAULT_HORIZONS, type=_parse_horizons)
+    parser.add_argument(
+        "--page-output",
+        default=None,
+        type=Path,
+        help="Optional Hugo page path (e.g. content/performance/_index.md)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        generate(
+            args.analysis_dir,
+            args.output,
+            horizons=tuple(args.horizons),
+            page_output=args.page_output,
+        )
+    except (FileNotFoundError, json.JSONDecodeError, ValueError) as exc:
+        print(f"ERROR: {exc}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/aims/validate_signal_performance.py
+++ b/src/aims/validate_signal_performance.py
@@ -1,0 +1,267 @@
+r"""Validate an AIMS cumulative signal-performance artifact.
+
+Hand-rolled validator following the ``validate_analysis.py`` pattern (no
+``jsonschema`` dependency). The format reference is
+``data/schema/signal_performance.schema.json``; the artifact is produced by
+``aims.signal_performance`` at ``data/performance/signals.json``.
+
+Usage:
+    uv run .agents/skills/market-analysis/scripts/validate_signal_performance.py \
+        --input data/performance/signals.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any, Final
+
+from aims.signal_performance import SIGNAL_PERFORMANCE_VERSION
+
+_REQUIRED_TOP: Final[tuple[str, ...]] = (
+    "version",
+    "metadata",
+    "signal_evaluation",
+    "warnings",
+)
+_REQUIRED_META: Final[tuple[str, ...]] = (
+    "generated_at",
+    "as_of",
+    "git_commit",
+    "config",
+    "inputs",
+    "disclaimer",
+)
+_REQUIRED_EVALUATION: Final[tuple[str, ...]] = ("dates_evaluated", "horizons")
+_REQUIRED_HORIZON: Final[tuple[str, ...]] = (
+    "count",
+    "top5_average_return",
+    "benchmark_average_return",
+    "excess_return",
+    "hit_rate",
+    "pending",
+    "incomplete",
+    "by_asset_class",
+    "by_regime",
+)
+_REQUIRED_BUCKET: Final[tuple[str, ...]] = (
+    "count",
+    "top5_average_return",
+    "benchmark_average_return",
+    "excess_return",
+    "hit_rate",
+)
+_DATE_RE: Final[re.Pattern[str]] = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def _is_count(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+
+def _is_number_or_null(value: Any) -> bool:
+    return value is None or (
+        isinstance(value, (int, float)) and not isinstance(value, bool)
+    )
+
+
+def _is_rate_or_null(value: Any) -> bool:
+    if value is None:
+        return True
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and 0.0 <= float(value) <= 1.0
+    )
+
+
+def _validate_bucket(where: str, bucket: Any) -> list[str]:
+    if not isinstance(bucket, dict):
+        return [f"{where} must be a JSON object"]
+    errors = [
+        f"{where} missing required key: {key!r}"
+        for key in _REQUIRED_BUCKET
+        if key not in bucket
+    ]
+    if errors:
+        return errors
+    if not _is_count(bucket["count"]):
+        errors.append(f"{where}.count must be a non-negative integer")
+    errors.extend(
+        f"{where}.{key} must be null or a number"
+        for key in ("top5_average_return", "benchmark_average_return", "excess_return")
+        if not _is_number_or_null(bucket[key])
+    )
+    if not _is_rate_or_null(bucket["hit_rate"]):
+        errors.append(f"{where}.hit_rate must be null or a number in [0, 1]")
+    return errors
+
+
+def _validate_horizon(where: str, horizon: Any) -> list[str]:
+    if not isinstance(horizon, dict):
+        return [f"{where} must be a JSON object"]
+    errors = [
+        f"{where} missing required key: {key!r}"
+        for key in _REQUIRED_HORIZON
+        if key not in horizon
+    ]
+    if errors:
+        return errors
+    errors.extend(_validate_bucket(where, horizon))
+    errors.extend(
+        f"{where}.{key} must be a non-negative integer"
+        for key in ("pending", "incomplete")
+        if not _is_count(horizon[key])
+    )
+    for key in ("by_asset_class", "by_regime"):
+        buckets = horizon[key]
+        if not isinstance(buckets, dict):
+            errors.append(f"{where}.{key} must be a JSON object")
+            continue
+        for label, bucket in buckets.items():
+            errors.extend(_validate_bucket(f"{where}.{key}.{label}", bucket))
+    return errors
+
+
+def _validate_metadata(metadata: Any) -> tuple[list[str], list[int]]:
+    if not isinstance(metadata, dict):
+        return ["'metadata' must be a JSON object"], []
+    errors = [
+        f"metadata missing required key: {key!r}"
+        for key in _REQUIRED_META
+        if key not in metadata
+    ]
+    horizons: list[int] = []
+    config = metadata.get("config")
+    if isinstance(config, dict):
+        top_k = config.get("top_k")
+        if not _is_count(top_k) or not isinstance(top_k, int) or top_k < 1:
+            errors.append("metadata.config.top_k must be a positive integer")
+        raw = config.get("horizons")
+        if (
+            not isinstance(raw, list)
+            or not raw
+            or any(not _is_count(h) or h < 1 for h in raw)
+            or len(set(raw)) != len(raw)
+        ):
+            errors.append("metadata.config.horizons must be unique positive integers")
+        else:
+            horizons = [int(h) for h in raw]
+        tolerance = config.get("return_consistency_tolerance")
+        if (
+            not isinstance(tolerance, (int, float))
+            or isinstance(tolerance, bool)
+            or tolerance < 0
+        ):
+            errors.append(
+                "metadata.config.return_consistency_tolerance must be a"
+                " non-negative number"
+            )
+    elif "config" in metadata:
+        errors.append("metadata.config must be a JSON object")
+    inputs = metadata.get("inputs")
+    if isinstance(inputs, dict):
+        dates = inputs.get("analysis_dates")
+        if not isinstance(dates, list) or any(
+            not isinstance(d, str) or not _DATE_RE.match(d) for d in dates
+        ):
+            errors.append(
+                "metadata.inputs.analysis_dates must be a list of YYYY-MM-DD dates"
+            )
+        elif dates != sorted(dates):
+            errors.append("metadata.inputs.analysis_dates must be sorted")
+    elif "inputs" in metadata:
+        errors.append("metadata.inputs must be a JSON object")
+    as_of = metadata.get("as_of")
+    if isinstance(as_of, str) and not _DATE_RE.match(as_of):
+        errors.append(f"metadata.as_of {as_of!r} is not a YYYY-MM-DD date")
+    return errors, horizons
+
+
+def validate_artifact(data: dict[str, Any]) -> list[str]:
+    """Validate shape, enums, and value ranges of a signal-performance artifact."""
+    errors = [
+        f"missing required key: {key!r}" for key in _REQUIRED_TOP if key not in data
+    ]
+    if errors:
+        return errors
+    if data["version"] != SIGNAL_PERFORMANCE_VERSION:
+        errors.append(
+            f"unsupported version {data['version']!r}"
+            f" (expected {SIGNAL_PERFORMANCE_VERSION!r})"
+        )
+    meta_errors, horizons = _validate_metadata(data["metadata"])
+    errors.extend(meta_errors)
+
+    evaluation = data["signal_evaluation"]
+    if not isinstance(evaluation, dict):
+        errors.append("'signal_evaluation' must be a JSON object")
+    else:
+        errors.extend(
+            f"signal_evaluation missing required key: {key!r}"
+            for key in _REQUIRED_EVALUATION
+            if key not in evaluation
+        )
+        if "dates_evaluated" in evaluation and not _is_count(
+            evaluation["dates_evaluated"]
+        ):
+            errors.append(
+                "signal_evaluation.dates_evaluated must be a non-negative integer"
+            )
+        horizon_map = evaluation.get("horizons")
+        if not isinstance(horizon_map, dict):
+            if "horizons" in evaluation:
+                errors.append("signal_evaluation.horizons must be a JSON object")
+        else:
+            if horizons and sorted(horizon_map) != sorted(f"{h}d" for h in horizons):
+                errors.append(
+                    "signal_evaluation.horizons keys do not match"
+                    " metadata.config.horizons"
+                )
+            for name in sorted(horizon_map):
+                errors.extend(
+                    _validate_horizon(
+                        f"signal_evaluation.horizons.{name}", horizon_map[name]
+                    )
+                )
+
+    warnings = data["warnings"]
+    if not isinstance(warnings, list) or any(not isinstance(w, str) for w in warnings):
+        errors.append("'warnings' must be a list of strings")
+    return errors
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input",
+        type=Path,
+        required=True,
+        help="Path to signal-performance artifact JSON file",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        with args.input.open(encoding="utf-8") as stream:
+            data: dict[str, Any] = json.load(stream)
+    except FileNotFoundError as exc:
+        print(f"ERROR: file not found: {exc.filename}")
+        return 1
+    except json.JSONDecodeError as exc:
+        print(f"ERROR: invalid JSON: {exc}")
+        return 1
+    errors = validate_artifact(data)
+    if errors:
+        for error in errors:
+            print(error)
+        return 1
+    print(f"validated {args.input}: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_notify_slack.py
+++ b/tests/test_notify_slack.py
@@ -785,3 +785,120 @@ def test_main_reports_invalid_performance(ns: ModuleType, tmp_path: Path) -> Non
             str(perf_path),
         ])
     assert result == 1
+
+
+# ── signal-performance trailing summary ──────────────────────────────────────────
+
+
+def _signal_perf(horizons: dict[str, Any]) -> dict[str, Any]:
+    return {"signal_evaluation": {"horizons": horizons}}
+
+
+def test_signal_performance_summary_reports_excess_and_hit_rate(
+    ns: ModuleType,
+) -> None:
+    signal_performance = _signal_perf({
+        "20d": {"count": 8, "excess_return": 0.0123, "hit_rate": 0.625}
+    })
+    assert (
+        ns._signal_performance_summary(signal_performance)
+        == "20d top-5 excess +1.23% (n=8), hit rate 62%"
+    )
+
+
+def test_signal_performance_summary_negative_excess() -> None:
+    signal_performance = _signal_perf({
+        "20d": {"count": 4, "excess_return": -0.005, "hit_rate": None}
+    })
+    assert (
+        _aims_ns._signal_performance_summary(signal_performance)
+        == "20d top-5 excess -0.50% (n=4)"
+    )
+
+
+def test_signal_performance_summary_custom_horizon(ns: ModuleType) -> None:
+    signal_performance = _signal_perf({
+        "1d": {"count": 2, "excess_return": 0.01, "hit_rate": 1.0}
+    })
+    assert ns._signal_performance_summary(signal_performance, horizon=1) == (
+        "1d top-5 excess +1.00% (n=2), hit rate 100%"
+    )
+
+
+def test_signal_performance_summary_none_without_bucket(ns: ModuleType) -> None:
+    assert ns._signal_performance_summary(_signal_perf({})) is None
+
+
+def test_signal_performance_summary_none_with_zero_count(ns: ModuleType) -> None:
+    signal_performance = _signal_perf({
+        "20d": {"count": 0, "excess_return": None, "hit_rate": None}
+    })
+    assert ns._signal_performance_summary(signal_performance) is None
+
+
+def test_build_success_payload_adds_signal_performance_field(
+    ns: ModuleType, fixture_artifact: dict[str, Any]
+) -> None:
+    signal_performance = _signal_perf({
+        "20d": {"count": 3, "excess_return": 0.02, "hit_rate": 0.67}
+    })
+    payload = ns.build_success_payload(
+        fixture_artifact, signal_performance=signal_performance
+    )
+    texts = [f["text"] for f in payload["blocks"][1]["fields"]]
+    assert any("Signal performance:" in t for t in texts)
+
+
+def test_build_success_payload_omits_signal_performance_when_empty(
+    ns: ModuleType, fixture_artifact: dict[str, Any]
+) -> None:
+    signal_performance = _signal_perf({"20d": {"count": 0}})
+    payload = ns.build_success_payload(
+        fixture_artifact, signal_performance=signal_performance
+    )
+    texts = [f["text"] for f in payload["blocks"][1]["fields"]]
+    assert not any("Signal performance:" in t for t in texts)
+
+
+def test_main_success_with_signal_performance(ns: ModuleType, tmp_path: Path) -> None:
+    artifact_path = tmp_path / "artifact.json"
+    with FIXTURE_PATH.open() as fh:
+        artifact_path.write_text(json.dumps(json.load(fh)))
+    signal_path = tmp_path / "signals.json"
+    signal_path.write_text(
+        json.dumps(_signal_perf({"20d": {"count": 1, "excess_return": 0.01}}))
+    )
+    mock_response = MagicMock()
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=False)
+    with (
+        patch.dict("os.environ", {"SLACK_WEBHOOK_URL": "https://hooks.slack.com/test"}),
+        patch("urllib.request.urlopen", return_value=mock_response),
+    ):
+        result = ns.main([
+            "--artifact",
+            str(artifact_path),
+            "--signal-performance",
+            str(signal_path),
+        ])
+    assert result == 0
+
+
+def test_main_reports_invalid_signal_performance(
+    ns: ModuleType, tmp_path: Path
+) -> None:
+    artifact_path = tmp_path / "artifact.json"
+    with FIXTURE_PATH.open() as fh:
+        artifact_path.write_text(json.dumps(json.load(fh)))
+    signal_path = tmp_path / "signals.json"
+    signal_path.write_text("{")
+    with patch.dict(
+        "os.environ", {"SLACK_WEBHOOK_URL": "https://hooks.slack.com/test"}
+    ):
+        result = ns.main([
+            "--artifact",
+            str(artifact_path),
+            "--signal-performance",
+            str(signal_path),
+        ])
+    assert result == 1

--- a/tests/test_signal_performance.py
+++ b/tests/test_signal_performance.py
@@ -1,0 +1,435 @@
+"""Tests for tracking realized forward returns of published top-5 signals."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import date, timedelta
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from aims import signal_performance as sp
+
+_UNIVERSE: dict[str, dict[str, Any]] = {
+    "A": {"score": 90.0, "ret_1d": 0.05, "asset_class": "equity"},
+    "B": {"score": 80.0, "ret_1d": 0.04, "asset_class": "equity"},
+    "C": {"score": 70.0, "ret_1d": 0.03, "asset_class": "commodity"},
+    "D": {"score": 60.0, "ret_1d": 0.02, "asset_class": "commodity"},
+    "E": {"score": 50.0, "ret_1d": 0.01, "asset_class": "equity_index"},
+    "F": {"score": 40.0, "ret_1d": -0.01, "asset_class": "equity_index"},
+}
+
+
+def _dates(n: int, start: str = "2024-01-01") -> list[str]:
+    first = date.fromisoformat(start)
+    return [(first + timedelta(days=i)).isoformat() for i in range(n)]
+
+
+def _inst(
+    symbol: str,
+    *,
+    is_reliable: bool = True,
+    tradable: bool | None = None,
+    ret_1d: float | None = None,
+) -> dict[str, Any]:
+    spec = _UNIVERSE[symbol]
+    inst: dict[str, Any] = {
+        "symbol": symbol,
+        "rank": 1,
+        "score": spec["score"],
+        "is_reliable": is_reliable,
+        "risk_gates": [] if is_reliable else ["stale_data"],
+        "explanation": "x",
+        "asset_class": spec["asset_class"],
+        "features": {"ret_1d": ret_1d if ret_1d is not None else spec["ret_1d"]},
+    }
+    if tradable is not None:
+        inst["tradable"] = tradable
+    return inst
+
+
+def _analysis(
+    when: str,
+    symbols: list[str],
+    *,
+    regime: str | None = None,
+    overrides: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    overrides = overrides or {}
+    instruments = [_inst(s, **overrides.get(s, {})) for s in symbols]
+    meta: dict[str, Any] = {
+        "generated_at": f"{when}T00:00:00+00:00",
+        "config": {"interval": "d"},
+        "data_freshness": dict.fromkeys(symbols, when),
+    }
+    if regime is not None:
+        meta["market_regime"] = {"label": regime}
+    return {"metadata": meta, "instruments": instruments}
+
+
+def _chain(
+    symbols: list[str],
+    n: int,
+    *,
+    regimes: list[str] | None = None,
+    start: str = "2024-01-01",
+) -> list[dict[str, Any]]:
+    dates = _dates(n, start)
+    return [
+        _analysis(when, symbols, regime=(regimes[i] if regimes else None))
+        for i, when in enumerate(dates)
+    ]
+
+
+# ── _resolve_return ──────────────────────────────────────────────────────────────
+
+
+def test_resolve_return_unmatched_without_bar_date() -> None:
+    realized, status = sp._resolve_return("A", {}, {}, {}, {}, 1)
+    assert (realized, status) == (None, "unmatched")
+
+
+def test_resolve_return_unmatched_without_chained_index() -> None:
+    realized, status = sp._resolve_return(
+        "A", {"A": "2024-01-01"}, {}, {}, {"A": {}}, 1
+    )
+    assert (realized, status) == (None, "unmatched")
+
+
+def test_resolve_return_pending_at_chain_end() -> None:
+    bars = {"A": [sp.Bar("2024-01-01", 0.01, None)]}
+    realized, status = sp._resolve_return(
+        "A", {"A": "2024-01-01"}, bars, {"A": set()}, {"A": {"2024-01-01": 0}}, 1
+    )
+    assert (realized, status) == (None, "pending")
+
+
+def test_resolve_return_ok() -> None:
+    bars = {"A": [sp.Bar("2024-01-01", 0.01, None), sp.Bar("2024-01-02", 0.02, None)]}
+    realized, status = sp._resolve_return(
+        "A", {"A": "2024-01-01"}, bars, {"A": set()}, {"A": {"2024-01-01": 0}}, 1
+    )
+    assert status == "ok"
+    assert realized == pytest.approx(0.02)
+
+
+def test_resolve_return_broken() -> None:
+    bars = {"A": [sp.Bar("2024-01-01", 0.01, None), sp.Bar("2024-01-02", 0.02, None)]}
+    realized, status = sp._resolve_return(
+        "A", {"A": "2024-01-01"}, bars, {"A": {1}}, {"A": {"2024-01-01": 0}}, 1
+    )
+    assert (realized, status) == (None, "broken")
+
+
+# ── evaluate_signals ──────────────────────────────────────────────────────────────
+
+
+def test_evaluate_signals_rejects_invalid_horizons() -> None:
+    with pytest.raises(ValueError, match="unique"):
+        sp.evaluate_signals([], horizons=(1, 1))
+    with pytest.raises(ValueError, match="positive"):
+        sp.evaluate_signals([], horizons=())
+    with pytest.raises(ValueError, match="positive"):
+        sp.evaluate_signals([], horizons=(0,))
+
+
+def test_evaluate_signals_empty_analyses() -> None:
+    result, warnings = sp.evaluate_signals([], horizons=(1,))
+    assert result["dates_evaluated"] == 0
+    assert result["horizons"]["1d"]["count"] == 0
+    assert result["horizons"]["1d"]["top5_average_return"] is None
+    assert result["horizons"]["1d"]["by_asset_class"] == {}
+    assert result["horizons"]["1d"]["by_regime"] == {}
+    assert warnings == []
+
+
+def test_evaluate_signals_top5_excludes_lowest_scorer_and_computes_benchmark() -> None:
+    symbols = list(_UNIVERSE)
+    analyses = _chain(symbols, 3, regimes=["Bullish", "Bearish", "Bullish"])
+    result, warnings = sp.evaluate_signals(analyses, horizons=(1,))
+    assert warnings == []
+    assert result["dates_evaluated"] == 3
+    horizon = result["horizons"]["1d"]
+    # 2 fully resolved days x 5 top-5 slots; the 3rd (last) day is pending.
+    assert horizon["count"] == 10
+    assert horizon["pending"] == 5
+    assert horizon["incomplete"] == 0
+    assert horizon["top5_average_return"] == pytest.approx(0.03, abs=1e-5)
+    assert horizon["benchmark_average_return"] == pytest.approx(0.14 / 6, abs=1e-5)
+    assert horizon["excess_return"] == pytest.approx(0.03 - 0.14 / 6, abs=1e-5)
+    assert horizon["hit_rate"] == pytest.approx(0.6)
+
+
+def test_evaluate_signals_by_asset_class_breakdown() -> None:
+    symbols = list(_UNIVERSE)
+    analyses = _chain(symbols, 3)
+    result, _ = sp.evaluate_signals(analyses, horizons=(1,))
+    by_asset_class = result["horizons"]["1d"]["by_asset_class"]
+    assert sorted(by_asset_class) == ["commodity", "equity", "equity_index"]
+    assert by_asset_class["equity"]["count"] == 4
+    assert by_asset_class["equity"]["top5_average_return"] == pytest.approx(0.045)
+    assert by_asset_class["commodity"]["count"] == 4
+    assert by_asset_class["commodity"]["top5_average_return"] == pytest.approx(0.025)
+    # F (equity_index) is excluded from top-5, so only E contributes.
+    assert by_asset_class["equity_index"]["count"] == 2
+    assert by_asset_class["equity_index"]["top5_average_return"] == pytest.approx(0.01)
+
+
+def test_evaluate_signals_by_regime_breakdown() -> None:
+    symbols = list(_UNIVERSE)
+    analyses = _chain(symbols, 3, regimes=["Bullish", "Bearish", "Bullish"])
+    result, _ = sp.evaluate_signals(analyses, horizons=(1,))
+    by_regime = result["horizons"]["1d"]["by_regime"]
+    assert by_regime["Bullish"]["count"] == 5
+    assert by_regime["Bearish"]["count"] == 5
+    assert by_regime["Bullish"]["top5_average_return"] == pytest.approx(0.03)
+
+
+def test_evaluate_signals_defaults_regime_to_unavailable() -> None:
+    symbols = list(_UNIVERSE)
+    analyses = _chain(symbols, 2)  # no regime label set
+    result, _ = sp.evaluate_signals(analyses, horizons=(1,))
+    by_regime = result["horizons"]["1d"]["by_regime"]
+    assert list(by_regime) == ["Unavailable"]
+
+
+def test_evaluate_signals_excludes_non_tradable_from_top5() -> None:
+    symbols = list(_UNIVERSE)
+    # Make A (the top scorer) non-tradable; it must not occupy a top-5 slot
+    # even though it would otherwise rank first, but it still counts toward
+    # the benchmark.
+    analyses = _chain(symbols, 3)
+    for artifact in analyses:
+        for inst in artifact["instruments"]:
+            if inst["symbol"] == "A":
+                inst["tradable"] = False
+    result, _ = sp.evaluate_signals(analyses, horizons=(1,))
+    horizon = result["horizons"]["1d"]
+    # Top-5 now B..F's top 5 minus benchmark-only exclusion: B,C,D,E,F.
+    assert horizon["count"] == 10
+    assert horizon["by_asset_class"]["equity_index"]["count"] == 4  # E and F now
+
+
+def test_evaluate_signals_skips_dates_without_reliable_instruments() -> None:
+    analysis = _analysis("2024-01-01", ["A"], overrides={"A": {"is_reliable": False}})
+    result, _ = sp.evaluate_signals([analysis], horizons=(1,))
+    assert result["dates_evaluated"] == 0
+
+
+def test_evaluate_signals_broken_chain_recorded_as_incomplete_with_warning() -> None:
+    # ret_5d that cannot be reproduced by the chained ret_1d values marks the
+    # link broken; build 6 days so day0's 5-day forward window is affected.
+    dates = _dates(7)
+    analyses = []
+    for i, when in enumerate(dates):
+        instruments = []
+        for symbol in _UNIVERSE:
+            inst = _inst(symbol)
+            if symbol == "A" and i == 5:
+                # Any ret_5d inconsistent with the chained ret_1d values
+                # breaks the preceding 5 links for A.
+                inst["features"]["ret_5d"] = 999.0
+            instruments.append(inst)
+        analyses.append({
+            "metadata": {
+                "generated_at": f"{when}T00:00:00+00:00",
+                "config": {"interval": "d"},
+                "data_freshness": dict.fromkeys(_UNIVERSE, when),
+            },
+            "instruments": instruments,
+        })
+    result, warnings = sp.evaluate_signals(analyses, horizons=(1,))
+    assert result["horizons"]["1d"]["incomplete"] > 0
+    assert any("broken bar chain" in w for w in warnings)
+
+
+def test_evaluate_signals_top5_symbol_unmatched_is_incomplete_without_warning() -> None:
+    when = "2024-01-01"
+    analysis = _analysis(when, list(_UNIVERSE))
+    del analysis["metadata"]["data_freshness"]["A"]
+    result, warnings = sp.evaluate_signals([analysis], horizons=(1,))
+    assert result["horizons"]["1d"]["incomplete"] >= 1
+    assert warnings == []
+
+
+def test_evaluate_signals_deduplicates_conflicting_ret_1d_warnings() -> None:
+    when = "2024-01-01"
+    analyses = [
+        _analysis(when, ["A"]),
+        {
+            **_analysis(when, ["A"]),
+            "instruments": [_inst("A", ret_1d=0.5)],
+        },
+        {
+            **_analysis(when, ["A"]),
+            "instruments": [_inst("A", ret_1d=0.9)],
+        },
+    ]
+    _, warnings = sp.evaluate_signals(analyses, horizons=(1,))
+    conflict = [w for w in warnings if "conflicting ret_1d" in w]
+    assert len(conflict) == 1
+
+
+# ── build_artifact ────────────────────────────────────────────────────────────────
+
+
+def test_build_artifact_shape() -> None:
+    symbols = list(_UNIVERSE)
+    analyses = _chain(symbols, 3)
+    artifact = sp.build_artifact(analyses, as_of="2024-01-03", horizons=(1,))
+    assert artifact["version"] == sp.SIGNAL_PERFORMANCE_VERSION
+    assert artifact["metadata"]["as_of"] == "2024-01-03"
+    assert artifact["metadata"]["config"]["top_k"] == sp.TOP_K
+    assert artifact["metadata"]["inputs"]["analysis_dates"] == _dates(3)
+    assert artifact["metadata"]["disclaimer"] == sp.DISCLAIMER
+    assert "1d" in artifact["signal_evaluation"]["horizons"]
+
+
+def test_build_artifact_is_stable_across_json_round_trip() -> None:
+    symbols = list(_UNIVERSE)
+    analyses = _chain(symbols, 3)
+    artifact = sp.build_artifact(analyses, as_of="2024-01-03")
+    round_tripped = json.loads(json.dumps(artifact, sort_keys=True))
+    assert round_tripped["signal_evaluation"] == artifact["signal_evaluation"]
+
+
+# ── render_page ───────────────────────────────────────────────────────────────────
+
+
+def test_render_page_overview_and_breakdowns() -> None:
+    symbols = list(_UNIVERSE)
+    analyses = _chain(symbols, 3, regimes=["Bullish", "Bearish", "Bullish"])
+    artifact = sp.build_artifact(analyses, as_of="2024-01-03", horizons=(1,))
+    page = sp.render_page(artifact)
+    assert 'title = "Signal Performance"' in page
+    assert "## Cumulative Overview" in page
+    assert "### By Asset Class" in page
+    assert "### By Market Regime" in page
+    assert "equity" in page
+    assert "Bullish" in page
+    assert sp.DISCLAIMER in page
+
+
+def test_render_page_no_observations_yet() -> None:
+    artifact = sp.build_artifact([], as_of="2024-01-01", horizons=(1,))
+    page = sp.render_page(artifact)
+    assert "_No matured observations yet._" in page
+
+
+def test_render_page_caps_warning_list() -> None:
+    artifact = sp.build_artifact([], as_of="2024-01-01", horizons=(1,))
+    artifact["warnings"] = [f"warning {i:02d}" for i in range(25)]
+    page = sp.render_page(artifact)
+    assert "warning 19" in page
+    assert "warning 20" not in page
+    assert "… and 5 more" in page
+
+
+def test_render_page_no_warnings_section_when_empty() -> None:
+    artifact = sp.build_artifact([], as_of="2024-01-01", horizons=(1,))
+    page = sp.render_page(artifact)
+    assert "Warnings" not in page
+
+
+def test_render_page_warnings_under_cap_omits_more_suffix() -> None:
+    artifact = sp.build_artifact([], as_of="2024-01-01", horizons=(1,))
+    artifact["warnings"] = ["one", "two", "three"]
+    page = sp.render_page(artifact)
+    assert "Warnings (3)" in page
+    assert "more" not in page
+
+
+# ── generate / main ───────────────────────────────────────────────────────────────
+
+
+def _write_analysis(path: Path, artifact: dict[str, Any]) -> None:
+    path.write_text(json.dumps(artifact, sort_keys=True), encoding="utf-8")
+
+
+def test_generate_writes_artifact_and_page(tmp_path: Path) -> None:
+    analysis_dir = tmp_path / "analysis"
+    analysis_dir.mkdir()
+    symbols = list(_UNIVERSE)
+    for artifact in _chain(symbols, 3):
+        when = artifact["metadata"]["generated_at"][:10]
+        _write_analysis(analysis_dir / f"{when}.json", artifact)
+    output = tmp_path / "signals.json"
+    page_output = tmp_path / "page.md"
+    sp.generate(analysis_dir, output, horizons=(1,), page_output=page_output)
+    written = json.loads(output.read_text())
+    assert written["metadata"]["as_of"] == "2024-01-03"
+    assert page_output.read_text().startswith("+++")
+
+
+def test_generate_ignores_non_daily_artifacts(tmp_path: Path) -> None:
+    analysis_dir = tmp_path / "analysis"
+    analysis_dir.mkdir()
+    daily = _analysis("2024-01-01", ["A"])
+    weekly = _analysis("2024-01-01", ["A"])
+    weekly["metadata"]["config"]["interval"] = "w"
+    _write_analysis(analysis_dir / "2024-01-01.json", daily)
+    _write_analysis(analysis_dir / "2024-01-01-w.json", weekly)
+    output = tmp_path / "signals.json"
+    sp.generate(analysis_dir, output, horizons=(1,))
+    written = json.loads(output.read_text())
+    assert written["metadata"]["inputs"]["analysis_dates"] == ["2024-01-01"]
+
+
+def test_generate_raises_without_daily_artifacts(tmp_path: Path) -> None:
+    analysis_dir = tmp_path / "analysis"
+    analysis_dir.mkdir()
+    with pytest.raises(ValueError, match="no daily analysis artifacts"):
+        sp.generate(analysis_dir, tmp_path / "signals.json")
+
+
+def test_main_success(tmp_path: Path) -> None:
+    analysis_dir = tmp_path / "analysis"
+    analysis_dir.mkdir()
+    _write_analysis(analysis_dir / "2024-01-01.json", _analysis("2024-01-01", ["A"]))
+    output = tmp_path / "signals.json"
+    rc = sp.main([
+        "--analysis-dir",
+        str(analysis_dir),
+        "--output",
+        str(output),
+        "--horizons",
+        "1",
+    ])
+    assert rc == 0
+    assert output.exists()
+
+
+def test_main_error_returns_nonzero(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    analysis_dir = tmp_path / "empty"
+    analysis_dir.mkdir()
+    rc = sp.main([
+        "--analysis-dir",
+        str(analysis_dir),
+        "--output",
+        str(tmp_path / "out.json"),
+    ])
+    assert rc == 1
+    assert "ERROR" in capsys.readouterr().out
+
+
+def test_parse_horizons_rejects_invalid() -> None:
+    with pytest.raises(argparse.ArgumentTypeError):
+        sp._parse_horizons("0")
+    with pytest.raises(argparse.ArgumentTypeError):
+        sp._parse_horizons("a")
+    assert sp._parse_horizons("1,5") == (1, 5)
+
+
+def test_analysis_interval_defaults_to_empty_string() -> None:
+    assert sp._analysis_interval({}) == ""
+
+
+def test_artifact_date_requires_valid_generated_at() -> None:
+    with pytest.raises(ValueError, match="generated_at"):
+        sp._artifact_date({"metadata": {}})

--- a/tests/test_validate_signal_performance.py
+++ b/tests/test_validate_signal_performance.py
@@ -1,0 +1,359 @@
+"""Tests for the cumulative signal-performance artifact validator."""
+
+from __future__ import annotations
+
+import copy
+import json
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+from aims import signal_performance as sp
+from aims.validate_signal_performance import main, validate_artifact
+
+
+def _valid_artifact() -> dict[str, Any]:
+    analyses = [
+        {
+            "metadata": {
+                "generated_at": "2024-01-01T00:00:00+00:00",
+                "config": {"interval": "d"},
+                "data_freshness": {"A": "2024-01-01", "B": "2024-01-01"},
+                "market_regime": {"label": "Bullish"},
+            },
+            "instruments": [
+                {
+                    "symbol": "A",
+                    "rank": 1,
+                    "score": 90.0,
+                    "is_reliable": True,
+                    "risk_gates": [],
+                    "explanation": "x",
+                    "asset_class": "equity",
+                    "features": {"ret_1d": 0.02},
+                },
+                {
+                    "symbol": "B",
+                    "rank": 2,
+                    "score": 80.0,
+                    "is_reliable": True,
+                    "risk_gates": [],
+                    "explanation": "x",
+                    "asset_class": "commodity",
+                    "features": {"ret_1d": 0.01},
+                },
+            ],
+        },
+        {
+            "metadata": {
+                "generated_at": "2024-01-02T00:00:00+00:00",
+                "config": {"interval": "d"},
+                "data_freshness": {"A": "2024-01-02", "B": "2024-01-02"},
+                "market_regime": {"label": "Bullish"},
+            },
+            "instruments": [
+                {
+                    "symbol": "A",
+                    "rank": 1,
+                    "score": 90.0,
+                    "is_reliable": True,
+                    "risk_gates": [],
+                    "explanation": "x",
+                    "asset_class": "equity",
+                    "features": {"ret_1d": 0.02},
+                },
+                {
+                    "symbol": "B",
+                    "rank": 2,
+                    "score": 80.0,
+                    "is_reliable": True,
+                    "risk_gates": [],
+                    "explanation": "x",
+                    "asset_class": "commodity",
+                    "features": {"ret_1d": 0.01},
+                },
+            ],
+        },
+    ]
+    return sp.build_artifact(analyses, as_of="2024-01-02", horizons=(1,))
+
+
+def test_validate_valid_artifact() -> None:
+    assert validate_artifact(_valid_artifact()) == []
+
+
+def test_validate_missing_top_key() -> None:
+    artifact = _valid_artifact()
+    del artifact["warnings"]
+    assert validate_artifact(artifact) == ["missing required key: 'warnings'"]
+
+
+def test_validate_wrong_version() -> None:
+    artifact = _valid_artifact()
+    artifact["version"] = "9.9.9"
+    assert any("unsupported version" in e for e in validate_artifact(artifact))
+
+
+def test_validate_metadata_must_be_object() -> None:
+    artifact = _valid_artifact()
+    artifact["metadata"] = []
+    assert "'metadata' must be a JSON object" in validate_artifact(artifact)
+
+
+def test_validate_metadata_missing_key() -> None:
+    artifact = _valid_artifact()
+    del artifact["metadata"]["disclaimer"]
+    errors = validate_artifact(artifact)
+    assert any("metadata missing required key: 'disclaimer'" in e for e in errors)
+
+
+def test_validate_config_top_k_must_be_positive_int() -> None:
+    artifact = _valid_artifact()
+    artifact["metadata"]["config"]["top_k"] = 0
+    errors = validate_artifact(artifact)
+    assert any("top_k must be a positive integer" in e for e in errors)
+    artifact["metadata"]["config"]["top_k"] = "5"
+    errors = validate_artifact(artifact)
+    assert any("top_k must be a positive integer" in e for e in errors)
+
+
+def test_validate_config_horizons_must_be_unique_positive() -> None:
+    artifact = _valid_artifact()
+    artifact["metadata"]["config"]["horizons"] = [1, 1]
+    errors = validate_artifact(artifact)
+    assert any("horizons must be unique positive integers" in e for e in errors)
+
+
+def test_validate_config_tolerance_must_be_non_negative() -> None:
+    artifact = _valid_artifact()
+    artifact["metadata"]["config"]["return_consistency_tolerance"] = -1
+    errors = validate_artifact(artifact)
+    assert any("return_consistency_tolerance" in e for e in errors)
+
+
+def test_validate_config_must_be_object_when_present() -> None:
+    artifact = _valid_artifact()
+    artifact["metadata"]["config"] = "bad"
+    errors = validate_artifact(artifact)
+    assert any("metadata.config must be a JSON object" in e for e in errors)
+
+
+def test_validate_config_absent_skips_config_checks() -> None:
+    artifact = _valid_artifact()
+    del artifact["metadata"]["config"]
+    errors = validate_artifact(artifact)
+    assert any("metadata missing required key: 'config'" in e for e in errors)
+    assert not any("metadata.config must be" in e for e in errors)
+
+
+def test_validate_inputs_dates_must_be_sorted_iso_dates() -> None:
+    artifact = _valid_artifact()
+    artifact["metadata"]["inputs"]["analysis_dates"] = ["2024-01-02", "2024-01-01"]
+    errors = validate_artifact(artifact)
+    assert any("analysis_dates must be sorted" in e for e in errors)
+    artifact["metadata"]["inputs"]["analysis_dates"] = ["bad-date"]
+    errors = validate_artifact(artifact)
+    assert any("YYYY-MM-DD" in e for e in errors)
+
+
+def test_validate_inputs_must_be_object_when_present() -> None:
+    artifact = _valid_artifact()
+    artifact["metadata"]["inputs"] = "bad"
+    errors = validate_artifact(artifact)
+    assert any("metadata.inputs must be a JSON object" in e for e in errors)
+
+
+def test_validate_inputs_absent_skips_inputs_checks() -> None:
+    artifact = _valid_artifact()
+    del artifact["metadata"]["inputs"]
+    errors = validate_artifact(artifact)
+    assert any("metadata missing required key: 'inputs'" in e for e in errors)
+    assert not any("metadata.inputs must be" in e for e in errors)
+
+
+def test_validate_as_of_must_be_iso_date() -> None:
+    artifact = _valid_artifact()
+    artifact["metadata"]["as_of"] = "not-a-date"
+    errors = validate_artifact(artifact)
+    assert any("is not a YYYY-MM-DD date" in e for e in errors)
+
+
+def test_validate_signal_evaluation_must_be_object() -> None:
+    artifact = _valid_artifact()
+    artifact["signal_evaluation"] = []
+    errors = validate_artifact(artifact)
+    assert "'signal_evaluation' must be a JSON object" in errors
+
+
+def test_validate_dates_evaluated_must_be_non_negative_int() -> None:
+    artifact = _valid_artifact()
+    artifact["signal_evaluation"]["dates_evaluated"] = -1
+    errors = validate_artifact(artifact)
+    assert any("dates_evaluated must be a non-negative integer" in e for e in errors)
+
+
+def test_validate_horizons_must_be_object() -> None:
+    artifact = _valid_artifact()
+    artifact["signal_evaluation"]["horizons"] = "bad"
+    errors = validate_artifact(artifact)
+    assert any("signal_evaluation.horizons must be a JSON object" in e for e in errors)
+
+
+def test_validate_horizons_absent_skips_horizons_object_check() -> None:
+    artifact = _valid_artifact()
+    del artifact["signal_evaluation"]["horizons"]
+    errors = validate_artifact(artifact)
+    assert any(
+        "signal_evaluation missing required key: 'horizons'" in e for e in errors
+    )
+    assert not any("horizons must be a JSON object" in e for e in errors)
+
+
+def test_validate_horizons_keys_must_match_config() -> None:
+    artifact = _valid_artifact()
+    artifact["signal_evaluation"]["horizons"]["5d"] = artifact["signal_evaluation"][
+        "horizons"
+    ].pop("1d")
+    errors = validate_artifact(artifact)
+    assert any("horizons keys do not match" in e for e in errors)
+
+
+def test_validate_horizon_missing_key() -> None:
+    artifact = _valid_artifact()
+    del artifact["signal_evaluation"]["horizons"]["1d"]["count"]
+    errors = validate_artifact(artifact)
+    assert any(
+        "signal_evaluation.horizons.1d missing required key: 'count'" in e
+        for e in errors
+    )
+
+
+def test_validate_horizon_must_be_object() -> None:
+    artifact = _valid_artifact()
+    artifact["signal_evaluation"]["horizons"]["1d"] = "bad"
+    errors = validate_artifact(artifact)
+    assert any(
+        "signal_evaluation.horizons.1d must be a JSON object" in e for e in errors
+    )
+
+
+def test_validate_horizon_pending_incomplete_must_be_non_negative() -> None:
+    artifact = _valid_artifact()
+    artifact["signal_evaluation"]["horizons"]["1d"]["pending"] = -1
+    errors = validate_artifact(artifact)
+    assert any(
+        "signal_evaluation.horizons.1d.pending must be a non-negative integer" in e
+        for e in errors
+    )
+
+
+def test_validate_bucket_must_be_object() -> None:
+    artifact = _valid_artifact()
+    artifact["signal_evaluation"]["horizons"]["1d"]["count"] = "bad"
+    errors = validate_artifact(artifact)
+    assert any("count must be a non-negative integer" in e for e in errors)
+
+
+def test_validate_bucket_missing_key() -> None:
+    artifact = _valid_artifact()
+    del artifact["signal_evaluation"]["horizons"]["1d"]["hit_rate"]
+    errors = validate_artifact(artifact)
+    assert any("missing required key: 'hit_rate'" in e for e in errors)
+
+
+def test_validate_bucket_average_return_must_be_number_or_null() -> None:
+    artifact = _valid_artifact()
+    artifact["signal_evaluation"]["horizons"]["1d"]["top5_average_return"] = "bad"
+    errors = validate_artifact(artifact)
+    assert any("top5_average_return must be null or a number" in e for e in errors)
+
+
+def test_validate_bucket_hit_rate_out_of_range() -> None:
+    artifact = _valid_artifact()
+    artifact["signal_evaluation"]["horizons"]["1d"]["hit_rate"] = 1.5
+    errors = validate_artifact(artifact)
+    assert any("hit_rate must be null or a number in [0, 1]" in e for e in errors)
+
+
+def test_validate_by_asset_class_must_be_object() -> None:
+    artifact = _valid_artifact()
+    artifact["signal_evaluation"]["horizons"]["1d"]["by_asset_class"] = "bad"
+    errors = validate_artifact(artifact)
+    assert any("by_asset_class must be a JSON object" in e for e in errors)
+
+
+def test_validate_by_asset_class_bucket_shape() -> None:
+    artifact = _valid_artifact()
+    by_asset_class = artifact["signal_evaluation"]["horizons"]["1d"]["by_asset_class"]
+    bucket = next(iter(by_asset_class.values()))
+    bucket["count"] = "bad"
+    errors = validate_artifact(artifact)
+    assert any("count must be a non-negative integer" in e for e in errors)
+
+
+def test_validate_by_asset_class_bucket_must_be_object() -> None:
+    artifact = _valid_artifact()
+    by_asset_class = artifact["signal_evaluation"]["horizons"]["1d"]["by_asset_class"]
+    label = next(iter(by_asset_class))
+    by_asset_class[label] = []
+    errors = validate_artifact(artifact)
+    assert any(f"by_asset_class.{label} must be a JSON object" in e for e in errors)
+
+
+def test_validate_by_asset_class_bucket_missing_key() -> None:
+    artifact = _valid_artifact()
+    by_asset_class = artifact["signal_evaluation"]["horizons"]["1d"]["by_asset_class"]
+    label, bucket = next(iter(by_asset_class.items()))
+    del bucket["hit_rate"]
+    errors = validate_artifact(artifact)
+    assert any(
+        f"by_asset_class.{label} missing required key: 'hit_rate'" in e for e in errors
+    )
+
+
+def test_validate_bucket_hit_rate_null_is_valid() -> None:
+    artifact = _valid_artifact()
+    by_asset_class = artifact["signal_evaluation"]["horizons"]["1d"]["by_asset_class"]
+    _, bucket = next(iter(by_asset_class.items()))
+    bucket["hit_rate"] = None
+    assert validate_artifact(artifact) == []
+
+
+def test_validate_warnings_must_be_list_of_strings() -> None:
+    artifact = _valid_artifact()
+    artifact["warnings"] = "bad"
+    errors = validate_artifact(artifact)
+    assert "'warnings' must be a list of strings" in errors
+    artifact["warnings"] = [1, 2]
+    errors = validate_artifact(artifact)
+    assert "'warnings' must be a list of strings" in errors
+
+
+def test_main_valid_file(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    path = tmp_path / "signals.json"
+    path.write_text(json.dumps(_valid_artifact()), encoding="utf-8")
+    assert main(["--input", str(path)]) == 0
+    assert "OK" in capsys.readouterr().out
+
+
+def test_main_invalid_file(tmp_path: Path) -> None:
+    artifact = copy.deepcopy(_valid_artifact())
+    del artifact["warnings"]
+    path = tmp_path / "signals.json"
+    path.write_text(json.dumps(artifact), encoding="utf-8")
+    assert main(["--input", str(path)]) == 1
+
+
+def test_main_missing_file(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["--input", str(tmp_path / "missing.json")]) == 1
+    assert "ERROR" in capsys.readouterr().out
+
+
+def test_main_invalid_json(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    path = tmp_path / "bad.json"
+    path.write_text("{not json", encoding="utf-8")
+    assert main(["--input", str(path)]) == 1
+    assert "ERROR" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

- Add `src/aims/signal_performance.py`: joins each committed daily analysis artifact's top-5 reliable/tradable instruments with realized forward returns (reusing the #97 bar-chaining/`forward_return` machinery — no live price fetch) against an equal-weight benchmark over that date's reliable universe, at 1d/5d/20d horizons.
- Each top-5 instrument becomes an individually tagged "slot observation" (asset class + market regime label, #77), so per-asset-class and per-regime breakdowns don't require whole-date completeness.
- New cumulative artifact `data/performance/signals.json` (`SIGNAL_PERFORMANCE_VERSION = "1.0.0"`, rebuilt in full each run) + `data/schema/signal_performance.schema.json` + `src/aims/validate_signal_performance.py` + thin skill wrapper scripts.
- New public page `content/performance/_index.md`: cumulative overview table, by-asset-class and by-regime breakdowns, warnings.
- `src/aims/notifications.py`: new `--signal-performance` CLI arg; when matured 20d observations exist, the Slack success payload gains a trailing `20d top-5 excess ...` line (excess return + hit rate), mirroring the existing `--performance` (stance hit-rate) pattern.
- `.github/workflows/daily-market-analysis.yml`: new "Track signal performance" step after "Evaluate qualitative stances" (daily interval only, independent of the qualitative outcome), validates the artifact, commits `data/performance/signals.json` and `content/performance/` in the analysis PR, and passes `--signal-performance` to `notify_slack.py`.
- `OPERATIONS.md`: new "Signal performance tracking (#82)" subsection under §3 Scoring methodology, plus a manual-recovery recipe under §9.

## Validation

- `uv run pytest` — 1134 passed, 100% branch coverage (`tests/test_signal_performance.py`, `tests/test_validate_signal_performance.py`, extended `tests/test_notify_slack.py`).
- `uv run ruff format . && uv run ruff check .` — clean.
- `uv run pyright .` — 0 errors.
- `hugo --gc --minify` — builds; new `content/performance/_index.md` renders.
- `.agents/skills/local-qa/scripts/qa.sh` — zizmor/actionlint/yamllint/checkov all clean on the workflow change.

## Post-merge

- First daily run after merge populates `data/performance/signals.json` from the existing committed `data/analysis/*.json` history and publishes `content/performance/`.
- Closes #82.