### PR TITLE
fix(ci): adopt reusable GitHub Pages deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ permissions:
   contents: read
 concurrency:
   group: ${{ github.event_name == 'pull_request' && format('hugo-pr-{0}', github.run_id) || 'github-pages-build' }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name != 'pull_request' }}
 jobs:
   github-actions-lint-and-scan:
     if: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ on:
 permissions:
   contents: read
 concurrency:
-  group: ${{ github.event_name == 'pull_request' && format('hugo-pr-{0}', github.run_id) || 'github-pages-build' }}
+  group: ${{ github.event_name == 'pull_request' && format('hugo-pr-{0}', github.run_id) || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion != 'success') && format('hugo-workflow-run-skip-{0}', github.run_id) || 'github-pages-build' }}
   cancel-in-progress: ${{ github.event_name != 'pull_request' }}
 jobs:
   github-actions-lint-and-scan:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,9 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.event_name == 'pull_request' && format('hugo-pr-{0}', github.run_id) || 'github-pages-build' }}
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0   # v7.0.0
         with:
@@ -110,6 +113,16 @@ jobs:
           extended: true
       - run: uv run python tools/okf_hugo_adapter.py --src okf --dst content/knowledge --check
       - run: hugo --gc --minify
+      - name: Upload GitHub Pages artifact
+        if: >
+          github.event_name == 'push'
+          || github.event_name == 'workflow_dispatch'
+          || (github.event_name == 'workflow_run'
+          && github.event.workflow_run.conclusion == 'success')
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          name: github-pages
+          path: site
   validate-market-data-config:
     if: >
       github.event_name == 'push'
@@ -159,58 +172,58 @@ jobs:
       - okf-hugo-build
       - validate-market-data-config
     permissions:
-      contents: read
       id-token: write
       pages: write
+    uses: dceoy/gha-for-devops/.github/workflows/github-pages-deploy.yml@98c45d7227f03e4188da8273619e02c1062ca427
+    with:
+      artifact-name: github-pages
+      deployment-attempts: 2
+      environment: github-pages
+      runs-on: ubuntu-latest
+
+  notify-pages-deploy-failure:
+    if: always()
+    needs:
+      - hugo-deploy-to-gh-pages
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deploy.outputs.page_url || steps.deploy-retry.outputs.page_url }}
-    concurrency:
-      group: github-pages
-      cancel-in-progress: false
     env:
+      PAGES_URL: ${{ needs.hugo-deploy-to-gh-pages.outputs['page-url'] }}
       SLACK_NOTIFICATIONS_ENABLED: ${{ secrets.SLACK_WEBHOOK_URL != '' }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0   # v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        if: >
+          always()
+          && needs.hugo-deploy-to-gh-pages.result == 'failure'
+          && env.SLACK_NOTIFICATIONS_ENABLED == 'true'
         with:
           persist-credentials: false
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-        with:
-          go-version: stable
-      - name: Install Hugo
-        uses: peaceiris/actions-hugo@2752ce1d29631191ea3f27c23495fa06139a5b78 # v3.2.1
-        with:
-          hugo-version: latest
-          extended: true
-      - name: Build site
-        run: hugo --gc --minify
-      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
-      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
-        with:
-          path: site
-      - name: Deploy to GitHub Pages
-        id: deploy
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
-        continue-on-error: true
-      # Pages deploys fail transiently ("Deployment failed, try again
-      # later."); one in-run retry absorbs that without a manual re-run.
-      - name: Retry deploy to GitHub Pages
-        id: deploy-retry
-        if: steps.deploy.outcome == 'failure'
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39   # v8.2.0
-        if: failure() && env.SLACK_NOTIFICATIONS_ENABLED == 'true'
+        if: >
+          always()
+          && needs.hugo-deploy-to-gh-pages.result == 'failure'
+          && env.SLACK_NOTIFICATIONS_ENABLED == 'true'
       - name: Sync dependencies
-        if: failure() && env.SLACK_NOTIFICATIONS_ENABLED == 'true'
+        if: >
+          always()
+          && needs.hugo-deploy-to-gh-pages.result == 'failure'
+          && env.SLACK_NOTIFICATIONS_ENABLED == 'true'
         run: uv sync
       - name: Notify Slack (deploy failure)
-        if: failure() && env.SLACK_NOTIFICATIONS_ENABLED == 'true'
+        if: >
+          always()
+          && needs.hugo-deploy-to-gh-pages.result == 'failure'
+          && env.SLACK_NOTIFICATIONS_ENABLED == 'true'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
+          message="Hugo Pages deploy failed"
+          if [[ -n "${PAGES_URL}" ]]; then
+            message+=" (Pages URL: ${PAGES_URL})"
+          fi
           uv run python .agents/skills/market-analysis/scripts/notify_slack.py \
             --failure \
             --run-url \
             "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            --message "Hugo Pages deploy failed"
+            --message "${message}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ on:
   workflow_dispatch:
 permissions:
   contents: read
+concurrency:
+  group: ${{ github.event_name == 'pull_request' && format('hugo-pr-{0}', github.run_id) || 'github-pages-build' }}
+  cancel-in-progress: false
 jobs:
   github-actions-lint-and-scan:
     if: >
@@ -94,9 +97,6 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    concurrency:
-      group: ${{ github.event_name == 'pull_request' && format('hugo-pr-{0}', github.run_id) || 'github-pages-build' }}
-      cancel-in-progress: false
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0   # v7.0.0
         with:

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -421,7 +421,7 @@ GitHub Pages deployment is handled by `ci.yml` (`hugo-deploy-to-gh-pages` job), 
 - `workflow_run` on "Daily market analysis" completion: bot merges performed with `GITHUB_TOKEN` create no push event, so the daily workflow finishing (successfully) re-runs CI/CD against the head of `main` and deploys it. Deploys are idempotent snapshots of `main`, so a redundant run after a dry run is harmless.
 - `workflow_dispatch` (`gh workflow run ci.yml`): manual full CI + deploy of current `main` — the recovery path when a deploy failed or the site is stale.
 
-The deploy job builds the site with Hugo, uploads it as a Pages artifact, and deploys via `actions/deploy-pages`. Pages deployments fail transiently ("Deployment failed, try again later."); the job retries the deploy once in-run. If the job still fails, a Slack failure notification fires when `SLACK_WEBHOOK_URL` is configured — otherwise check the run under the Actions tab and the deployment status via `gh api repos/<owner>/<repo>/deployments?environment=github-pages`.
+The AIMS-specific prerequisite job validates the OKF shadow content and builds the site with Hugo, then uploads the generated `site/` directory as a Pages artifact. Deployment is delegated to the pinned `dceoy/gha-for-devops` `github-pages-deploy.yml` reusable workflow, which performs the deployment and one bounded in-run retry. If the deployment still fails, the local AIMS follow-up job sends a Slack failure notification when `SLACK_WEBHOOK_URL` is configured — otherwise check the run under the Actions tab and the deployment status via `gh api repos/<owner>/<repo>/deployments?environment=github-pages`.
 
 ### Rollback
 


### PR DESCRIPTION
## Summary

- Keep AIMS-specific OKF/Hugo validation and site generation local, uploading the generated `site/` directory as the Pages artifact.
- Delegate deployment and the existing one-retry policy to the pinned `dceoy/gha-for-devops` `github-pages-deploy.yml` workflow at commit `98c45d7227f03e4188da8273619e02c1062ca427`.
- Keep the Slack deployment-failure notification in AIMS, including propagation of the reusable workflow's Pages URL output.
- Serialize deployment-bound Hugo builds so an older build cannot overwrite a newer deployment.
- Update `OPERATIONS.md` to document the new ownership boundary.

## Root cause

AIMS duplicated generic GitHub Pages build, artifact, deployment, retry, and environment handling in `.github/workflows/ci.yml`. That deployment mechanics should live in the shared workflow while AIMS-specific validation and notification policy remain local.

## Validation

- `.agents/skills/local-qa/scripts/qa.sh`
- 1,176 tests passed with 100% branch coverage
- Hugo build, Actionlint, Yamllint, Zizmor, Checkov, Pyright, Ruff, and CFD validation passed
- Security-focused review found no actionable findings

Fixes #170
