### PR TITLE
ci: run daily market analysis on weekdays

### DIFF
--- a/.github/workflows/daily-market-analysis.yml
+++ b/.github/workflows/daily-market-analysis.yml
@@ -3,7 +3,7 @@ name: Daily market analysis
 # checkov:skip=CKV_GHA_7: inputs are analysis params (date/interval/dry_run) for authorised manual backfills
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "0 1 * * 1-5"
   workflow_dispatch:
     inputs:
       analysis_date:


### PR DESCRIPTION
## Summary
- restrict the scheduled daily market analysis workflow to Monday through Friday
- keep `workflow_dispatch` available for manual weekend runs

## Why
The scheduled market analysis does not need to run on weekends. Limiting the cron schedule avoids unnecessary weekend executions while preserving manual backfills.

## Validation
- verified the branch differs from `main` only in `.github/workflows/daily-market-analysis.yml`
- net diff is one cron-line change: `0 1 * * *` → `0 1 * * 1-5`