### PR TITLE
chore: add Dependabot and harden local QA checks

### DIFF
--- a/.agents/skills/local-qa/scripts/qa.sh
+++ b/.agents/skills/local-qa/scripts/qa.sh
@@ -4,6 +4,7 @@ set -euxo pipefail
 cd "$(git rev-parse --show-toplevel)"
 
 # Python
+uv sync
 uv run ruff format .
 uv run ruff check --fix .
 uv run pyright .

--- a/.agents/skills/local-qa/scripts/qa.sh
+++ b/.agents/skills/local-qa/scripts/qa.sh
@@ -14,8 +14,9 @@ uv run python .agents/skills/update-cfd-instruments/scripts/validate_cfd_instrum
 	--input data/cfd_instruments.csv \
 	--schema data/schema/cfd_instruments.schema.json
 
-# Markdown
-npx -y prettier --write './**/*.{md,json}'
+# Markdown (JSON is excluded: Prettier rewrites alter SHA-256 hashes used by
+# qualitative input verification for analysis/evidence fixtures and artifacts.)
+npx -y prettier --write './**/*.md'
 
 # OKF knowledge shadow content
 uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge --check

--- a/.agents/skills/local-qa/scripts/qa.sh
+++ b/.agents/skills/local-qa/scripts/qa.sh
@@ -7,42 +7,28 @@ cd "$(git rev-parse --show-toplevel)"
 uv run ruff format .
 uv run ruff check --fix .
 uv run pyright .
-
-if [ -d tests ] || [ -n "$(git ls-files 'tests/**' '*test*.py' 'test_*.py')" ]; then
-  uv run pytest
-else
-  echo "No Python tests found; skipping pytest."
-fi
+uv run pytest
 
 # Validate CFD instruments CSV
-if [ -f data/cfd_instruments.csv ]; then
-  uv run python .agents/skills/update-cfd-instruments/scripts/validate_cfd_instruments.py \
-    --input data/cfd_instruments.csv \
-    --schema data/schema/cfd_instruments.schema.json
-fi
+uv run python .agents/skills/update-cfd-instruments/scripts/validate_cfd_instruments.py \
+	--input data/cfd_instruments.csv \
+	--schema data/schema/cfd_instruments.schema.json
 
 # Markdown
-npx -y prettier --write './**/*.md'
+npx -y prettier --write './**/*.{md,json}'
 
 # OKF knowledge shadow content
-if [ -d okf ]; then
-  uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge --check
-fi
+uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge --check
 
 # Hugo
 hugo --gc --minify
 
+# Shell scripts
+git ls-files -z -- '*.sh' '*.bash' '*.bats' | xargs -0 -t shfmt --write
+git ls-files -z -- '*.sh' '*.bash' '*.bats' | xargs -0 -t shellcheck
+
 # GitHub Actions
-case "${OSTYPE}" in
-  darwin* | linux* )
-    zizmor --fix=safe .github/workflows
-    if [ -n "$(git ls-files '.github/workflows/*.yml' '.github/workflows/*.yaml')" ]; then
-      git ls-files -z -- '.github/workflows/*.yml' '.github/workflows/*.yaml' | xargs -0 -t actionlint
-      git ls-files -z -- '.github/workflows/*.yml' '.github/workflows/*.yaml' | xargs -0 -t yamllint -d '{"extends": "relaxed", "rules": {"line-length": "disable"}}'
-    fi
-    checkov --framework=all --output=github_failed_only --directory=.
-    ;;
-  * )
-    echo "GitHub Actions linting is only supported on Linux and macOS."
-    ;;
-esac
+zizmor --fix=safe .github/workflows
+git ls-files -z -- '.github/workflows/*.yml' '.github/workflows/*.yaml' | xargs -0 -t actionlint
+git ls-files -z -- '.github/workflows/*.yml' '.github/workflows/*.yaml' | xargs -0 -t yamllint -d '{"extends": "relaxed", "rules": {"line-length": "disable"}}'
+checkov --framework=all --output=github_failed_only --directory=.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 10
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: daily
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 10
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: daily
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 10

--- a/content/results/2026-07-04-market-analysis.md
+++ b/content/results/2026-07-04-market-analysis.md
@@ -26,6 +26,7 @@ git_commit = "a3e7e8c"
 ## Signal History
 
 Compared with the previous available report (**2026-07-02**).
+
 - **Universe change:** 5 → 33 instruments; percentile-based scores and deltas are not directly comparable across this change.
 - **New top-5:** AAPL, UNH, ^STOXX50E
 - **Persistent top signals:** ^DJI (5 reports), ^GDAXI (5 reports)

--- a/content/results/2026-07-05-market-analysis.md
+++ b/content/results/2026-07-05-market-analysis.md
@@ -30,6 +30,7 @@ _No scheduled events for covered instruments in the next 7 days._
 ## Signal History
 
 Compared with the previous available report (**2026-07-04**).
+
 - **New top-5:** None
 - **Persistent top signals:** ^DJI (6 reports), ^GDAXI (6 reports), AAPL (2 reports), UNH (2 reports), ^STOXX50E (2 reports)
 - **Dropped from top-5:** None

--- a/content/results/2026-07-06-market-analysis.md
+++ b/content/results/2026-07-06-market-analysis.md
@@ -30,6 +30,7 @@ _No scheduled events for covered instruments in the next 7 days._
 ## Signal History
 
 Compared with the previous available report (**2026-07-05**).
+
 - **New top-5:** None
 - **Persistent top signals:** ^DJI (7 reports), ^GDAXI (7 reports), AAPL (3 reports), UNH (3 reports), ^STOXX50E (3 reports)
 - **Dropped from top-5:** None

--- a/content/results/2026-07-07-market-analysis.md
+++ b/content/results/2026-07-07-market-analysis.md
@@ -30,6 +30,7 @@ _No scheduled events for covered instruments in the next 7 days._
 ## Signal History
 
 Compared with the previous available report (**2026-07-06**).
+
 - **New top-5:** 8306.T, JPM, ZS=F
 - **Persistent top signals:** ^GDAXI (8 reports), AAPL (4 reports)
 - **Dropped from top-5:** UNH, ^DJI, ^STOXX50E

--- a/content/results/2026-07-08-market-analysis.md
+++ b/content/results/2026-07-08-market-analysis.md
@@ -34,6 +34,7 @@ Scheduled events within the next 7 days for covered instruments (from `data/cale
 ## Signal History
 
 Compared with the previous available report (**2026-07-07**).
+
 - **New top-5:** UNH, ZC=F, ^DJI
 - **Persistent top signals:** JPM (2 reports), ZS=F (2 reports)
 - **Dropped from top-5:** 8306.T, AAPL, ^GDAXI

--- a/content/results/2026-07-09-market-analysis.md
+++ b/content/results/2026-07-09-market-analysis.md
@@ -35,6 +35,7 @@ Scheduled events within the next 7 days for covered instruments (from `data/cale
 ## Signal History
 
 Compared with the previous available report (**2026-07-08**).
+
 - **New top-5:** AAPL, ^GSPC
 - **Persistent top signals:** ZS=F (3 reports), UNH (2 reports), ^DJI (2 reports)
 - **Dropped from top-5:** JPM, ZC=F

--- a/content/results/2026-07-10-market-analysis.md
+++ b/content/results/2026-07-10-market-analysis.md
@@ -35,6 +35,7 @@ Scheduled events within the next 7 days for covered instruments (from `data/cale
 ## Signal History
 
 Compared with the previous available report (**2026-07-09**).
+
 - **New top-5:** JPM
 - **Persistent top signals:** ZS=F (4 reports), UNH (3 reports), ^DJI (3 reports), AAPL (2 reports)
 - **Dropped from top-5:** ^GSPC

--- a/content/results/2026-07-11-market-analysis.md
+++ b/content/results/2026-07-11-market-analysis.md
@@ -35,6 +35,7 @@ Scheduled events within the next 7 days for covered instruments (from `data/cale
 ## Signal History
 
 Compared with the previous available report (**2026-07-10**).
+
 - **New top-5:** META, ZW=F
 - **Persistent top signals:** ZS=F (5 reports), ^DJI (4 reports), JPM (2 reports)
 - **Dropped from top-5:** AAPL, UNH

--- a/content/results/2026-07-12-market-analysis.md
+++ b/content/results/2026-07-12-market-analysis.md
@@ -35,6 +35,7 @@ Scheduled events within the next 7 days for covered instruments (from `data/cale
 ## Signal History
 
 Compared with the previous available report (**2026-07-11**).
+
 - **New top-5:** ZC=F
 - **Persistent top signals:** ZS=F (6 reports), JPM (3 reports), META (2 reports), ZW=F (2 reports)
 - **Dropped from top-5:** ^DJI

--- a/content/results/2026-07-13-market-analysis.md
+++ b/content/results/2026-07-13-market-analysis.md
@@ -35,6 +35,7 @@ Scheduled events within the next 7 days for covered instruments (from `data/cale
 ## Signal History
 
 Compared with the previous available report (**2026-07-12**).
+
 - **New top-5:** ^DJI
 - **Persistent top signals:** ZS=F (7 reports), JPM (4 reports), META (3 reports), ZW=F (3 reports)
 - **Dropped from top-5:** ZC=F

--- a/content/results/2026-07-14-market-analysis.md
+++ b/content/results/2026-07-14-market-analysis.md
@@ -34,6 +34,7 @@ Scheduled events within the next 7 days for covered instruments (from `data/cale
 ## Signal History
 
 Compared with the previous available report (**2026-07-13**).
+
 - **New top-5:** AAPL, UNH
 - **Persistent top signals:** ZS=F (8 reports), ZW=F (4 reports), ^DJI (2 reports)
 - **Dropped from top-5:** JPM, META

--- a/content/results/2026-07-15-market-analysis.md
+++ b/content/results/2026-07-15-market-analysis.md
@@ -35,6 +35,7 @@ Scheduled events within the next 7 days for covered instruments (from `data/cale
 ## Signal History
 
 Compared with the previous available report (**2026-07-14**).
+
 - **New top-5:** META, ^FCHI, ^FTSE
 - **Persistent top signals:** ZS=F (9 reports), ZW=F (5 reports)
 - **Dropped from top-5:** AAPL, UNH, ^DJI

--- a/content/results/2026-07-16-market-analysis.md
+++ b/content/results/2026-07-16-market-analysis.md
@@ -36,6 +36,7 @@ Scheduled events within the next 7 days for covered instruments (from `data/cale
 ## Signal History
 
 Compared with the previous available report (**2026-07-15**).
+
 - **New top-5:** AAPL, JPM, ZC=F
 - **Persistent top signals:** ZW=F (6 reports), META (2 reports)
 - **Dropped from top-5:** ZS=F, ^FCHI, ^FTSE

--- a/content/results/2026-07-17-market-analysis.md
+++ b/content/results/2026-07-17-market-analysis.md
@@ -36,6 +36,7 @@ Scheduled events within the next 7 days for covered instruments (from `data/cale
 ## Signal History
 
 Compared with the previous available report (**2026-07-16**).
+
 - **New top-5:** ZS=F, ^HSI
 - **Persistent top signals:** ZW=F (7 reports), AAPL (2 reports), JPM (2 reports)
 - **Dropped from top-5:** META, ZC=F

--- a/content/results/2026-07-18-market-analysis.md
+++ b/content/results/2026-07-18-market-analysis.md
@@ -36,6 +36,7 @@ Scheduled events within the next 7 days for covered instruments (from `data/cale
 ## Signal History
 
 Compared with the previous available report (**2026-07-17**).
+
 - **New top-5:** ZC=F
 - **Persistent top signals:** ZW=F (8 reports), AAPL (3 reports), JPM (3 reports), ZS=F (2 reports)
 - **Dropped from top-5:** ^HSI

--- a/content/results/2026-07-19-market-analysis.md
+++ b/content/results/2026-07-19-market-analysis.md
@@ -36,6 +36,7 @@ Scheduled events within the next 7 days for covered instruments (from `data/cale
 ## Signal History
 
 Compared with the previous available report (**2026-07-18**).
+
 - **New top-5:** None
 - **Persistent top signals:** ZW=F (9 reports), AAPL (4 reports), JPM (4 reports), ZS=F (3 reports), ZC=F (2 reports)
 - **Dropped from top-5:** None

--- a/content/results/2026-07-20-market-analysis.md
+++ b/content/results/2026-07-20-market-analysis.md
@@ -36,6 +36,7 @@ Scheduled events within the next 7 days for covered instruments (from `data/cale
 ## Signal History
 
 Compared with the previous available report (**2026-07-19**).
+
 - **New top-5:** ^FTSE
 - **Persistent top signals:** ZW=F (10 reports), AAPL (5 reports), JPM (5 reports), ZS=F (4 reports)
 - **Dropped from top-5:** ZC=F

--- a/content/results/2026-07-21-market-analysis.md
+++ b/content/results/2026-07-21-market-analysis.md
@@ -36,6 +36,7 @@ Scheduled events within the next 7 days for covered instruments (from `data/cale
 ## Signal History
 
 Compared with the previous available report (**2026-07-20**).
+
 - **New top-5:** ZC=F, ^HSI
 - **Persistent top signals:** ZW=F (11 reports), AAPL (6 reports), ZS=F (5 reports)
 - **Dropped from top-5:** JPM, ^FTSE

--- a/content/results/2026-07-22-market-analysis.md
+++ b/content/results/2026-07-22-market-analysis.md
@@ -37,6 +37,7 @@ Scheduled events within the next 7 days for covered instruments (from `data/cale
 ## Signal History
 
 Compared with the previous available report (**2026-07-21**).
+
 - **New top-5:** JPM, UNH
 - **Persistent top signals:** ZW=F (12 reports), AAPL (7 reports), ZS=F (6 reports)
 - **Dropped from top-5:** ZC=F, ^HSI

--- a/content/results/2026-07-23-market-analysis.md
+++ b/content/results/2026-07-23-market-analysis.md
@@ -38,6 +38,7 @@ Scheduled events within the next 7 days for covered instruments (from `data/cale
 ## Signal History
 
 Compared with the previous available report (**2026-07-22**).
+
 - **New top-5:** BZ=F, ZC=F
 - **Persistent top signals:** ZW=F (13 reports), ZS=F (7 reports), JPM (2 reports)
 - **Dropped from top-5:** AAPL, UNH

--- a/content/results/2026-07-24-market-analysis.md
+++ b/content/results/2026-07-24-market-analysis.md
@@ -41,6 +41,7 @@ Scheduled events within the next 7 days for covered instruments (from `data/cale
 ## Signal History
 
 Compared with the previous available report (**2026-07-23**).
+
 - **New top-5:** None
 - **Persistent top signals:** ZW=F (14 reports), ZS=F (8 reports), JPM (3 reports), BZ=F (2 reports), ZC=F (2 reports)
 - **Dropped from top-5:** None

--- a/content/results/2026-07-25-market-analysis.md
+++ b/content/results/2026-07-25-market-analysis.md
@@ -41,6 +41,7 @@ Scheduled events within the next 7 days for covered instruments (from `data/cale
 ## Signal History
 
 Compared with the previous available report (**2026-07-24**).
+
 - **New top-5:** AAPL, ^FTSE
 - **Persistent top signals:** ZS=F (9 reports), JPM (4 reports), ZC=F (3 reports)
 - **Dropped from top-5:** BZ=F, ZW=F

--- a/content/results/2026-07-26-market-analysis.md
+++ b/content/results/2026-07-26-market-analysis.md
@@ -41,6 +41,7 @@ Scheduled events within the next 7 days for covered instruments (from `data/cale
 ## Signal History
 
 Compared with the previous available report (**2026-07-25**).
+
 - **New top-5:** BZ=F, ^HSI
 - **Persistent top signals:** ZS=F (10 reports), ZC=F (4 reports), ^FTSE (2 reports)
 - **Dropped from top-5:** AAPL, JPM

--- a/content/results/2026-07-27-market-analysis.md
+++ b/content/results/2026-07-27-market-analysis.md
@@ -42,6 +42,7 @@ Scheduled events within the next 7 days for covered instruments (from `data/cale
 ## Signal History
 
 Compared with the previous available report (**2026-07-26**).
+
 - **New top-5:** AAPL, JPM
 - **Persistent top signals:** ZS=F (11 reports), ZC=F (5 reports), ^FTSE (3 reports)
 - **Dropped from top-5:** BZ=F, ^HSI

--- a/content/results/2026-07-28-market-analysis.md
+++ b/content/results/2026-07-28-market-analysis.md
@@ -43,6 +43,7 @@ Scheduled events within the next 7 days for covered instruments (from `data/cale
 ## Signal History
 
 Compared with the previous available report (**2026-07-27**).
+
 - **New top-5:** ^GDAXI, ^HSI
 - **Persistent top signals:** ^FTSE (4 reports), AAPL (2 reports), JPM (2 reports)
 - **Dropped from top-5:** ZC=F, ZS=F

--- a/content/results/2026-07-29-market-analysis.md
+++ b/content/results/2026-07-29-market-analysis.md
@@ -40,6 +40,7 @@ Scheduled events within the next 7 days for covered instruments (from `data/cale
 ## Signal History
 
 Compared with the previous available report (**2026-07-28**).
+
 - **New top-5:** ZC=F, ^FCHI
 - **Persistent top signals:** ^FTSE (5 reports), AAPL (3 reports), JPM (3 reports)
 - **Dropped from top-5:** ^GDAXI, ^HSI

--- a/content/results/2026-07-30-market-analysis.md
+++ b/content/results/2026-07-30-market-analysis.md
@@ -38,6 +38,7 @@ Scheduled events within the next 7 days for covered instruments (from `data/cale
 ## Signal History
 
 Compared with the previous available report (**2026-07-29**).
+
 - **New top-5:** ^GDAXI, ^HSI
 - **Persistent top signals:** ^FTSE (6 reports), AAPL (4 reports), ^FCHI (2 reports)
 - **Dropped from top-5:** JPM, ZC=F


### PR DESCRIPTION
## Summary
- Add Dependabot config for `github-actions`, `pip`, and `gomod` with daily checks and a 7-day cooldown
- Simplify `local-qa` to always run pytest, CFD validation, OKF checks, and GHA linters
- Add `shfmt`/`shellcheck` for shell scripts; keep Prettier on markdown only (JSON rewriting breaks qualitative content hashes)
- Cover the under-cap warnings branch in `performance.render_page` so local QA reaches 100% branch coverage

## Test plan
- [x] Full pre-push QA (`.agents/skills/local-qa/scripts/qa.sh`) passed, including 1137 tests at 100% coverage
- [x] `shfmt` / `shellcheck` on tracked shell scripts
- [ ] Confirm Dependabot opens update PRs after merge