### PR TITLE
Add dependency cooldown to local QA

### DIFF
--- a/.agents/skills/local-qa/scripts/qa.sh
+++ b/.agents/skills/local-qa/scripts/qa.sh
@@ -3,6 +3,11 @@
 set -euxo pipefail
 cd "$(git rev-parse --show-toplevel)"
 
+COOLDOWN_DAYS=7
+export UV_EXCLUDE_NEWER="${COOLDOWN_DAYS} days"
+export NPM_CONFIG_MIN_RELEASE_AGE="${COOLDOWN_DAYS}"
+export PNPM_CONFIG_MINIMUM_RELEASE_AGE=$((COOLDOWN_DAYS * 24 * 60))
+
 # Python
 uv sync
 uv run ruff format .


### PR DESCRIPTION
## Summary
- add a 7-day dependency release cooldown to local QA
- configure uv, npm, and pnpm cooldown environment variables
- keep the existing QA commands unchanged

## Rationale
Follow the `pr-review-loop` local QA pattern so ad-hoc dependency resolution avoids packages published within the cooldown window, reducing supply-chain exposure to freshly published releases.

## Validation
- change is limited to `.agents/skills/local-qa/scripts/qa.sh`
- existing QA workflow is otherwise unchanged