### PR TITLE
feat(reports): #83 ボラティリティ目標サイジングとATRストップコンテキスト

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -181,6 +181,20 @@ output is informational and is not investment advice.
 
 Each feature value is converted to a cross-sectional percentile rank across all instruments in the universe for that run. Features where "lower is better" are inverted (100 minus percentile). The composite score is the unweighted mean of all ten feature ranks, ranging from 0 to 100.
 
+### Volatility-targeted sizing and ATR stop context (#83)
+
+Each reliable instrument's artifact entry also carries a `risk_context` block — informational sizing/stop hints computed from the same fetched OHLCV bars, stored separately from `features` and never fed into `score_instruments` or risk-gate suppression:
+
+| Field                   | Formula                                                                                                                                                                                                  |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `atr_14`                | 14-bar Average True Range (Wilder's true range, simple mean, not Wilder's smoothing), in price units                                                                                                     |
+| `atr_14_pct`            | `atr_14 / latest_close`                                                                                                                                                                                  |
+| `vol_target_multiplier` | `metadata.config.risk_target_annual_vol / features.vol_20d` — a notional scale factor for a configurable per-position annualized-volatility target (default 10%); `null` when `vol_20d` is `null` or `0` |
+| `stop_distance`         | `metadata.config.stop_atr_multiple * atr_14` (default multiple: 2.0), in price units                                                                                                                     |
+| `stop_distance_pct`     | `stop_distance / latest_close`                                                                                                                                                                           |
+
+All five fields are `null` together when there are fewer than 15 bars (ATR needs 14 true-range observations plus the prior close); `vol_target_multiplier` is independently `null` whenever `vol_20d` is unavailable, even if ATR itself is computable. The two config values are recorded in every artifact's `metadata.config` so a report or downstream reader never has to guess which target/multiple produced a given number. Rendered in the report's "Risk Context" table with the disclaimer that this is not account-level advice, margin-call simulation, or broker integration — it ignores account size, existing exposure, and execution costs. See `data/schema/analysis.schema.json`'s `risk_context` note for the JSON shape.
+
 ### Risk gates
 
 Instruments that fail quality checks are included in output but marked `is_reliable: false` and ranked below reliable instruments. They appear in the "Instruments to Avoid" section of the report.

--- a/data/schema/analysis.schema.json
+++ b/data/schema/analysis.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "AIMS analysis artifact",
   "description": "Schema reference for validate_analysis.py. Validation is implemented in Python rather than a JSON Schema library to avoid runtime dependencies.",
-  "artifact_version": "1.1.0",
+  "artifact_version": "1.2.0",
   "required_top_keys": ["version", "metadata", "instruments"],
   "required_metadata_keys": [
     "generated_at",
@@ -27,7 +27,9 @@
     "stale_days",
     "max_gap_days",
     "min_history",
-    "coverage_policy"
+    "coverage_policy",
+    "risk_target_annual_vol",
+    "stop_atr_multiple"
   ],
   "required_coverage_keys": [
     "attempted_count",
@@ -41,7 +43,8 @@
     "data_source": "Sorted comma-separated provider names, e.g. 'stooq' or 'csv,stooq'.",
     "data_freshness": "Object mapping symbol to latest bar date (YYYY-MM-DD) or 'n/a' if no bars.",
     "rank": "Display rank after reliability-aware ordering: reliable instruments (is_reliable=true) rank first by score descending; unreliable instruments follow.",
-    "market_regime": "Computed once at generation time from the share of reliable instruments trading above their 20-day moving average (breadth). 'breadth' is null and 'label' is 'Unavailable' when no reliable instrument has MA20 data. Reports and notifications read this field as the source of truth; artifacts predating schema 1.1.0 lack it and are labeled by on-the-fly recomputation for backward compatibility."
+    "market_regime": "Computed once at generation time from the share of reliable instruments trading above their 20-day moving average (breadth). 'breadth' is null and 'label' is 'Unavailable' when no reliable instrument has MA20 data. Reports and notifications read this field as the source of truth; artifacts predating schema 1.1.0 lack it and are labeled by on-the-fly recomputation for backward compatibility.",
+    "risk_context": "Informational volatility-targeted sizing and ATR stop-distance hints (#83), never used in scoring or risk-gate suppression. 'atr_14' is the 14-bar Average True Range in price units; 'atr_14_pct' is atr_14 divided by the latest close. 'vol_target_multiplier' is metadata.config.risk_target_annual_vol divided by features.vol_20d (a notional scale factor for a configurable per-position annualized-volatility target); null when vol_20d is null or zero. 'stop_distance' is metadata.config.stop_atr_multiple times atr_14, in price units; 'stop_distance_pct' is stop_distance divided by the latest close. All fields are null when there isn't enough history (fewer than 15 bars) or the underlying input is null/zero. Artifacts predating schema 1.2.0 lack this field."
   },
   "required_instrument_keys": [
     "symbol",
@@ -50,7 +53,15 @@
     "is_reliable",
     "risk_gates",
     "explanation",
-    "features"
+    "features",
+    "risk_context"
+  ],
+  "required_risk_context_keys": [
+    "atr_14",
+    "atr_14_pct",
+    "vol_target_multiplier",
+    "stop_distance",
+    "stop_distance_pct"
   ],
   "optional_instrument_keys": {
     "canonical_id": "Canonical instrument identifier from canonical_instrument_mappings.csv, e.g. 'spx'. Present when generate --mapping is used.",

--- a/src/aims/market_analysis.py
+++ b/src/aims/market_analysis.py
@@ -65,7 +65,11 @@ _FETCH_STATUS_FAILED: Final[str] = "failed"
 _FETCH_STATUS_PENDING: Final[str] = "pending"
 
 SCORING_VERSION: Final[str] = "1.0.0"
-ARTIFACT_VERSION: Final[str] = "1.1.0"
+ARTIFACT_VERSION: Final[str] = "1.2.0"
+
+_ATR_PERIOD: Final[int] = 14
+DEFAULT_RISK_TARGET_ANNUAL_VOL: Final[float] = 0.10
+DEFAULT_STOP_ATR_MULTIPLE: Final[float] = 2.0
 
 _BULLISH_BREADTH: Final[float] = 0.65
 _BEARISH_BREADTH: Final[float] = 0.35
@@ -918,6 +922,73 @@ def compute_features(bars: list[OhlcvBar]) -> InstrumentFeatures:
     )
 
 
+# ── Risk context ───────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class RiskContext:
+    """Volatility-targeted sizing and ATR stop-distance hints (#83).
+
+    Purely informational: derived from already-fetched OHLCV data but never
+    fed into ``score_instruments`` or risk-gate suppression.
+    """
+
+    atr_14: float | None
+    atr_14_pct: float | None
+    vol_target_multiplier: float | None
+    stop_distance: float | None
+    stop_distance_pct: float | None
+
+
+def _true_range(prev_close: float, high: float, low: float) -> float:
+    return max(high - low, abs(high - prev_close), abs(low - prev_close))
+
+
+def compute_atr(bars: list[OhlcvBar], n: int = _ATR_PERIOD) -> float | None:
+    """Average True Range over the trailing *n* bars, or ``None`` if too few."""
+    if len(bars) < n + 1:
+        return None
+    trs = [
+        _true_range(bars[i - 1].close, bars[i].high, bars[i].low)
+        for i in range(len(bars) - n, len(bars))
+    ]
+    return sum(trs) / n
+
+
+def compute_risk_context(
+    bars: list[OhlcvBar],
+    features: InstrumentFeatures,
+    *,
+    risk_target_annual_vol: float = DEFAULT_RISK_TARGET_ANNUAL_VOL,
+    stop_atr_multiple: float = DEFAULT_STOP_ATR_MULTIPLE,
+) -> RiskContext:
+    """Derive ATR(14), a vol-target size multiplier, and an ATR stop distance.
+
+    ``vol_target_multiplier`` is ``risk_target_annual_vol / vol_20d`` (a
+    scale-down factor when realized volatility exceeds the target, scale-up
+    when below it); ``stop_distance`` is ``stop_atr_multiple * atr_14``. Any
+    input that can't be computed (short history, zero/missing volatility or
+    price) yields ``None`` for the fields that depend on it rather than
+    raising, matching the rest of this module's missing-data handling.
+    """
+    atr = compute_atr(bars)
+    last_close = bars[-1].close if bars else None
+    atr_pct = atr / last_close if atr is not None and last_close else None
+    vol = features.vol_20d
+    vol_target_multiplier = risk_target_annual_vol / vol if vol else None
+    stop_distance = atr * stop_atr_multiple if atr is not None else None
+    stop_distance_pct = (
+        stop_distance / last_close if stop_distance is not None and last_close else None
+    )
+    return RiskContext(
+        atr_14=atr,
+        atr_14_pct=atr_pct,
+        vol_target_multiplier=vol_target_multiplier,
+        stop_distance=stop_distance,
+        stop_distance_pct=stop_distance_pct,
+    )
+
+
 # ── Scoring ────────────────────────────────────────────────────────────────────
 
 
@@ -932,6 +1003,7 @@ class InstrumentScore:
     risk_gates: list[str]
     is_reliable: bool
     explanation: str
+    risk_context: RiskContext
 
 
 def _percentile_rank(values: list[float | None], idx: int) -> float:
@@ -1046,6 +1118,8 @@ def score_instruments(
     min_history: int = _MIN_HISTORY,
     max_gap_days: int = _MAX_GAP_DAYS,
     extra_risk_gates: dict[str, list[str]] | None = None,
+    risk_target_annual_vol: float = DEFAULT_RISK_TARGET_ANNUAL_VOL,
+    stop_atr_multiple: float = DEFAULT_STOP_ATR_MULTIPLE,
 ) -> list[InstrumentScore]:
     if not data:
         return []
@@ -1082,6 +1156,12 @@ def score_instruments(
                 risk_gates=gates,
                 is_reliable=not bool(gates),
                 explanation=_build_explanation(symbol, feats, gates),
+                risk_context=compute_risk_context(
+                    data[symbol],
+                    feats,
+                    risk_target_annual_vol=risk_target_annual_vol,
+                    stop_atr_multiple=stop_atr_multiple,
+                ),
             )
         )
 
@@ -1154,6 +1234,16 @@ def _features_to_dict(feats: InstrumentFeatures) -> dict[str, float | None]:
         "mdd_60d": feats.mdd_60d,
         "rsi_14": feats.rsi_14,
         "zscore_20d": feats.zscore_20d,
+    }
+
+
+def _risk_context_to_dict(rc: RiskContext) -> dict[str, float | None]:
+    return {
+        "atr_14": rc.atr_14,
+        "atr_14_pct": rc.atr_14_pct,
+        "vol_target_multiplier": rc.vol_target_multiplier,
+        "stop_distance": rc.stop_distance,
+        "stop_distance_pct": rc.stop_distance_pct,
     }
 
 
@@ -1230,6 +1320,7 @@ def generate_artifact(
             "risk_gates": s.risk_gates,
             "explanation": s.explanation,
             "features": _features_to_dict(s.features),
+            "risk_context": _risk_context_to_dict(s.risk_context),
         }
         _apply_instrument_metadata(entry, s.symbol)
         return entry
@@ -1247,6 +1338,13 @@ def generate_artifact(
         rsi_14=None,
         zscore_20d=None,
     )
+    empty_risk_context = RiskContext(
+        atr_14=None,
+        atr_14_pct=None,
+        vol_target_multiplier=None,
+        stop_distance=None,
+        stop_distance_pct=None,
+    )
     next_rank = max((s.rank for s in scores), default=0) + 1
     for sym in sorted(missing_symbols or []):
         entry: dict[str, Any] = {
@@ -1257,6 +1355,7 @@ def generate_artifact(
             "risk_gates": [RISK_GATE_MISSING_DATA],
             "explanation": f"Suppressed: {RISK_GATE_MISSING_DATA}",
             "features": _features_to_dict(empty_feats),
+            "risk_context": _risk_context_to_dict(empty_risk_context),
         }
         _apply_instrument_metadata(entry, sym)
         instruments.append(entry)
@@ -1659,6 +1758,8 @@ def _cmd_generate(args: argparse.Namespace) -> int:
         return 1
 
     config = build_config_dict(policy)
+    config["risk_target_annual_vol"] = DEFAULT_RISK_TARGET_ANNUAL_VOL
+    config["stop_atr_multiple"] = DEFAULT_STOP_ATR_MULTIPLE
     analysis_date: str | None = getattr(args, "analysis_date", None) or None
     reference_time: datetime | None = None
     if analysis_date:

--- a/src/aims/reports.py
+++ b/src/aims/reports.py
@@ -705,6 +705,62 @@ def _section_symbol_details(instruments: list[dict[str, Any]]) -> str:
     return f"{header}\n\n" + "\n\n".join(subsections)
 
 
+_RISK_CONTEXT_DISCLAIMER: Final[str] = (
+    "Volatility-targeted sizing and ATR-based stop distances are informational"
+    " sizing/stop hints derived from historical price action, not investment"
+    " advice, account-level guidance, or margin-call simulation. They ignore"
+    " account size, existing exposure, broker margin rules, and execution"
+    " costs."
+)
+
+
+def _fmt_price(value: float | None) -> str:
+    return f"{value:.4f}" if value is not None else "n/a"
+
+
+def _fmt_multiplier(value: float | None) -> str:
+    return f"{value:.2f}x" if value is not None else "n/a"
+
+
+def _section_risk_context(instruments: list[dict[str, Any]]) -> str:
+    header = "## Risk Context"
+    reliable = sorted(
+        [i for i in instruments if i.get("is_reliable")],
+        key=lambda i: int(i.get("rank", 0)),
+    )
+    if not reliable:
+        return f"{header}\n\n_No reliable instruments to display._"
+    table_headers = [
+        "Instrument",
+        "ATR(14)",
+        "ATR % of price",
+        "Vol-target multiplier",
+        "Stop distance",
+        "Stop distance %",
+    ]
+    alignments: list[MarkdownAlignment] = [
+        "left",
+        "right",
+        "right",
+        "right",
+        "right",
+        "right",
+    ]
+    rows: list[list[str]] = []
+    for inst in reliable:
+        rc = inst.get("risk_context") or {}
+        rows.append([
+            _instrument_label(inst),
+            _fmt_price(rc.get("atr_14")),
+            _format_vol(rc.get("atr_14_pct")),
+            _fmt_multiplier(rc.get("vol_target_multiplier")),
+            _fmt_price(rc.get("stop_distance")),
+            _format_vol(rc.get("stop_distance_pct")),
+        ])
+    table = format_markdown_table(table_headers, rows, alignments)
+    return f"{header}\n\n{table}\n\n> {_RISK_CONTEXT_DISCLAIMER}"
+
+
 def _section_methodology(scoring_version: str, git_commit: str) -> str:
     header = "## Methodology"
     feature_list = (
@@ -815,6 +871,7 @@ def generate_report(
         _section_instrument_scores(instruments),
         _section_data_freshness(data_source, freshness),
         _section_symbol_details(instruments),
+        _section_risk_context(instruments),
         _section_methodology(scoring_version, git_commit),
         _section_disclaimer(),
     ])

--- a/src/aims/validate_analysis.py
+++ b/src/aims/validate_analysis.py
@@ -12,7 +12,7 @@ import json
 from pathlib import Path
 from typing import Any, Final
 
-ARTIFACT_VERSION: Final[str] = "1.1.0"
+ARTIFACT_VERSION: Final[str] = "1.2.0"
 DEFAULT_INPUT: Final[Path] = Path("data/analysis")
 
 _REQUIRED_TOP: Final[tuple[str, ...]] = ("version", "metadata", "instruments")
@@ -45,6 +45,8 @@ _REQUIRED_CONFIG: Final[tuple[str, ...]] = (
     "max_gap_days",
     "min_history",
     "coverage_policy",
+    "risk_target_annual_vol",
+    "stop_atr_multiple",
 )
 _REQUIRED_COVERAGE: Final[tuple[str, ...]] = (
     "attempted_count",
@@ -64,6 +66,14 @@ _REQUIRED_INST: Final[tuple[str, ...]] = (
     "risk_gates",
     "explanation",
     "features",
+    "risk_context",
+)
+_REQUIRED_RISK_CONTEXT: Final[tuple[str, ...]] = (
+    "atr_14",
+    "atr_14_pct",
+    "vol_target_multiplier",
+    "stop_distance",
+    "stop_distance_pct",
 )
 
 
@@ -180,6 +190,24 @@ def validate_artifact(data: dict[str, Any]) -> list[str]:
             tradable = inst.get("tradable")
             if tradable is not None and not isinstance(tradable, bool):
                 errors.append(f"instrument[{idx}]: tradable must be a boolean")
+            risk_context = inst.get("risk_context")
+            if risk_context is None:
+                errors.append(f"instrument[{idx}]: risk_context must not be null")
+            elif not isinstance(risk_context, dict):
+                errors.append(f"instrument[{idx}]: risk_context must be a JSON object")
+            else:
+                errors.extend(
+                    f"instrument[{idx}].risk_context missing required key: {key!r}"
+                    for key in _REQUIRED_RISK_CONTEXT
+                    if key not in risk_context
+                )
+                errors.extend(
+                    f"instrument[{idx}].risk_context.{key} must be null or a number"
+                    for key in _REQUIRED_RISK_CONTEXT
+                    if key in risk_context
+                    and risk_context[key] is not None
+                    and not isinstance(risk_context[key], (int, float))
+                )
 
     return errors
 

--- a/tests/golden/2024-01-01-market-analysis-partially-gated.md
+++ b/tests/golden/2024-01-01-market-analysis-partially-gated.md
@@ -116,6 +116,15 @@ Data source: **stooq**
 | rsi_14     |  55.0 |
 | zscore_20d |   0.7 |
 
+## Risk Context
+
+| Instrument                          | ATR(14) | ATR % of price | Vol-target multiplier | Stop distance | Stop distance % |
+| ----------------------------------- | ------: | -------------: | --------------------: | ------------: | --------------: |
+| S&P 500 / ^SPX                      |     n/a |            n/a |                   n/a |           n/a |             n/a |
+| Dow Jones Industrial Average / ^DJI |     n/a |            n/a |                   n/a |           n/a |             n/a |
+
+> Volatility-targeted sizing and ATR-based stop distances are informational sizing/stop hints derived from historical price action, not investment advice, account-level guidance, or margin-call simulation. They ignore account size, existing exposure, broker margin rules, and execution costs.
+
 ## Methodology
 
 Instruments are scored and ranked cross-sectionally using the following features:

--- a/tests/golden/2024-01-01-market-analysis-with-events.md
+++ b/tests/golden/2024-01-01-market-analysis-with-events.md
@@ -93,6 +93,15 @@ Data source: **stooq**
 | rsi_14     |  55.0 |
 | zscore_20d |   0.7 |
 
+## Risk Context
+
+| Instrument                          | ATR(14) | ATR % of price | Vol-target multiplier | Stop distance | Stop distance % |
+| ----------------------------------- | ------: | -------------: | --------------------: | ------------: | --------------: |
+| S&P 500 / ^SPX                      |     n/a |            n/a |                   n/a |           n/a |             n/a |
+| Dow Jones Industrial Average / ^DJI |     n/a |            n/a |                   n/a |           n/a |             n/a |
+
+> Volatility-targeted sizing and ATR-based stop distances are informational sizing/stop hints derived from historical price action, not investment advice, account-level guidance, or margin-call simulation. They ignore account size, existing exposure, broker margin rules, and execution costs.
+
 ## Methodology
 
 Instruments are scored and ranked cross-sectionally using the following features:

--- a/tests/golden/2024-01-01-market-analysis-with-qualitative.md
+++ b/tests/golden/2024-01-01-market-analysis-with-qualitative.md
@@ -118,6 +118,15 @@ Data source: **stooq**
 | rsi_14     |  55.0 |
 | zscore_20d |   0.7 |
 
+## Risk Context
+
+| Instrument                          | ATR(14) | ATR % of price | Vol-target multiplier | Stop distance | Stop distance % |
+| ----------------------------------- | ------: | -------------: | --------------------: | ------------: | --------------: |
+| S&P 500 / ^SPX                      |     n/a |            n/a |                   n/a |           n/a |             n/a |
+| Dow Jones Industrial Average / ^DJI |     n/a |            n/a |                   n/a |           n/a |             n/a |
+
+> Volatility-targeted sizing and ATR-based stop distances are informational sizing/stop hints derived from historical price action, not investment advice, account-level guidance, or margin-call simulation. They ignore account size, existing exposure, broker margin rules, and execution costs.
+
 ## Methodology
 
 Instruments are scored and ranked cross-sectionally using the following features:

--- a/tests/golden/2024-01-01-market-analysis.md
+++ b/tests/golden/2024-01-01-market-analysis.md
@@ -84,6 +84,15 @@ Data source: **stooq**
 | rsi_14     |  55.0 |
 | zscore_20d |   0.7 |
 
+## Risk Context
+
+| Instrument | ATR(14) | ATR % of price | Vol-target multiplier | Stop distance | Stop distance % |
+| ---------- | ------: | -------------: | --------------------: | ------------: | --------------: |
+| ^SPX       |     n/a |            n/a |                   n/a |           n/a |             n/a |
+| ^DJI       |     n/a |            n/a |                   n/a |           n/a |             n/a |
+
+> Volatility-targeted sizing and ATR-based stop distances are informational sizing/stop hints derived from historical price action, not investment advice, account-level guidance, or margin-call simulation. They ignore account size, existing exposure, broker margin rules, and execution costs.
+
 ## Methodology
 
 Instruments are scored and ranked cross-sectionally using the following features:

--- a/tests/test_generate_report.py
+++ b/tests/test_generate_report.py
@@ -933,6 +933,65 @@ def test_section_symbol_details_null_features(gr: ModuleType) -> None:
     assert "n/a" in result
 
 
+# ── _section_risk_context (#83) ─────────────────────────────────────────────────
+
+
+def test_section_risk_context_empty(gr: ModuleType) -> None:
+    result = gr._section_risk_context([])
+    assert "No reliable instruments" in result
+
+
+def test_section_risk_context_no_reliable(gr: ModuleType) -> None:
+    result = gr._section_risk_context([
+        {"symbol": "BAD", "rank": 1, "score": 20.0, "is_reliable": False}
+    ])
+    assert "No reliable instruments" in result
+
+
+def test_section_risk_context_renders_values(gr: ModuleType) -> None:
+    instruments = [
+        {
+            "symbol": "AAPL",
+            "rank": 1,
+            "score": 70.0,
+            "is_reliable": True,
+            "risk_context": {
+                "atr_14": 1.5,
+                "atr_14_pct": 0.015,
+                "vol_target_multiplier": 0.8,
+                "stop_distance": 3.0,
+                "stop_distance_pct": 0.03,
+            },
+        }
+    ]
+    result = gr._section_risk_context(instruments)
+    assert "## Risk Context" in result
+    assert "AAPL" in result
+    assert "1.5000" in result
+    assert "1.5%" in result
+    assert "0.80x" in result
+    assert "3.0000" in result
+    assert "3.0%" in result
+    assert "informational sizing/stop hints" in result
+
+
+def test_section_risk_context_missing_field_renders_na(gr: ModuleType) -> None:
+    instruments = [
+        {"symbol": "X", "rank": 1, "score": 50.0, "is_reliable": True},
+    ]
+    result = gr._section_risk_context(instruments)
+    assert "n/a" in result
+
+
+def test_section_risk_context_sorted_by_rank(gr: ModuleType) -> None:
+    instruments = [
+        {"symbol": "SYM_SECOND", "rank": 2, "score": 60.0, "is_reliable": True},
+        {"symbol": "SYM_FIRST", "rank": 1, "score": 70.0, "is_reliable": True},
+    ]
+    result = gr._section_risk_context(instruments)
+    assert result.index("SYM_FIRST") < result.index("SYM_SECOND")
+
+
 # ── delta table in _section_signal_history tests ────────────────────────────────
 
 

--- a/tests/test_market_analysis.py
+++ b/tests/test_market_analysis.py
@@ -555,6 +555,80 @@ def test_compute_features_full(ma: ModuleType) -> None:
     assert feats.zscore_20d is not None
 
 
+# ── ATR / risk context (#83) ────────────────────────────────────────────────────
+
+
+def test_compute_atr_insufficient(ma: ModuleType) -> None:
+    bars = _make_bars(ma, "X", [float(100 + i) for i in range(14)])
+    assert ma.compute_atr(bars) is None
+
+
+def test_compute_atr_flat_bars_is_zero(ma: ModuleType) -> None:
+    bars = _make_bars(ma, "X", [100.0] * 15)
+    assert ma.compute_atr(bars) == pytest.approx(0.0)
+
+
+def test_compute_atr_matches_hand_calculation(ma: ModuleType) -> None:
+    # With high=low=close (the _make_bars default), true range collapses to
+    # the absolute close-to-close change, so ATR(14) is the mean absolute
+    # daily change over the trailing 14 bars.
+    closes = [float(100 + i) for i in range(15)]
+    bars = _make_bars(ma, "X", closes)
+    assert ma.compute_atr(bars) == pytest.approx(1.0)
+
+
+def _risk_context_bars(ma: ModuleType, closes: list[float]) -> list[object]:
+    return _make_bars(ma, "X", closes)
+
+
+def test_compute_risk_context_full(ma: ModuleType) -> None:
+    closes = [float(100 + i) for i in range(21)]
+    bars = _risk_context_bars(ma, closes)
+    feats = ma.compute_features(bars)
+    rc = ma.compute_risk_context(
+        bars, feats, risk_target_annual_vol=0.10, stop_atr_multiple=2.0
+    )
+    last_close = closes[-1]
+    assert rc.atr_14 == pytest.approx(1.0)
+    assert rc.atr_14_pct == pytest.approx(1.0 / last_close)
+    assert feats.vol_20d is not None
+    assert rc.vol_target_multiplier == pytest.approx(0.10 / feats.vol_20d)
+    assert rc.stop_distance == pytest.approx(2.0)
+    assert rc.stop_distance_pct == pytest.approx(2.0 / last_close)
+
+
+def test_compute_risk_context_insufficient_history(ma: ModuleType) -> None:
+    bars = _risk_context_bars(ma, [float(100 + i) for i in range(5)])
+    feats = ma.compute_features(bars)
+    rc = ma.compute_risk_context(bars, feats)
+    assert rc.atr_14 is None
+    assert rc.atr_14_pct is None
+    assert rc.stop_distance is None
+    assert rc.stop_distance_pct is None
+    # vol_target_multiplier depends only on features.vol_20d, not ATR.
+    assert rc.vol_target_multiplier is None
+
+
+def test_compute_risk_context_zero_volatility(ma: ModuleType) -> None:
+    bars = _risk_context_bars(ma, [100.0] * 21)
+    feats = ma.compute_features(bars)
+    assert feats.vol_20d == pytest.approx(0.0)
+    rc = ma.compute_risk_context(bars, feats)
+    assert rc.vol_target_multiplier is None
+
+
+def test_compute_risk_context_empty_bars(ma: ModuleType) -> None:
+    feats = _empty_features(ma)
+    rc = ma.compute_risk_context([], feats)
+    assert rc == ma.RiskContext(
+        atr_14=None,
+        atr_14_pct=None,
+        vol_target_multiplier=None,
+        stop_distance=None,
+        stop_distance_pct=None,
+    )
+
+
 # ── _percentile_rank ──────────────────────────────────────────────────────────
 
 
@@ -970,7 +1044,7 @@ def test_generate_artifact_structure(ma: ModuleType, mocker: MockerFixture) -> N
     ref = bars[-1].timestamp + timedelta(days=1)
     scores = ma.score_instruments({"A": bars}, reference_time=ref)
     artifact = ma.generate_artifact(scores, {"A": bars}, {"stale_days": 5})
-    assert artifact["version"] == "1.1.0"
+    assert artifact["version"] == "1.2.0"
     assert "metadata" in artifact
     assert "instruments" in artifact
     meta = artifact["metadata"]
@@ -1033,6 +1107,13 @@ def _score(
         rsi_14=None,
         zscore_20d=None,
     )
+    risk_context = ma.RiskContext(
+        atr_14=None,
+        atr_14_pct=None,
+        vol_target_multiplier=None,
+        stop_distance=None,
+        stop_distance_pct=None,
+    )
     return ma.InstrumentScore(
         symbol=symbol,
         rank=1,
@@ -1041,6 +1122,7 @@ def _score(
         risk_gates=[] if is_reliable else ["stale_data"],
         is_reliable=is_reliable,
         explanation="x",
+        risk_context=risk_context,
     )
 
 
@@ -1178,7 +1260,7 @@ def test_save_artifact_path_contains_date(
     path = ma.save_artifact(artifact, tmp_path)
     assert path.suffix == ".json"
     loaded = json.loads(path.read_text())
-    assert loaded["version"] == "1.1.0"
+    assert loaded["version"] == "1.2.0"
 
 
 def test_save_artifact_no_generated_at(ma: ModuleType, tmp_path: Path) -> None:

--- a/tests/test_validate_analysis.py
+++ b/tests/test_validate_analysis.py
@@ -20,6 +20,14 @@ def va() -> ModuleType:
     return _aims_va
 
 
+VALID_RISK_CONTEXT: dict[str, Any] = {
+    "atr_14": 1.5,
+    "atr_14_pct": 0.015,
+    "vol_target_multiplier": 0.8,
+    "stop_distance": 3.0,
+    "stop_distance_pct": 0.03,
+}
+
 VALID_INSTRUMENT: dict[str, Any] = {
     "symbol": "AAPL.US",
     "rank": 1,
@@ -28,6 +36,7 @@ VALID_INSTRUMENT: dict[str, Any] = {
     "risk_gates": [],
     "explanation": "Strong momentum.",
     "features": {"ret_1d": 0.01},
+    "risk_context": VALID_RISK_CONTEXT,
 }
 
 VALID_REGIME: dict[str, Any] = {
@@ -39,7 +48,7 @@ VALID_REGIME: dict[str, Any] = {
 }
 
 VALID_ARTIFACT: dict[str, Any] = {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "metadata": {
         "generated_at": "2024-01-01T00:00:00+00:00",
         "git_commit": "abc1234",
@@ -55,6 +64,8 @@ VALID_ARTIFACT: dict[str, Any] = {
                 "min_success_ratio": 0.8,
                 "max_missing_symbols": 1,
             },
+            "risk_target_annual_vol": 0.10,
+            "stop_atr_multiple": 2.0,
         },
         "coverage": {
             "attempted_count": 1,
@@ -222,6 +233,45 @@ def test_validate_tradable_must_be_boolean(va: ModuleType) -> None:
     data = {**VALID_ARTIFACT, "instruments": [inst]}
     errors = va.validate_artifact(data)
     assert any("tradable must be a boolean" in e for e in errors)
+
+
+def test_validate_risk_context_null_rejected(va: ModuleType) -> None:
+    inst = {**VALID_INSTRUMENT, "risk_context": None}
+    data = {**VALID_ARTIFACT, "instruments": [inst]}
+    errors = va.validate_artifact(data)
+    assert any("risk_context must not be null" in e for e in errors)
+
+
+def test_validate_risk_context_must_be_object(va: ModuleType) -> None:
+    inst = {**VALID_INSTRUMENT, "risk_context": []}
+    data = {**VALID_ARTIFACT, "instruments": [inst]}
+    errors = va.validate_artifact(data)
+    assert any("risk_context must be a JSON object" in e for e in errors)
+
+
+def test_validate_risk_context_missing_key(va: ModuleType) -> None:
+    bad_rc = {k: v for k, v in VALID_RISK_CONTEXT.items() if k != "atr_14"}
+    inst = {**VALID_INSTRUMENT, "risk_context": bad_rc}
+    data = {**VALID_ARTIFACT, "instruments": [inst]}
+    errors = va.validate_artifact(data)
+    assert any("risk_context missing required key: 'atr_14'" in e for e in errors)
+
+
+def test_validate_risk_context_null_fields_accepted(va: ModuleType) -> None:
+    all_null = dict.fromkeys(VALID_RISK_CONTEXT)
+    inst = {**VALID_INSTRUMENT, "risk_context": all_null}
+    data = {**VALID_ARTIFACT, "instruments": [inst]}
+    assert va.validate_artifact(data) == []
+
+
+def test_validate_risk_context_field_wrong_type(va: ModuleType) -> None:
+    inst = {
+        **VALID_INSTRUMENT,
+        "risk_context": {**VALID_RISK_CONTEXT, "atr_14": "1.5"},
+    }
+    data = {**VALID_ARTIFACT, "instruments": [inst]}
+    errors = va.validate_artifact(data)
+    assert any("risk_context.atr_14 must be null or a number" in e for e in errors)
 
 
 # ── data_freshness validation ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `src/aims/market_analysis.py`: new `RiskContext` dataclass + `compute_atr`/`compute_risk_context`, computed per reliable/unreliable instrument from the same fetched OHLCV bars (14-bar Average True Range, a volatility-targeted position-size multiplier, and an ATR-based stop distance). Stored as a new `risk_context` block on each artifact instrument, kept separate from scored `features` — never fed into `score_instruments`, `_build_feature_columns`, or risk-gate suppression.
- New config values `risk_target_annual_vol` (default 0.10) and `stop_atr_multiple` (default 2.0) recorded in every artifact's `metadata.config` so a reader always knows which target/multiple produced a given number.
- `ARTIFACT_VERSION` bumped `1.1.0` → `1.2.0` (new required instrument field). `validate_analysis.py` and `data/schema/analysis.schema.json` updated to match: `risk_context` is required with 5 null-or-number fields, and the two new config keys are required.
- `src/aims/reports.py`: new "Risk Context" table section (ATR, ATR % of price, vol-target multiplier, stop distance, stop distance %) for reliable instruments, with a prominent disclaimer that this is informational sizing/stop hints, not account-level advice, margin-call simulation, or broker integration.
- Golden report fixtures regenerated — the four `tests/golden/2024-01-01-market-analysis*.md` files gain the new section (rendering `n/a` since those fixtures predate schema 1.2.0, exercising the same backward-compatible path old artifacts take).

## Validation

- `uv run pytest` — 1151 passed, 100% branch coverage. New tests: `compute_atr`/`compute_risk_context` (insufficient history, zero volatility, empty bars, hand-verified formula values) in `tests/test_market_analysis.py`; `risk_context` schema validation (null/object/missing-key/wrong-type/all-null-fields) in `tests/test_validate_analysis.py`; `_section_risk_context` rendering (empty, no-reliable, populated values, missing field, rank sort) in `tests/test_generate_report.py`.
- `uv run ruff format . && uv run ruff check .` — clean.
- `uv run pyright .` — 0 errors.
- `hugo --gc --minify` — builds.
- `.agents/skills/local-qa/scripts/qa.sh` — clean (no workflow files touched by this PR).

## Post-merge

- First daily run after merge produces artifacts with `risk_context` populated and the "Risk Context" report section rendering real values instead of `n/a`.
- Closes #83.