### PR TITLE
fix: authenticate qualitative OAuth action with GitHub

### DIFF
--- a/.github/workflows/daily-market-analysis.yml
+++ b/.github/workflows/daily-market-analysis.yml
@@ -370,6 +370,9 @@ jobs:
         uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # OAuth authenticates Claude; the built-in token prevents the action
+          # from attempting a separate Claude GitHub App token exchange.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: ${{ steps.qualitative_prepare.outputs.prompt }}
           claude_args: >-
             --model claude-opus-4-8 --max-turns 1 --disallowedTools "*"
@@ -395,6 +398,9 @@ jobs:
         uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # OAuth authenticates Claude; the built-in token prevents the action
+          # from attempting a separate Claude GitHub App token exchange.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: ${{ steps.qualitative_prepare.outputs.prompt }}
           claude_args: >-
             --model claude-opus-4-8 --max-turns 1 --disallowedTools "*"


### PR DESCRIPTION
## Summary

- pass the workflow's built-in `GITHUB_TOKEN` to both Claude Code Action invocations
- retain OAuth exclusively for Claude model authentication
- preserve the existing tool ban, deterministic prepare/finalize boundary, one-retry cap, and fail-open publication behavior

## Root cause

After #139, scheduled runs detected `CLAUDE_CODE_OAUTH_TOKEN` and committed daily evidence bundles, but produced no `data/qualitative/*.json` artifacts. Without an explicit `github_token`, Claude Code Action attempts a separate Claude GitHub App token exchange before model execution. That exchange is not configured for this scheduled automation path, so the action fails before finalization.

The action's documented OAuth workaround is to provide the workflow token explicitly. Claude still cannot use repository tools because both invocations retain `--disallowedTools "*"`.

## Impact

Shadow-mode qualitative artifacts can begin accumulating after merge, while quantitative publication remains fail-open. Rendering remains disabled until #98's exit criteria are met.

## Validation

CI/CD run 267 passed in full:

- actionlint, yamllint, zizmor, and Checkov
- Ruff, Pyright, and pytest
- CodeQL
- CFD/mapping/backtest validation
- OKF/Hugo build

The branch is one commit ahead of `main` with a one-file, six-line addition.

Progresses #98.
